### PR TITLE
vllm: add Lemonade ROCm bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Main package outputs:
 - `packages.x86_64-linux.llama-cpp-vulkan`
 - `packages.x86_64-linux.ec-su-axb35-monitor`
 - `packages.x86_64-linux.strix-halo-mes-firmware`
+- `packages.x86_64-linux.vllm-rocm-lemonade-gfx1151`
 - `packages.x86_64-linux.xrt-amdxdna`
 
 Main app outputs:
@@ -91,6 +92,7 @@ Target records are generic build descriptors, not a hardware inventory. Hostname
 - `packages.x86_64-linux.therock-python-gfx1151`
 - `packages.x86_64-linux.torch-rocm-gfx1151`
 - `packages.x86_64-linux.ds4-rocm-gfx1151`
+- `packages.x86_64-linux.vllm-rocm-lemonade-gfx1151`
 
 The lower-level ROCm module overlay also exposes reusable narrowed package scopes:
 

--- a/flake.nix
+++ b/flake.nix
@@ -641,6 +641,24 @@
                   }
                 ) ds4RocmTargets
               );
+              lemonadeVllmRocmTargets = builtins.filter (
+                rocmTarget: rocmTarget.packageSuffix == "gfx1151"
+              ) rocmTargets;
+              lemonadeVllmRocmTargetPackages = lib.listToAttrs (
+                map (
+                  rocmTarget:
+                  let
+                    s = rocmTarget.packageSuffix;
+                  in
+                  {
+                    name = "vllm-rocm-lemonade-${s}";
+                    value = prev.callPackage ./pkgs/lemonade-vllm-rocm {
+                      target = s;
+                      releaseTag = "vllm0.21.0-rocm7.13.0-${s}";
+                    };
+                  }
+                ) lemonadeVllmRocmTargets
+              );
             in
             {
               # EC-SU_AXB35 packages
@@ -675,6 +693,7 @@
               llama-cpp-master-cuda = applyMasterSrc "llama-cpp-master-cuda" llamaCppCudaBase;
             }
             // ds4RocmTargetPackages
+            // lemonadeVllmRocmTargetPackages
             // llamaCppRocmTargetPackages
             // llamaCppMasterRocmTargetPackages
             // (therockRocmOverlay final prev)
@@ -763,6 +782,12 @@
               ds4RocmPackages = lib.genAttrs (builtins.filter (
                 name: builtins.hasAttr name pkgs
               ) ds4RocmPackageNames) (name: pkgs.${name});
+              vllmRocmLemonadePackageNames = map (
+                rocmTarget: "vllm-rocm-lemonade-${rocmTarget.packageSuffix}"
+              ) rocmTargets;
+              vllmRocmLemonadePackages = lib.genAttrs (builtins.filter (
+                name: builtins.hasAttr name pkgs
+              ) vllmRocmLemonadePackageNames) (name: pkgs.${name});
               cudaPkgs = cudaPackagesFor pkgs.stdenv.hostPlatform.system;
 
               therockPackages =
@@ -790,6 +815,7 @@
               inherit (cudaPkgs) llama-cpp-cuda llama-cpp-master-cuda;
             }
             // ds4RocmPackages
+            // vllmRocmLemonadePackages
             // llamaCppTargetPackages
             // therockPackages;
         in
@@ -959,6 +985,7 @@
           system = pkgs.stdenv.hostPlatform.system;
           s = defaultRocmTarget.packageSuffix;
           therockPytorchPackage = "torch-rocm-${s}";
+          vllmRocmLemonadePackage = "vllm-rocm-lemonade-${s}";
           benchmarkSet = self.benchmarks.${system};
           cpuBenchmark = benchmarkSet.bench-llama2-7b-llama-cpp-cpu-b512-fa1;
           cpuBenchmarkMetadata = builtins.toJSON cpuBenchmark.passthru.benchmark;
@@ -1239,6 +1266,9 @@
             package-fastflowlm = pkgs.fastflowlm;
             package-strix-halo-mes-firmware = pkgs.strix-halo-mes-firmware;
             "therock-pytorch-${s}" = pkgs.${therockPytorchPackage};
