### PR TITLE
fix nix flake show

### DIFF
--- a/pkgs/llamacpp-rocm-bin.nix
+++ b/pkgs/llamacpp-rocm-bin.nix
@@ -3,7 +3,8 @@
 , fetchzip
 , autoPatchelfHook
 , zlib
-, glibc
+, glibc,
+...
 }:
 
 stdenv.mkDerivation rec {


### PR DESCRIPTION
`nix flake show` on this flake dies with 
```
rror:
       … while evaluating the attribute 'llamacpp-rocm-bin-gfx1151'
         at /nix/store/vsqz9y4xpxm9qrxbmzbgffk1mha2azj4-source/flake.nix:154:11:
          153|           # Binary packages for each target
          154|           llamacpp-rocm-bin-gfx1151 = prev.callPackage ./pkgs/llamacpp-rocm-bin.nix {
             |           ^
          155|             gfxTarget = "gfx1151";

       … while calling a functor (an attribute set with a '__functor' attribute)
         at /nix/store/c39q7pww80997lz0fyqxpvsr29q6f7ld-source/lib/customisation.nix:306:7:
          305|     if missingArgs == { } then
          306|       makeOverridable f allArgs
             |       ^
          307|     # This needs to be an abort so it can't be caught with `builtins.tryEval`,

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: function 'anonymous lambda' called with unexpected argument 'gfxTarget'
       at /nix/store/vsqz9y4xpxm9qrxbmzbgffk1mha2azj4-source/pkgs/llamacpp-rocm-bin.nix:1:1:
            1| { lib
             | ^
            2| , stdenv
```


This fixes it by simply accepting further arguments, so you can use nix flake show to find the actual arguments.