### PR TITLE
ds4: add ROCm HIP package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It provides:
 - Linux-only ROCm outputs, including generic ROCm builds and Strix Halo `gfx1151` narrowed builds
 - TheRock ROCm/PyTorch packaging for configured Linux GPU targets
 - FastFlowLM packaging for AMD XDNA2 NPU inference
+- DS4-HIP packaging for DwarfStar 4 ROCm inference
 - NixOS modules for llama.cpp RPC servers, EC fan/power controls, Ryzen power limits, RAID0 disk layout, system tuning, and benchmark hosts
 - cross-platform benchmark helpers and derivations for reproducible local model/tool runs
 - a minimal `fevm-faex9` NixOS example builder
@@ -25,6 +26,8 @@ Main package outputs:
 - `packages.x86_64-darwin.default`
 - `packages.x86_64-darwin.llama-cpp`
 - `packages.x86_64-linux.default`
+- `packages.x86_64-linux.ds4-rocm`
+- `packages.x86_64-linux.ds4-rocm-gfx1151`
 - `packages.x86_64-linux.fastflowlm`
 - `packages.x86_64-linux.llama-cpp`
 - `packages.x86_64-linux.llama-cpp-rocm`
@@ -87,6 +90,7 @@ Target records are generic build descriptors, not a hardware inventory. Hostname
 - `packages.x86_64-linux.therock-rocm-gfx1151-env`
 - `packages.x86_64-linux.therock-python-gfx1151`
 - `packages.x86_64-linux.torch-rocm-gfx1151`
+- `packages.x86_64-linux.ds4-rocm-gfx1151`
 
 The lower-level ROCm module overlay also exposes reusable narrowed package scopes:
 
@@ -198,6 +202,15 @@ Benchmark derivations are generated from structured tool/model/scenario records 
 nix build .#benchmarks.x86_64-linux.bench-llama2-7b-llama-cpp-cpu-b512-fa1
 cat result/stdout.txt
 cat result/metadata.json
+```
+
+DS4-HIP benchmarks expect a caller-provided GGUF model at `/models/ds4/ds4flash.gguf`
+and a benchmark runner advertising `gfx1151` with `/models/ds4` mounted into
+the Nix sandbox:
+
+```bash
+nix build .#benchmarks.x86_64-linux.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke
+cat result/results.csv
 ```
 
 External flakes can reuse `lib.benchmarks` while injecting their own packages, model paths, required system features, environment variables, and host profile names. For example, with a caller-provided CUDA-enabled `myCudaLlamaCpp` package:

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ cat result/metadata.json
 ```
 
 DS4-HIP benchmarks expect a caller-provided GGUF model at `/models/ds4/ds4flash.gguf`
-and a benchmark runner advertising `gfx1151` with `/models/ds4` mounted into
+and a benchmark runner advertising `gfx1151` with `/models` mounted into
 the Nix sandbox:
 
 ```bash
@@ -245,6 +245,8 @@ boot.kernelParams = [
   "iommu=off"
 ];
 
+benchmark.modelsPath = "/models";
+
 benchmark.runners.my-strix-gpu = {
   gpus = [
     {
@@ -254,6 +256,10 @@ benchmark.runners.my-strix-gpu = {
   ];
 };
 ```
+
+Benchmark runners create `benchmark.modelsPath` if needed and add it to Nix
+build sandboxes. They do not manage the model files themselves; benchmark
+derivations define the expected model paths under that root.
 
 For FastFlowLM NPU benchmarks, advertise a separate runner with IOMMU passthrough rather than reusing an IOMMU-off GPU runner:
 