+          }
+          // lib.optionalAttrs (builtins.hasAttr vllmRocmLemonadePackage pkgs) {
+            "package-${vllmRocmLemonadePackage}" = pkgs.${vllmRocmLemonadePackage};
           }
         )
       );

--- a/pkgs/lemonade-vllm-rocm/amdsmi-compat/__init__.py
+++ b/pkgs/lemonade-vllm-rocm/amdsmi-compat/__init__.py
@@ -1,0 +1,55 @@
+import os
+
+
+class AmdSmiException(Exception):
+    pass
+
+
+def _device_count():
+    return int(os.getenv("AMDSMI_COMPAT_DEVICE_COUNT", "1"))
+
+
+def _gfx_arch():
+    return os.getenv("AMDSMI_COMPAT_GFX", "gfx1151")
+
+
+def _device_name():
+    return os.getenv("AMDSMI_COMPAT_DEVICE_NAME", "Radeon 8060S Graphics")
+
+
+def amdsmi_init():
+    return None
+
+
+def amdsmi_shut_down():
+    return None
+
+
+def amdsmi_get_processor_handles():
+    return list(range(_device_count()))
+
+
+def amdsmi_get_gpu_asic_info(handle):
+    if handle < 0 or handle >= _device_count():
+        raise AmdSmiException(f"invalid processor handle: {handle}")
+
+    return {
+        "target_graphics_version": _gfx_arch(),
+        "market_name": _device_name(),
+        "device_id": "",
+        "asic_serial": f"0x{handle + 1:032x}",
+    }
+
+
+def amdsmi_get_gpu_device_uuid(handle):
+    return f"GPU-{handle}"
+
+
+def amdsmi_topo_get_link_type(handle, peer_handle):
+    if handle == peer_handle:
+        return {"hops": 0, "type": 0}
+    return {"hops": 2, "type": 0}
+
+
+def amdsmi_topo_get_numa_node_number(handle):
+    return 0

--- a/pkgs/lemonade-vllm-rocm/c10-hip-compat.cc
+++ b/pkgs/lemonade-vllm-rocm/c10-hip-compat.cc
@@ -1,0 +1,99 @@
+#include <cstdint>
+
+struct C10Stream {
+  uint64_t opaque;
+};
+
+struct C10SourceLocation {
+  const char *function;
+  const char *file;
+  uint32_t line;
+};
+
+extern "C" int8_t cuda_current_device()
+    __asm__("_ZN3c104cuda14current_deviceEv");
+extern "C" C10Stream cuda_get_stream_from_pool_bool(bool, int8_t)
+    __asm__("_ZN3c104cuda17getStreamFromPoolEba");
+extern "C" C10Stream cuda_get_stream_from_pool_int(int, int8_t)
+    __asm__("_ZN3c104cuda17getStreamFromPoolEia");
+extern "C" C10Stream cuda_get_current_stream(int8_t)
+    __asm__("_ZN3c104cuda20getCurrentCUDAStreamEa");
+extern "C" C10Stream cuda_get_default_stream(int8_t)
+    __asm__("_ZN3c104cuda20getDefaultCUDAStreamEa");
+extern "C" void cuda_set_current_stream(C10Stream)
+    __asm__("_ZN3c104cuda20setCurrentCUDAStreamENS0_10CUDAStreamE");
+extern "C" void cuda_warn_or_error_on_sync()
+    __asm__("_ZN3c104cuda21warn_or_error_on_syncEv");
+extern "C" void cuda_check_impl(int, const char *, const char *, uint32_t, bool)
+    __asm__("_ZN3c104cuda29c10_cuda_check_implementationEiPKcS2_jb");
+extern "C" void *cuda_stream_stream(const C10Stream *)
+    __asm__("_ZNK3c104cuda10CUDAStream6streamEv");
+extern "C" void c10_message_logger_new_ctor(
+    void *, C10SourceLocation, int, bool)
+    __asm__("_ZN3c1013MessageLoggerC1ENS_14SourceLocationEib");
+
+extern "C" int8_t hip_current_device()
+    __asm__("_ZN3c103hip14current_deviceEv");
+extern "C" C10Stream hip_get_stream_from_pool_bool(bool, int8_t)
+    __asm__("_ZN3c103hip17getStreamFromPoolEba");
+extern "C" C10Stream hip_get_stream_from_pool_int(int, int8_t)
+    __asm__("_ZN3c103hip17getStreamFromPoolEia");
+extern "C" C10Stream hip_get_current_stream(int8_t)
+    __asm__("_ZN3c103hip19getCurrentHIPStreamEa");
+extern "C" C10Stream hip_get_default_stream(int8_t)
+    __asm__("_ZN3c103hip19getDefaultHIPStreamEa");
+extern "C" void hip_set_current_stream(C10Stream)
+    __asm__("_ZN3c103hip19setCurrentHIPStreamENS0_9HIPStreamE");
+extern "C" void hip_warn_or_error_on_sync()
+    __asm__("_ZN3c103hip21warn_or_error_on_syncEv");
+extern "C" void hip_check_impl(int, const char *, const char *, uint32_t, bool)
+    __asm__("_ZN3c103hip28c10_hip_check_implementationEiPKcS2_jb");
+extern "C" void *hip_stream_stream(const C10Stream *)
+    __asm__("_ZNK3c103hip9HIPStream6streamEv");
+extern "C" void c10_message_logger_old_ctor(void *, const char *, int, int, bool)
+    __asm__("_ZN3c1013MessageLoggerC1EPKciib");
+
+extern "C" int8_t hip_current_device() { return cuda_current_device(); }
+
+extern "C" C10Stream hip_get_stream_from_pool_bool(
+    bool is_high_priority, int8_t device) {
+  return cuda_get_stream_from_pool_bool(is_high_priority, device);
+}
+
+extern "C" C10Stream hip_get_stream_from_pool_int(
+    int priority, int8_t device) {
+  return cuda_get_stream_from_pool_int(priority, device);
+}
+
+extern "C" C10Stream hip_get_current_stream(int8_t device) {
+  return cuda_get_current_stream(device);
+}
+
+extern "C" C10Stream hip_get_default_stream(int8_t device) {
+  return cuda_get_default_stream(device);
+}
+
+extern "C" void hip_set_current_stream(C10Stream stream) {
+  cuda_set_current_stream(stream);
+}
+
+extern "C" void hip_warn_or_error_on_sync() { cuda_warn_or_error_on_sync(); }
+
+extern "C" void hip_check_impl(
+    int code,
+    const char *file,
+    const char *func,
+    uint32_t line,
+    bool include_device_assertions) {
+  cuda_check_impl(code, file, func, line, include_device_assertions);
+}
+
+extern "C" void *hip_stream_stream(const C10Stream *stream) {
+  return cuda_stream_stream(stream);
+}
+
+extern "C" void c10_message_logger_old_ctor(
+    void *self, const char *file, int line, int severity, bool exit_on_fatal) {
+  C10SourceLocation loc{nullptr, file, static_cast<uint32_t>(line)};
+  c10_message_logger_new_ctor(self, loc, severity, exit_on_fatal);
+}