@@ -271,7 +277,7 @@ benchmark.runners.my-strix-npu = {
 };
 ```
 
-The runner module does not manage model files; benchmark derivations define their own workload inputs. By default, benchmark runners assert `iommu=off`; NPU hosts should use a separate runner profile with IOMMU passthrough.
+By default, benchmark runners assert `iommu=off`; NPU hosts should use a separate runner profile with IOMMU passthrough.
 
 Use `benchmark.executor` on machines that submit benchmark builds to register runner hosts as Nix remotes:
 

--- a/bench/suites/ds4.nix
+++ b/bench/suites/ds4.nix
@@ -1,0 +1,181 @@
+{
+  pkgs,
+  package,
+  modelRoot ? "/models/ds4",
+  target,
+  hostProfile ? "linux-amd-kfd",
+  matrixMetadata ? { },
+}:
+
+let
+  inherit (pkgs) lib;
+  benchLib = import ../lib.nix { inherit lib; };
+
+  clean = lib.replaceStrings [ ":" "." "/" "_" ] [ "-" "-" "-" "-" ];
+
+  modelConfigs = {
+    deepseek-v4-flash = {
+      path = "${modelRoot}/ds4flash.gguf";
+      repo = "antirez/deepseek-v4-gguf";
+      description = "DeepSeek V4 Flash GGUF for DwarfStar 4";
+      cases = [
+        {
+          scenario = "smoke";
+          ctxStart = 128;
+          ctxMax = 256;
+          stepIncr = 128;
+          genTokens = 8;
+          promptRepeats = 1024;
+          fastFull = false;
+        }
+        {
+          scenario = "fast-full";
+          ctxStart = 2048;
+          ctxMax = 16384;
+          stepIncr = 2048;
+          genTokens = 32;
+          promptRepeats = 32768;
+          fastFull = true;
+        }
+      ];
+    };
+  };
+
+  mkCaseName =
+    {
+      scenario,
+      ...
+    }:
+    "ds4-rocm-${target.packageSuffix}-${clean scenario}";
+
+  mkRunner =
+    model:
+    {
+      ctxStart,
+      ctxMax,
+      stepIncr,
+      genTokens,
+      promptRepeats,
+      fastFull ? false,
+      ...
+    }:
+    let
+      executable = if fastFull then "ds4-bench-fast-full" else "ds4-bench";
+    in
+    pkgs.writeShellScript "ds4-rocm-${target.packageSuffix}-benchmark-runner" ''
+      set -euo pipefail
+
+      prompt="$TMPDIR/ds4-prompt.txt"
+      for i in $(seq 1 ${toString promptRepeats}); do
+        printf 'DwarfStar 4 ROCm benchmark prompt paragraph %05d. This text is intentionally repetitive and deterministic so the fixed token sequence is long enough for context frontier measurement. It discusses GPU memory bandwidth, attention prefill, routed experts, and decode throughput on AMD Strix Halo. ' "$i"
+      done > "$prompt"
+
+      ${package}/bin/${executable} \
+        -m ${lib.escapeShellArg model.path} \
+        --cuda \
+        --prompt-file "$prompt" \
+        --ctx-start ${toString ctxStart} \
+        --ctx-max ${toString ctxMax} \
+        --step-incr ${toString stepIncr} \
+        --gen-tokens ${toString genTokens} \
+        --csv "$out/results.csv"
+
+      cat "$out/results.csv"
+    '';
+
+  mkBenchmark =
+    modelName: model:
+    {
+      scenario,
+      ctxStart,
+      ctxMax,
+      stepIncr,
+      genTokens,
+      fastFull ? false,
+      ...
+    }@case:
+    let
+      name = mkCaseName case;
+      params = {
+        inherit
+          ctxStart
+          ctxMax
+          stepIncr
+          genTokens
+          fastFull
+          ;
+      };
+    in
+    benchLib.mkBenchmark {
+      inherit
+        pkgs
+        name
+        package
+        ;
+      command = [ (mkRunner model case) ];
+      env = {
+        DS4_MODEL = model.path;
+        DS4_SERVER_PERFLEVEL = "skip";
+        DS4_SERVER_FAST_FULL = if fastFull then "1" else null;
+      };
+      requirements = {
+        systemFeatures = [ target.systemFeature ];
+        hostProfiles = [ hostProfile ];
+        sandboxPaths = [
+          "/dev/dri"
+          "/dev/kfd"
+          "/sys/class/drm"
+          "/sys/class/kfd"
+          modelRoot
+        ];
+      };
+      metadata = lib.recursiveUpdate {
+        kind = "ds4";
+        suite = "ds4";
+        accelerator = "rocm";
+        backend = "hip";
+        inherit
+          params
+          scenario
+          ;
+        target = {
+          inherit (target)
+            packageSuffix
+            runtimeArch
+            systemFeature
+            ;
+        };
+        model = {
+          name = modelName;
+          inherit (model)
+            description
+            path
+            repo
+            ;
+        };
+        tool = {
+          backend = "rocm";
+          packageRole = "ds4-rocm";
+        };
+      } matrixMetadata;
+      meta.platforms = [ "x86_64-linux" ];
+      description = "Run DS4 ROCm benchmark ${modelName}/${name}";
+    };
+
+  generateModelBenchmarks =
+    modelName: model:
+    builtins.listToAttrs (
+      map (case: {
+        name = mkCaseName case;
+        value = mkBenchmark modelName model case;
+      }) model.cases
+    );
+
+  benchmarks = lib.mapAttrs generateModelBenchmarks modelConfigs;
+in
+{
+  inherit
+    benchmarks
+    mkBenchmark
+    ;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,22 @@
 {
   "nodes": {
+    "ds4-hip": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779749771,
+        "narHash": "sha256-fpND5xv3ceafMg26JDeGatm5yNDpM8CBcZlAQ1iG+f8=",
+        "owner": "ejpir",
+        "repo": "ds4-hip",
+        "rev": "aa09fdca6cef1b73d2664f6c114260c4c3c31643",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ejpir",
+        "ref": "rocm-upstream-shape-cyberneurova",
+        "repo": "ds4-hip",
+        "type": "github"
+      }
+    },
     "ec-su-axb35": {
       "flake": false,
       "locked": {
@@ -66,6 +83,7 @@
     },
     "root": {
       "inputs": {
+        "ds4-hip": "ds4-hip",
         "ec-su-axb35": "ec-su-axb35",
         "fastflowlm": "fastflowlm",
         "llama-cpp-master": "llama-cpp-master",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,11 @@
       flake = false;
     };
 
+    ds4-hip = {
+      url = "github:ejpir/ds4-hip/rocm-upstream-shape-cyberneurova";
+      flake = false;
+    };
+
     xrt-src = {
       url = "git+https://github.com/Xilinx/XRT?ref=XRT-2.21&submodules=1";
       flake = false;
@@ -496,8 +501,16 @@
                   inherit pkgs;
                   package = pkgs.fastflowlm;
                 }).benchmarks;
+              ds4Benchmarks =
+                (import ./bench/suites/ds4.nix {
+                  inherit pkgs;
+                  package = pkgs.${"ds4-rocm-${defaultRocmTarget.packageSuffix}"};
+                  target = defaultTargetMetadata;
+                }).benchmarks;
             in
-            flattenBenchmarks acceleratedBenchmarks // flattenBenchmarks fastflowlmBenchmarks
+            flattenBenchmarks acceleratedBenchmarks
+            // flattenBenchmarks fastflowlmBenchmarks
+            // flattenBenchmarks ds4Benchmarks
           );
         in
         flattenBenchmarks genericBenchmarks // linuxBenchmarks;
@@ -606,6 +619,28 @@
                 "${prefix}-unstable-${
                   input.shortRev or (if input ? rev then builtins.substring 0 7 input.rev else "unknown")
                 }";
+              ds4RocmTargets = builtins.filter (
+                rocmTarget: builtins.hasAttr rocmTarget.packageSuffix defaultTherockSources.rocm.linux
+              ) rocmTargets;
+              ds4RocmTargetPackages = lib.listToAttrs (
+                map (
+                  rocmTarget:
+                  let
+                    s = rocmTarget.packageSuffix;
+                  in
+                  {
+                    name = "ds4-rocm-${s}";
+                    value = prev.callPackage ./pkgs/ds4-rocm {
+                      src = inputs.ds4-hip;
+                      rocmSdk = final."therock-rocm-${s}";
+                      version = inputVersion "experimental" inputs.ds4-hip;
+                      packageSuffix = s;
+                      offloadArch = builtins.head rocmTarget.buildTargets;
+                      hsaOverrideGfxVersion = rocmTarget.hsaOverride or null;
+                    };
+                  }
+                ) ds4RocmTargets
+              );
             in
             {
               # EC-SU_AXB35 packages
@@ -629,6 +664,8 @@
                 src = inputs.fastflowlm;
               };
 
+              ds4-rocm = ds4RocmTargetPackages."ds4-rocm-${defaultRocmTarget.packageSuffix}";
+
               # Generic ROCm llama.cpp build; target narrowing is explicit below.
               llama-cpp-rocm = llamaCppRocmBase;
               llama-cpp-vulkan = llamaCppVulkanBase;
@@ -637,6 +674,7 @@
               llama-cpp-master-vulkan = applyMasterSrc "llama-cpp-master-vulkan" llamaCppVulkanBase;
               llama-cpp-master-cuda = applyMasterSrc "llama-cpp-master-cuda" llamaCppCudaBase;
             }
+            // ds4RocmTargetPackages
             // llamaCppRocmTargetPackages
             // llamaCppMasterRocmTargetPackages
             // (therockRocmOverlay final prev)
@@ -721,6 +759,10 @@
               llamaCppTargetPackages = lib.genAttrs (
                 llamaCppTargetPackageNames ++ llamaCppMasterTargetPackageNames
               ) (name: pkgs.${name});
+              ds4RocmPackageNames = map (rocmTarget: "ds4-rocm-${rocmTarget.packageSuffix}") rocmTargets;
+              ds4RocmPackages = lib.genAttrs (builtins.filter (
+                name: builtins.hasAttr name pkgs
+              ) ds4RocmPackageNames) (name: pkgs.${name});
               cudaPkgs = cudaPackagesFor pkgs.stdenv.hostPlatform.system;
 
               therockPackages =
@@ -733,6 +775,7 @@
             in
             {
               inherit (pkgs)
+                ds4-rocm
                 ec-su-axb35-monitor
                 fastflowlm
                 llama-cpp-rocm
@@ -746,6 +789,7 @@
                 ;
               inherit (cudaPkgs) llama-cpp-cuda llama-cpp-master-cuda;
             }
+            // ds4RocmPackages
             // llamaCppTargetPackages
             // therockPackages;
         in
@@ -1107,6 +1151,8 @@
           let
             fastflowlmBenchmark = benchmarkSet.bench-llama3-2-1b-fastflowlm-medium;
             fastflowlmBenchmarkMetadata = builtins.toJSON fastflowlmBenchmark.passthru.benchmark;
+            ds4Benchmark = benchmarkSet.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke;
+            ds4BenchmarkMetadata = builtins.toJSON ds4Benchmark.passthru.benchmark;
           in
           {
             benchmark-runner-profiles =
@@ -1156,7 +1202,37 @@
                   touch "$out"
                 '';
 
+            ds4-benchmark-metadata =
+              pkgs.runCommandLocal "ci-ds4-benchmark-metadata"
+                {
+                  nativeBuildInputs = [ pkgs.jq ];
+                }
+                ''
+                  cat > metadata.json <<'JSON'
+                  ${ds4BenchmarkMetadata}
+                  JSON
+
+                  jq -e '
+                    .kind == "ds4"
+                    and .accelerator == "rocm"
+                    and .backend == "hip"
+                    and .requirements.systemFeatures == [ "gfx1151" ]
+                    and .requirements.hostProfiles == [ "linux-amd-kfd" ]
+                    and (.requirements.sandboxPaths | index("/dev/kfd") != null)
+                    and (.requirements.sandboxPaths | index("/dev/dri") != null)
+                    and (.requirements.sandboxPaths | index("/models/ds4") != null)
+                    and .model.path == "/models/ds4/ds4flash.gguf"
+                    and .packages == [ "ds4-rocm-gfx1151" ]
+                    and .params.ctxStart == 128
+                    and .params.ctxMax == 256
+                    and .params.genTokens == 8
+                  ' metadata.json
+
+                  touch "$out"
+                '';
+
             "package-llama-cpp-rocm-${s}" = pkgs."llama-cpp-rocm-${s}";
+            "package-ds4-rocm-${s}" = pkgs."ds4-rocm-${s}";
             package-fastflowlm = pkgs.fastflowlm;
             package-strix-halo-mes-firmware = pkgs.strix-halo-mes-firmware;
             "therock-pytorch-${s}" = pkgs.${therockPytorchPackage};

--- a/flake.nix
+++ b/flake.nix
@@ -989,6 +989,7 @@
           benchmarkRunnerProfileMetadata = builtins.toJSON {
             features = benchmarkRunnerProfileConfig.nix.settings.system-features;
             sandboxPaths = benchmarkRunnerProfileConfig.nix.settings.extra-sandbox-paths;
+            tmpfilesRules = benchmarkRunnerProfileConfig.systemd.tmpfiles.rules;
             udevRules = benchmarkRunnerProfileConfig.services.udev.extraRules;
           };
 
@@ -1168,10 +1169,12 @@
                   jq -e '
                     (.features | index("${defaultRocmTarget.systemFeature}") != null)
                     and (.features | index("caller-feature") != null)
+                    and (.sandboxPaths | index("/models") != null)
                     and (.sandboxPaths | index("/dev/dri") != null)
                     and (.sandboxPaths | index("/dev/kfd") != null)
                     and (.sandboxPaths | index("/dev/accel") == null)
                     and (.sandboxPaths | index("/caller/device") != null)
+                    and (.tmpfilesRules | index("d /models 0755 root root -") != null)
                     and (.udevRules | contains("KERNEL==\"kfd\""))
                   ' profile.json
 

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -36,6 +36,8 @@ let
     runner:
     runner.systemFeatures ++ map common.gpuFeature runner.gpus ++ map common.npuFeature runner.npus;
 
+  modelsPath = toString cfg.modelsPath;
+
   gpus = concatMap (runner: runner.gpus) enabledRunners;
   npus = concatMap (runner: runner.npus) enabledRunners;
 
@@ -47,7 +49,10 @@ let
 
   systemFeatures = unique (concatMap runnerFeatures enabledRunners);
   extraSandboxPaths = unique (
-    concatMap (runner: runner.extraSandboxPaths) enabledRunners
+    [
+      modelsPath
+    ]
+    ++ concatMap (runner: runner.extraSandboxPaths) enabledRunners
     ++ optionals (hasGpu || hasNpu) [
       "/dev/shm"
       "/proc"
@@ -169,10 +174,23 @@ in
     ./benchmark-executor.nix
   ];
 
-  options.benchmark.runners = mkOption {
-    type = types.attrsOf runnerModule;
-    default = { };
-    description = "Named local benchmark runner capabilities.";
+  options.benchmark = {
+    modelsPath = mkOption {
+      type = types.path;
+      default = "/models";
+      description = ''
+        Host path containing benchmark model files. Benchmark runners create
+        this directory if needed and bind it read-only into Nix build
+        sandboxes. Individual benchmark derivations still define the model
+        files they expect beneath this root.
+      '';
+    };
+
+    runners = mkOption {
+      type = types.attrsOf runnerModule;
+      default = { };
+      description = "Named local benchmark runner capabilities.";
+    };
   };
 
   config = mkIf hasEnabledRunner {
@@ -197,6 +215,10 @@ in
       "extra-sandbox-paths" = extraSandboxPaths;
       sandbox = mkIf relaxSandbox "relaxed";
     };
+
+    systemd.tmpfiles.rules = [
+      "d ${modelsPath} 0755 root root -"
+    ];
 
     services.udev.extraRules = concatStringsSep "\n" (
       optionals hasAmdGpu [

--- a/pkgs/ds4-rocm/default.nix
+++ b/pkgs/ds4-rocm/default.nix
@@ -2,7 +2,6 @@
   lib,
   stdenv,
   gnumake,
-  makeWrapper,
   coreutils,
   curl,
   gnugrep,
@@ -35,41 +34,9 @@ let
     stdenv.cc.cc.lib
   ];
 
-  rocmEnvironment = [
-    "--set"
-    "HIP_PLATFORM"
-    "amd"
-  ]
-  ++ lib.optionals (hsaOverrideGfxVersion != null) [
-    "--set"
-    "HSA_OVERRIDE_GFX_VERSION"
-    hsaOverrideGfxVersion
-  ]
-  ++ [
-    "--set"
-    "ROCM_HOME"
-    "${rocmSdk}"
-    "--set"
-    "ROCM_PATH"
-    "${rocmSdk}"
-    "--set"
-    "HIP_PATH"
-    "${rocmSdk}"
-    "--set"
-    "DEVICE_LIB_PATH"
-    "${rocmSdk}/lib/llvm/amdgcn/bitcode"
-    "--set"
-    "HIP_DEVICE_LIB_PATH"
-    "${rocmSdk}/lib/llvm/amdgcn/bitcode"
-    "--prefix"
-    "PATH"
-    ":"
-    runtimePath
-    "--prefix"
-    "LD_LIBRARY_PATH"
-    ":"
-    runtimeLibraryPath
-  ];
+  hsaOverrideWrapperLine = lib.optionalString (hsaOverrideGfxVersion != null) ''
+    printf 'export HSA_OVERRIDE_GFX_VERSION=%s\n' ${lib.escapeShellArg (lib.escapeShellArg hsaOverrideGfxVersion)}
+  '';
 in
 stdenv.mkDerivation {
   pname = "ds4-rocm-${packageSuffix}";
@@ -77,7 +44,6 @@ stdenv.mkDerivation {
 
   nativeBuildInputs = [
     gnumake
-    makeWrapper
   ];
 
   dontConfigure = true;
@@ -100,13 +66,46 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
+    mkdir -p "$out/bin"
+
+    {
+      printf '#!%s\n' '${stdenv.shell}'
+      printf 'export HIP_PLATFORM=amd\n'
+      ${hsaOverrideWrapperLine}
+      printf 'export ROCM_HOME="%s"\n' '${rocmSdk}'
+      printf 'export ROCM_PATH="%s"\n' '${rocmSdk}'
+      printf 'export HIP_PATH="%s"\n' '${rocmSdk}'
+      printf 'export DEVICE_LIB_PATH="%s/lib/llvm/amdgcn/bitcode"\n' '${rocmSdk}'
+      printf 'export HIP_DEVICE_LIB_PATH="%s/lib/llvm/amdgcn/bitcode"\n' '${rocmSdk}'
+      printf 'export PATH="%s/bin:%s$%s"\n' "$out" '${runtimePath}' '{PATH:+:$PATH}'
+      printf 'export LD_LIBRARY_PATH="%s$%s"\n' '${runtimeLibraryPath}' '{LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}'
+      printf 'exec "$@"\n'
+    } > "$out/bin/ds4-rocm-env"
+    chmod +x "$out/bin/ds4-rocm-env"
+
+    installRocmWrapper() {
+      local name="$1"
+      local target="$2"
+      shift 2
+
+      {
+        printf '#!%s\n' '${stdenv.shell}'
+        for assignment in "$@"; do
+          printf 'export %s\n' "$assignment"
+        done
+        printf 'exec "%s/bin/ds4-rocm-env" "%s" "$@"\n' "$out" "$target"
+      } > "$out/bin/$name"
+      chmod +x "$out/bin/$name"
+    }
+
     for bin in \
       ds4-rocm-upstream \
       ds4-server-rocm-upstream \
       ds4-bench-rocm-upstream \
       ds4-eval-rocm-upstream \
       ds4-agent-rocm-upstream; do
-      install -Dm755 "$bin" "$out/bin/$bin"
+      install -Dm755 "$bin" "$out/libexec/ds4/$bin"
+      installRocmWrapper "$bin" "$out/libexec/ds4/$bin"
     done
 
     ln -s ds4-rocm-upstream "$out/bin/ds4"
@@ -144,43 +143,35 @@ stdenv.mkDerivation {
       --replace-fail 'make "$SERVER_MAKE_TARGET" -j"$(nproc)"' ':' \
       --replace-fail 'SERVER_BIN="./ds4-server-rocm-upstream"' 'SERVER_BIN="ds4-server-rocm-upstream"'
 
-    makeWrapper "$out/share/ds4/scripts/run_ds4_bench_rocm_upstream.sh" "$out/bin/ds4-bench-fast-full" \
-      --set DS4_SERVER_FAST_FULL 1 \
-      --prefix PATH : "$out/bin" \
-      ${lib.escapeShellArgs rocmEnvironment}
+    installRocmWrapper \
+      ds4-bench-fast-full \
+      "$out/share/ds4/scripts/run_ds4_bench_rocm_upstream.sh" \
+      DS4_SERVER_FAST_FULL=1
+    installRocmWrapper \
+      ds4-eval-fast-full \
+      "$out/share/ds4/scripts/run_ds4_eval_rocm_upstream.sh"
+    installRocmWrapper \
+      ds4-agent-fast-full \
+      "$out/share/ds4/scripts/start_ds4_agent_rocm_upstream.sh"
+    installRocmWrapper \
+      ds4-cli-fast-full \
+      "$out/share/ds4/scripts/start_ds4_cli_rocm_upstream.sh"
+    installRocmWrapper \
+      ds4-server-fast-full \
+      "$out/share/ds4/scripts/start_ds4_server.sh" \
+      DS4_SERVER_FAST_FULL=1
 
-    makeWrapper "$out/share/ds4/scripts/run_ds4_eval_rocm_upstream.sh" "$out/bin/ds4-eval-fast-full" \
-      --prefix PATH : "$out/bin" \
-      ${lib.escapeShellArgs rocmEnvironment}
-
-    makeWrapper "$out/share/ds4/scripts/start_ds4_agent_rocm_upstream.sh" "$out/bin/ds4-agent-fast-full" \
-      --prefix PATH : "$out/bin" \
-      ${lib.escapeShellArgs rocmEnvironment}
-
-    makeWrapper "$out/share/ds4/scripts/start_ds4_cli_rocm_upstream.sh" "$out/bin/ds4-cli-fast-full" \
-      --prefix PATH : "$out/bin" \
-      ${lib.escapeShellArgs rocmEnvironment}
-
-    makeWrapper "$out/share/ds4/scripts/start_ds4_server.sh" "$out/bin/ds4-server-fast-full" \
-      --set DS4_SERVER_FAST_FULL 1 \
-      --prefix PATH : "$out/bin" \
-      ${lib.escapeShellArgs rocmEnvironment}
-
-    install -Dm755 download_model.sh "$out/bin/ds4-download-model"
-    substituteInPlace "$out/bin/ds4-download-model" \
+    install -Dm755 download_model.sh "$out/share/ds4/download_model.sh"
+    substituteInPlace "$out/share/ds4/download_model.sh" \
       --replace-fail 'ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)' 'ROOT=''${DS4_ROOT:-$PWD}'
-    patchShebangs "$out/bin/ds4-download-model"
-    wrapProgram "$out/bin/ds4-download-model" \
-      --prefix PATH : "${runtimePath}"
+    patchShebangs "$out/share/ds4/download_model.sh"
 
-    for bin in \
-      ds4-rocm-upstream \
-      ds4-server-rocm-upstream \
-      ds4-bench-rocm-upstream \
-      ds4-eval-rocm-upstream \
-      ds4-agent-rocm-upstream; do
-      wrapProgram "$out/bin/$bin" ${lib.escapeShellArgs rocmEnvironment}
-    done
+    {
+      printf '#!%s\n' '${stdenv.shell}'
+      printf 'export PATH="%s$%s"\n' '${runtimePath}' '{PATH:+:$PATH}'
+      printf 'exec "%s/share/ds4/download_model.sh" "$@"\n' "$out"
+    } > "$out/bin/ds4-download-model"
+    chmod +x "$out/bin/ds4-download-model"
 
     runHook postInstall
   '';

--- a/pkgs/ds4-rocm/default.nix
+++ b/pkgs/ds4-rocm/default.nix
@@ -1,0 +1,195 @@
+{
+  lib,
+  stdenv,
+  gnumake,
+  makeWrapper,
+  coreutils,
+  curl,
+  gnugrep,
+  gnused,
+  gawk,
+  iproute2,
+  procps,
+  rocmSdk,
+  src,
+  version ? "experimental",
+  packageSuffix ? offloadArch,
+  offloadArch ? "gfx1151",
+  hsaOverrideGfxVersion ? null,
+}:
+
+let
+  runtimePath = lib.makeBinPath [
+    coreutils
+    curl
+    gnugrep
+    gnused
+    gawk
+    iproute2
+    procps
+    rocmSdk
+  ];
+
+  runtimeLibraryPath = lib.makeLibraryPath [
+    rocmSdk
+    stdenv.cc.cc.lib
+  ];
+
+  rocmEnvironment = [
+    "--set"
+    "HIP_PLATFORM"
+    "amd"
+  ]
+  ++ lib.optionals (hsaOverrideGfxVersion != null) [
+    "--set"
+    "HSA_OVERRIDE_GFX_VERSION"
+    hsaOverrideGfxVersion
+  ]
+  ++ [
+    "--set"
+    "ROCM_HOME"
+    "${rocmSdk}"
+    "--set"
+    "ROCM_PATH"
+    "${rocmSdk}"
+    "--set"
+    "HIP_PATH"
+    "${rocmSdk}"
+    "--set"
+    "DEVICE_LIB_PATH"
+    "${rocmSdk}/lib/llvm/amdgcn/bitcode"
+    "--set"
+    "HIP_DEVICE_LIB_PATH"
+    "${rocmSdk}/lib/llvm/amdgcn/bitcode"
+    "--prefix"
+    "PATH"
+    ":"
+    runtimePath
+    "--prefix"
+    "LD_LIBRARY_PATH"
+    ":"
+    runtimeLibraryPath
+  ];
+in
+stdenv.mkDerivation {
+  pname = "ds4-rocm-${packageSuffix}";
+  inherit src version;
+
+  nativeBuildInputs = [
+    gnumake
+    makeWrapper
+  ];
+
+  dontConfigure = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    make rocm-upstream -j"$NIX_BUILD_CORES" \
+      CC="$CC" \
+      ROCM_PATH="${rocmSdk}" \
+      ROCM_HIPCC="${rocmSdk}/bin/therock-hip-clang++" \
+      ROCM_ARCH="${offloadArch}" \
+      CFLAGS="-O3 -ffast-math -D_GNU_SOURCE -Wall -Wextra -std=c99" \
+      ROCM_CFLAGS="-O3 -fno-finite-math-only -pthread -D__HIP_PLATFORM_AMD__ -I. -Wno-unused-command-line-argument -x hip --offload-arch=${offloadArch}" \
+      ROCM_LDLIBS="-lm -pthread -L${rocmSdk}/lib -Wl,-rpath,${rocmSdk}/lib -lhipblas -lhipblaslt -lamdhip64"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for bin in \
+      ds4-rocm-upstream \
+      ds4-server-rocm-upstream \
+      ds4-bench-rocm-upstream \
+      ds4-eval-rocm-upstream \
+      ds4-agent-rocm-upstream; do
+      install -Dm755 "$bin" "$out/bin/$bin"
+    done
+
+    ln -s ds4-rocm-upstream "$out/bin/ds4"
+    ln -s ds4-server-rocm-upstream "$out/bin/ds4-server"
+    ln -s ds4-bench-rocm-upstream "$out/bin/ds4-bench"
+    ln -s ds4-eval-rocm-upstream "$out/bin/ds4-eval"
+    ln -s ds4-agent-rocm-upstream "$out/bin/ds4-agent"
+
+    mkdir -p "$out/share/ds4"
+    cp -R scripts speed-bench "$out/share/ds4/"
+    for file in README.md LICENSE MODEL_CARD.md AGENT.md gfx1151.md; do
+      if [ -e "$file" ]; then
+        install -Dm644 "$file" "$out/share/ds4/$file"
+      fi
+    done
+    patchShebangs "$out/share/ds4/scripts"
+
+    substituteInPlace "$out/share/ds4/scripts/run_ds4_bench_rocm_upstream.sh" \
+      --replace-fail 'make ds4-bench-rocm-upstream -j"$(nproc)"' ':' \
+      --replace-fail './ds4-bench-rocm-upstream' 'ds4-bench-rocm-upstream'
+
+    substituteInPlace "$out/share/ds4/scripts/run_ds4_eval_rocm_upstream.sh" \
+      --replace-fail 'make ds4-eval-rocm-upstream -j"$(nproc)"' ':' \
+      --replace-fail './ds4-eval-rocm-upstream' 'ds4-eval-rocm-upstream'
+
+    substituteInPlace "$out/share/ds4/scripts/start_ds4_agent_rocm_upstream.sh" \
+      --replace-fail 'make ds4-agent-rocm-upstream -j"$(nproc)"' ':' \
+      --replace-fail './ds4-agent-rocm-upstream' 'ds4-agent-rocm-upstream'
+
+    substituteInPlace "$out/share/ds4/scripts/start_ds4_cli_rocm_upstream.sh" \
+      --replace-fail 'make ds4-rocm-upstream -j"$(nproc)"' ':' \
+      --replace-fail './ds4-rocm-upstream' 'ds4-rocm-upstream'
+
+    substituteInPlace "$out/share/ds4/scripts/start_ds4_server.sh" \
+      --replace-fail 'make "$SERVER_MAKE_TARGET" -j"$(nproc)"' ':' \
+      --replace-fail 'SERVER_BIN="./ds4-server-rocm-upstream"' 'SERVER_BIN="ds4-server-rocm-upstream"'
+
+    makeWrapper "$out/share/ds4/scripts/run_ds4_bench_rocm_upstream.sh" "$out/bin/ds4-bench-fast-full" \
+      --set DS4_SERVER_FAST_FULL 1 \
+      --prefix PATH : "$out/bin" \
+      ${lib.escapeShellArgs rocmEnvironment}
+
+    makeWrapper "$out/share/ds4/scripts/run_ds4_eval_rocm_upstream.sh" "$out/bin/ds4-eval-fast-full" \
+      --prefix PATH : "$out/bin" \
+      ${lib.escapeShellArgs rocmEnvironment}
+
+    makeWrapper "$out/share/ds4/scripts/start_ds4_agent_rocm_upstream.sh" "$out/bin/ds4-agent-fast-full" \
+      --prefix PATH : "$out/bin" \
+      ${lib.escapeShellArgs rocmEnvironment}
+
+    makeWrapper "$out/share/ds4/scripts/start_ds4_cli_rocm_upstream.sh" "$out/bin/ds4-cli-fast-full" \
+      --prefix PATH : "$out/bin" \
+      ${lib.escapeShellArgs rocmEnvironment}
+
+    makeWrapper "$out/share/ds4/scripts/start_ds4_server.sh" "$out/bin/ds4-server-fast-full" \
+      --set DS4_SERVER_FAST_FULL 1 \
+      --prefix PATH : "$out/bin" \
+      ${lib.escapeShellArgs rocmEnvironment}
+
+    install -Dm755 download_model.sh "$out/bin/ds4-download-model"
+    substituteInPlace "$out/bin/ds4-download-model" \
+      --replace-fail 'ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)' 'ROOT=''${DS4_ROOT:-$PWD}'
+    patchShebangs "$out/bin/ds4-download-model"
+    wrapProgram "$out/bin/ds4-download-model" \
+      --prefix PATH : "${runtimePath}"
+
+    for bin in \
+      ds4-rocm-upstream \
+      ds4-server-rocm-upstream \
+      ds4-bench-rocm-upstream \
+      ds4-eval-rocm-upstream \
+      ds4-agent-rocm-upstream; do
+      wrapProgram "$out/bin/$bin" ${lib.escapeShellArgs rocmEnvironment}
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Experimental DwarfStar 4 ROCm/HIP build";
+    homepage = "https://github.com/ejpir/ds4-hip/tree/rocm-upstream-shape-cyberneurova";
+    license = lib.licenses.mit;
+    mainProgram = "ds4";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary
- add ds4-hip as a non-flake input
- package DS4 ROCm/HIP against the target-keyed TheRock SDK
- expose ds4-rocm packages/apps and add the gfx1151 package to PR checks

## Validation
- nix flake check --no-build --print-build-logs --builders ''
- nix build .#checks.x86_64-linux.package-ds4-rocm-gfx1151 --no-link --print-build-logs --builders ''
- nix build .#checks.x86_64-linux.format .#checks.x86_64-linux.deadnix .#checks.x86_64-linux.statix --no-link --print-build-logs --builders ''