--- a/pkgs/lemonade-vllm-rocm/default.nix
+++ b/pkgs/lemonade-vllm-rocm/default.nix
@@ -1,0 +1,258 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  makeWrapper,
+  gnutar,
+  gzip,
+  coreutils,
+  bash,
+  bzip2,
+  elfutils,
+  expat,
+  glibc,
+  libdrm,
+  libffi,
+  libuuid,
+  libxcrypt,
+  libxcrypt-legacy,
+  ncurses,
+  numactl,
+  ocl-icd,
+  openssl,
+  rdma-core,
+  sqlite,
+  xz,
+  tbb,
+  zlib,
+  zstd,
+  target ? "gfx1151",
+  releaseTag ? "vllm0.21.0-rocm7.13.0-gfx1151",
+}:
+
+let
+  baseUrl = "https://github.com/lemonade-sdk/vllm-rocm/releases/download/${releaseTag}";
+  archiveBase = "${releaseTag}-x64";
+  pythonShebang = "/opt/vllm/bin/python3";
+in
+stdenv.mkDerivation {
+  pname = "vllm-rocm-lemonade-${target}";
+  version = releaseTag;
+
+  partcount = fetchurl {
+    url = "${baseUrl}/${archiveBase}.partcount";
+    hash = "sha256-U8I05ehHK2rFHBrhyrP+BvrQU7646/2Jd7AQZVv908M=";
+  };
+
+  part01 = fetchurl {
+    url = "${baseUrl}/${archiveBase}.part01-of-02.tar.gz";
+    hash = "sha256-0/Ng991GDRQ1Bx71UKwzalIJrj6EULXk9mgisOgP6lw=";
+  };
+
+  part02 = fetchurl {
+    url = "${baseUrl}/${archiveBase}.part02-of-02.tar.gz";
+    hash = "sha256-yYuewM801jwGdxFbvSMDiZoAnpumldUgC5V/lbkxZO0=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    coreutils
+    gnutar
+    gzip
+    makeWrapper
+  ];
+
+  buildInputs = [
+    bash
+    bzip2
+    elfutils
+    expat
+    glibc
+    libdrm
+    libffi
+    libuuid
+    libxcrypt
+    libxcrypt-legacy
+    ncurses
+    numactl
+    ocl-icd
+    openssl
+    rdma-core
+    sqlite
+    stdenv.cc.cc.lib
+    tbb
+    xz
+    zlib
+    zstd
+  ];
+
+  autoPatchelfIgnoreMissingDeps = [
+    "libc10_cuda.so"
+    "libjpeg.so.8"
+    "libtorch_cuda.so"
+  ];
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontStrip = true;
+
+  appendRunpaths = [
+    "$ORIGIN/../lib"
+    "$ORIGIN/../lib64"
+    "$ORIGIN/../llvm/lib"
+    "$ORIGIN/../lib/llvm/lib"
+  ];
+
+  installPhase = ''
+        runHook preInstall
+
+        test "$(cat "$partcount")" = "2"
+
+        mkdir -p "$out"
+        cat "$part01" "$part02" | tar -xzf - -C "$out"
+        chmod -R u+w "$out"
+        find "$out/bin" -type f -exec chmod u+x {} +
+
+        while IFS= read -r script; do
+          substituteInPlace "$script" \
+            --replace-fail "${pythonShebang}" "$out/bin/python3"
+        done < <(grep -rl '^#!${pythonShebang}' "$out/bin" || true)
+
+        mkdir -p "$out/lib"
+        "$CXX" -shared -fPIC -O2 "${./c10-hip-compat.cc}" \
+          -o "$out/lib/libvllm-rocm-c10-hip-compat.so" \
+          -L"$out/lib/python3.12/site-packages/torch/lib" \
+          -lc10_hip -ltorch_hip -lc10 \
+          -Wl,-rpath,"$out/lib/python3.12/site-packages/torch/lib"
+
+        mkdir -p "$out/lib/python3.12/site-packages/amdsmi"
+        cp "${./amdsmi-compat/__init__.py}" \
+          "$out/lib/python3.12/site-packages/amdsmi/__init__.py"
+
+        rocm_core="$out/lib/python3.12/site-packages/_rocm_sdk_core"
+        mkdir -p "$rocm_core/bin" "$rocm_core/.info"
+
+        printf '7.13.0\n' > "$rocm_core/.info/version"
+        printf '7.13.99004\n' > "$rocm_core/.info/version-dev"
+
+        if [ ! -e "$rocm_core/hip" ]; then
+          ln -s . "$rocm_core/hip"
+        fi
+
+        cat > "$rocm_core/bin/hipconfig" <<EOF
+    #!${bash}/bin/bash
+    case "\''${1:-}" in
+      --version)
+        echo "7.13.99004"
+        ;;
+      --rocmpath|--path)
+        echo "$rocm_core"
+        ;;
+      --hipclangpath)
+        echo "$rocm_core/lib/llvm/bin"
+        ;;
+      --full)
+        echo "HIP version  : 7.13.99004"
+        echo "ROCm path    : $rocm_core"
+        echo "HIP path     : $rocm_core"
+        echo "HIP clang    : $rocm_core/lib/llvm/bin/clang++"
+        ;;
+      *)
+        echo "7.13.99004"
+        ;;
+    esac
+    EOF
+
+        cat > "$rocm_core/bin/hipcc" <<EOF
+    #!${bash}/bin/bash
+    if [ "\''${1:-}" = "--version" ]; then
+      echo "HIP version: 7.13.99004"
+      exec "$rocm_core/lib/llvm/bin/clang++" --version
+    fi
+    exec "$rocm_core/lib/llvm/bin/clang++" --rocm-path="$rocm_core" --hip-path="$rocm_core" "\$@"
+    EOF
+
+        cat > "$rocm_core/bin/rocminfo" <<'EOF'
+    #!/usr/bin/env bash
+    for candidate in /run/current-system/sw/bin/rocminfo /usr/bin/rocminfo; do
+      if [ -x "$candidate" ]; then
+        exec "$candidate" "$@"
+      fi
+    done
+    cat <<'ROCINFO'
+    ROCk module is loaded
+
+    ==========
+    HSA Agents
+    ==========
+    *******
+    Agent 1
+    *******
+      Name:                    gfx1151
+      Marketing Name:          Radeon 8060S Graphics
+      Vendor Name:             AMD
+      Device Type:             GPU
+      Compute Unit:            40
+    ROCINFO
+    EOF
+
+        cat > "$rocm_core/bin/rocm_agent_enumerator" <<'EOF'
+    #!/usr/bin/env bash
+    if [ -x /run/current-system/sw/bin/rocm_agent_enumerator ]; then
+      exec /run/current-system/sw/bin/rocm_agent_enumerator "$@"
+    fi
+    echo gfx1151
+    EOF
+
+        cat > "$rocm_core/bin/offload-arch" <<'EOF'
+    #!/usr/bin/env bash
+    echo gfx1151
+    EOF
+
+        chmod +x \
+          "$rocm_core/bin/hipconfig" \
+          "$rocm_core/bin/hipcc" \
+          "$rocm_core/bin/rocminfo" \
+          "$rocm_core/bin/rocm_agent_enumerator" \
+          "$rocm_core/bin/offload-arch"
+
+        for tool in hipconfig hipcc rocminfo rocm_agent_enumerator offload-arch; do
+          rm -f "$out/bin/$tool"
+          ln -s "$rocm_core/bin/$tool" "$out/bin/$tool"
+        done
+
+        mv "$out/bin/vllm" "$out/bin/vllm-unwrapped"
+        makeWrapper "$out/bin/vllm-unwrapped" "$out/bin/vllm" \
+          --set HSA_OVERRIDE_GFX_VERSION 11.5.1 \
+          --set HSA_NO_SCRATCH_RECLAIM 1 \
+          --set HSA_ENABLE_INTERRUPT 0 \
+          --set HIP_PLATFORM amd \
+          --set GPU_ARCHS gfx1151 \
+          --set PYTORCH_ROCM_ARCH gfx1151 \
+          --set FLASH_ATTENTION_TRITON_AMD_ENABLE TRUE \
+          --set TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL 1 \
+          --set ROCM_HOME "$rocm_core" \
+          --set ROCM_PATH "$rocm_core" \
+          --set HIP_PATH "$rocm_core" \
+          --set DEVICE_LIB_PATH "$rocm_core/lib/llvm/amdgcn/bitcode" \
+          --set HIP_DEVICE_LIB_PATH "$rocm_core/lib/llvm/amdgcn/bitcode" \
+          --set CC "${stdenv.cc}/bin/cc" \
+          --set CXX "${stdenv.cc}/bin/c++" \
+          --prefix PATH : "$out/bin" \
+          --prefix PATH : "${lib.makeBinPath [ stdenv.cc ]}" \
+          --run 'if [ -z "''${VLLM_CACHE_ROOT:-}" ]; then cache_root="''${XDG_CACHE_HOME:-''${HOME:-/tmp}/.cache}/vllm/lemonade-gfx1151"; mkdir -p "$cache_root" 2>/dev/null || cache_root="/tmp/vllm-''${USER:-$(id -u)}/lemonade-gfx1151"; export VLLM_CACHE_ROOT="$cache_root"; fi; mkdir -p "$VLLM_CACHE_ROOT" 2>/dev/null || true; if [ -z "''${TRITON_CACHE_DIR:-}" ]; then export TRITON_CACHE_DIR="$VLLM_CACHE_ROOT/triton_cache"; fi; mkdir -p "$TRITON_CACHE_DIR" 2>/dev/null || true; if [ -z "''${TORCHINDUCTOR_CACHE_DIR:-}" ]; then export TORCHINDUCTOR_CACHE_DIR="$VLLM_CACHE_ROOT/inductor_cache"; fi; mkdir -p "$TORCHINDUCTOR_CACHE_DIR" 2>/dev/null || true' \
+          --run 'if [ -z "''${AITER_JIT_DIR:-}" ]; then cache_root="''${XDG_CACHE_HOME:-''${HOME:-/tmp}/.cache}/aiter"; mkdir -p "$cache_root" 2>/dev/null || cache_root="/tmp/aiter-''${USER:-$(id -u)}"; cache_dir="$cache_root/lemonade-gfx1151"; stamp="$cache_dir/.prebuilt-vllm0.21.0-rocm7.13.0-gfx1151"; if [ ! -e "$stamp" ]; then rm -rf "$cache_dir.tmp"; mkdir -p "$cache_dir.tmp"; cp '"$out"'/lib/python3.12/site-packages/aiter/jit/module_*.so "$cache_dir.tmp/"; cp '"$out"'/lib/python3.12/site-packages/aiter/jit/optCompilerConfig.json "$cache_dir.tmp/" 2>/dev/null || true; mkdir -p "$cache_dir.tmp/build"; chmod -R u+w "$cache_dir.tmp"; touch "$cache_dir.tmp/.prebuilt-vllm0.21.0-rocm7.13.0-gfx1151"; rm -rf "$cache_dir"; mv "$cache_dir.tmp" "$cache_dir"; fi; export AITER_JIT_DIR="$cache_dir"; fi' \
+          --run 'export LD_PRELOAD="'"$out"'/lib/libvllm-rocm-c10-hip-compat.so''${LD_PRELOAD:+ $LD_PRELOAD}"'
+
+        runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Lemonade vLLM ROCm binary bundle for Strix Halo (${target})";
+    homepage = "https://github.com/lemonade-sdk/vllm-rocm";
+    license = licenses.asl20;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary
- package Lemonade's prebuilt vLLM ROCm gfx1151 bundle
- expose `packages.x86_64-linux.vllm-rocm-lemonade-gfx1151`
- add the package to PR quick checks so buildbot builds it

## Tests
- `nix flake check --no-build`
- `nix build .#packages.x86_64-linux.vllm-rocm-lemonade-gfx1151 --no-link --print-build-logs --print-out-paths --builders ""`
- `/nix/store/k6aanrwl86j8d7wazc8swr27zfpn0hxj-vllm-rocm-lemonade-gfx1151-vllm0.21.0-rocm7.13.0-gfx1151/bin/vllm --version`
- `nix build .#checks.x86_64-linux.format .#checks.x86_64-linux.deadnix .#checks.x86_64-linux.statix .#checks.x86_64-linux.package-vllm-rocm-lemonade-gfx1151 --no-link --print-build-logs --builders ""`