### PR TITLE
vllm: add TheRock ROCm source build

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ in
 
 To add another top-level target to this flake's default outputs, add a target record in `pkgs/therock/targets.nix`. The `llama-cpp-rocm-<target>` output appears from that record; TheRock binary/source/Python outputs appear as matching target-keyed JSON pins are added under `pkgs/therock/sources/`.
 
+The vLLM package exposes feature flags through normal derivation override arguments:
+
+```nix
+pkgs.vllm-rocm-therock-gfx1151.override {
+  benchSupport = true; # default
+  audioSupport = false;
+}
+```
+
+`benchSupport` is enabled by default. `audioSupport` is packaged but opt-in. Triton support is required and comes from the TheRock Python stack plus the pinned Triton kernels source. AITer and other unported upstream extras are exposed as disabled flags that fail with a clear unsupported-feature message if enabled before their packages are added.
+
 ## llama.cpp RPC Servers
 
 ```nix

--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ The vLLM package exposes feature flags through normal derivation override argume
 ```nix
 pkgs.vllm-rocm-therock-gfx1151.override {
   benchSupport = true; # default
-  audioSupport = false;
+  audioSupport = true; # default
 }
 ```
 
-`benchSupport` is enabled by default. `audioSupport` is packaged but opt-in. Triton support is required and comes from the TheRock Python stack plus the pinned Triton kernels source. AITer and other unported upstream extras are exposed as disabled flags that fail with a clear unsupported-feature message if enabled before their packages are added.
+`benchSupport` and `audioSupport` are enabled by default. Triton support is required and comes from the TheRock Python stack plus the pinned Triton kernels source. AITer, RIXL, and other unported upstream extras are exposed as disabled flags that fail with a clear unsupported-feature message if enabled before their packages are added.
 
 ## llama.cpp RPC Servers
 

--- a/README.md
+++ b/README.md
@@ -127,10 +127,11 @@ The vLLM package exposes feature flags through normal derivation override argume
 pkgs.vllm-rocm-therock-gfx1151.override {
   benchSupport = true; # default
   audioSupport = true; # default
+  otelSupport = true; # default, required by upstream vLLM
 }
 ```
 
-`benchSupport` and `audioSupport` are enabled by default. Triton support is required and comes from the TheRock Python stack plus the pinned Triton kernels source. AITer, RIXL, and other unported upstream extras are exposed as disabled flags that fail with a clear unsupported-feature message if enabled before their packages are added.
+`benchSupport`, `audioSupport`, and `otelSupport` are enabled by default. Triton support is required and comes from the TheRock Python stack plus the pinned Triton kernels source. AITer, RIXL, and other unported upstream extras are exposed as disabled flags that fail with a clear unsupported-feature message if enabled before their packages are added.
 
 ## llama.cpp RPC Servers
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,18 @@ nix build .#benchmarks.x86_64-linux.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smo
 cat result/results.csv
 ```
 
+vLLM benchmarks use the upstream offline benchmark CLI in throughput and
+latency modes. They expect the Hugging Face model cache under
+`/models/.cache/huggingface` and run offline against `Qwen/Qwen3-0.6B`:
+
+```bash
+nix build .#benchmarks.x86_64-linux.bench-qwen3-0-6b-vllm-rocm-gfx1151-throughput-smoke
+cat result/results.json
+
+nix build .#benchmarks.x86_64-linux.bench-qwen3-0-6b-vllm-rocm-gfx1151-latency-smoke
+cat result/results.json
+```
+
 External flakes can reuse `lib.benchmarks` while injecting their own packages, model paths, required system features, environment variables, and host profile names. For example, with a caller-provided CUDA-enabled `myCudaLlamaCpp` package:
 
 ```nix

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It provides:
 - generic `llama-cpp` outputs for Linux and macOS
 - Linux-only ROCm outputs, including generic ROCm builds and Strix Halo `gfx1151` narrowed builds
 - TheRock ROCm/PyTorch packaging for configured Linux GPU targets
+- source-built vLLM ROCm packaging against the TheRock Python/ROCm stack
 - FastFlowLM packaging for AMD XDNA2 NPU inference
 - DS4-HIP packaging for DwarfStar 4 ROCm inference
 - NixOS modules for llama.cpp RPC servers, EC fan/power controls, Ryzen power limits, RAID0 disk layout, system tuning, and benchmark hosts
@@ -35,6 +36,7 @@ Main package outputs:
 - `packages.x86_64-linux.llama-cpp-vulkan`
 - `packages.x86_64-linux.ec-su-axb35-monitor`
 - `packages.x86_64-linux.strix-halo-mes-firmware`
+- `packages.x86_64-linux.vllm-rocm-therock-gfx1151`
 - `packages.x86_64-linux.xrt-amdxdna`
 
 Main app outputs:
@@ -90,6 +92,7 @@ Target records are generic build descriptors, not a hardware inventory. Hostname
 - `packages.x86_64-linux.therock-rocm-gfx1151-env`
 - `packages.x86_64-linux.therock-python-gfx1151`
 - `packages.x86_64-linux.torch-rocm-gfx1151`
+- `packages.x86_64-linux.vllm-rocm-therock-gfx1151`
 - `packages.x86_64-linux.ds4-rocm-gfx1151`
 
 The lower-level ROCm module overlay also exposes reusable narrowed package scopes:

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Main package outputs:
 
 - `packages.aarch64-darwin.default`
 - `packages.aarch64-darwin.llama-cpp`
-- `packages.x86_64-darwin.default`
-- `packages.x86_64-darwin.llama-cpp`
 - `packages.x86_64-linux.default`
 - `packages.x86_64-linux.ds4-rocm`
 - `packages.x86_64-linux.ds4-rocm-gfx1151`
@@ -43,8 +41,6 @@ Main app outputs:
 
 - `apps.aarch64-darwin.llama-cli`
 - `apps.aarch64-darwin.llama-server`
-- `apps.x86_64-darwin.llama-cli`
-- `apps.x86_64-darwin.llama-server`
 - `apps.x86_64-linux.llama-cli`
 - `apps.x86_64-linux.llama-server`
 - `apps.x86_64-linux.llama-cli-rocm`

--- a/bench/lib.nix
+++ b/bench/lib.nix
@@ -220,7 +220,27 @@ rec {
         JSON
 
         ${envExports normalizedEnv}
+        set +e
         ${commandLine} > "$out/stdout.txt" 2> "$out/stderr.txt"
+        status=$?
+        set -e
+
+        if [ "$status" -ne 0 ]; then
+          echo "benchmark command failed with exit status $status" >&2
+          echo "command: ${commandLine}" >&2
+
+          if [ -s "$out/stdout.txt" ]; then
+            echo "--- benchmark stdout ---" >&2
+            sed -n '1,200p' "$out/stdout.txt" >&2
+          fi
+
+          if [ -s "$out/stderr.txt" ]; then
+            echo "--- benchmark stderr ---" >&2
+            sed -n '1,200p' "$out/stderr.txt" >&2
+          fi
+
+          exit "$status"
+        fi
       '';
 
   mkLlamaCppArgs =

--- a/bench/suites/vllm.nix
+++ b/bench/suites/vllm.nix
@@ -108,10 +108,24 @@ let
       backend
       "--dataset-name"
       datasetName
-      "--input-len"
-      inputLen
-      "--output-len"
-      outputLen
+    ]
+    ++ (
+      if datasetName == "random" then
+        [
+          "--random-input-len"
+          inputLen
+          "--random-output-len"
+          outputLen
+        ]
+      else
+        [
+          "--input-len"
+          inputLen
+          "--output-len"
+          outputLen
+        ]
+    )
+    ++ [
       "--num-prompts"
       numPrompts
     ]
@@ -168,6 +182,7 @@ let
     model: case:
     let
       vllmArgs = mkArgs model case;
+      hfCacheRepo = "models--${lib.replaceStrings [ "/" ] [ "--" ] model.id}";
     in
     pkgs.writeShellScript "vllm-${target.packageSuffix}-${case.mode}-${case.scenario}-runner" ''
       set -euo pipefail
@@ -183,6 +198,24 @@ let
         "$VLLM_CACHE_ROOT" \
         "$TORCHINDUCTOR_CACHE_DIR" \
         "$TRITON_CACHE_DIR"
+
+      model_cache="$HF_HOME/hub/${hfCacheRepo}"
+      if [ ! -d "$HF_HOME" ]; then
+        echo "HF_HOME does not exist: $HF_HOME" >&2
+        exit 2
+      fi
+      if [ ! -d "$model_cache" ]; then
+        echo "Hugging Face model cache is missing: $model_cache" >&2
+        if [ -d "$HF_HOME/hub" ]; then
+          echo "available cached models:" >&2
+          find "$HF_HOME/hub" -maxdepth 1 -type d -name 'models--*' -printf '  %f\n' | sort >&2
+        fi
+        exit 2
+      fi
+      if [ -z "$(find "$model_cache/snapshots" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null)" ]; then
+        echo "Hugging Face model cache has no snapshots: $model_cache" >&2
+        exit 2
+      fi
 
       ${package}/bin/vllm ${benchLib.shellArgs vllmArgs} --output-json "$out/results.json"
       cat "$out/results.json"

--- a/bench/suites/vllm.nix
+++ b/bench/suites/vllm.nix
@@ -1,0 +1,296 @@
+{
+  pkgs,
+  package,
+  modelRoot ? "/models",
+  hfCacheHome ? "${modelRoot}/.cache/huggingface",
+  target,
+  hostProfile ? "linux-amd-kfd",
+  matrixMetadata ? { },
+}:
+
+let
+  inherit (pkgs) lib;
+  benchLib = import ../lib.nix { inherit lib; };
+
+  clean = lib.replaceStrings [ ":" "." "/" "_" ] [ "-" "-" "-" "-" ];
+
+  optionalValueArg =
+    flag: value:
+    lib.optionals (value != null) [
+      flag
+      value
+    ];
+
+  optionalFlag = flag: enabled: lib.optional enabled flag;
+
+  normalizeArgs =
+    args:
+    if builtins.isList args then
+      args
+    else if args == "" then
+      [ ]
+    else
+      lib.splitString " " args;
+
+  modelConfigs = {
+    qwen3-0-6b = {
+      id = "Qwen/Qwen3-0.6B";
+      description = "Qwen3 0.6B Hugging Face model for vLLM smoke benchmarks";
+      cases = [
+        {
+          mode = "throughput";
+          scenario = "smoke";
+          inputLen = 128;
+          outputLen = 32;
+          numPrompts = 8;
+          maxModelLen = 512;
+        }
+        {
+          mode = "latency";
+          scenario = "smoke";
+          inputLen = 128;
+          outputLen = 32;
+          batchSize = 1;
+          numItersWarmup = 1;
+          numIters = 3;
+          maxModelLen = 512;
+        }
+      ];
+    };
+  };
+
+  mkCaseName =
+    {
+      mode,
+      scenario,
+      ...
+    }:
+    "vllm-rocm-${target.packageSuffix}-${clean mode}-${clean scenario}";
+
+  mkCommonArgs =
+    model:
+    {
+      maxModelLen ? null,
+      tensorParallelSize ? null,
+      gpuMemoryUtilization ? null,
+      trustRemoteCode ? false,
+      dtype ? null,
+      extraArgs ? [ ],
+      ...
+    }:
+    [
+      "--model"
+      model.id
+    ]
+    ++ optionalValueArg "--max-model-len" maxModelLen
+    ++ optionalValueArg "--tensor-parallel-size" tensorParallelSize
+    ++ optionalValueArg "--gpu-memory-utilization" gpuMemoryUtilization
+    ++ optionalValueArg "--dtype" dtype
+    ++ optionalFlag "--trust-remote-code" trustRemoteCode
+    ++ normalizeArgs extraArgs;
+
+  mkThroughputArgs =
+    model:
+    {
+      inputLen,
+      outputLen,
+      numPrompts,
+      backend ? "vllm",
+      datasetName ? "random",
+      disableDetokenize ? false,
+      asyncEngine ? false,
+      ...
+    }@case:
+    [
+      "bench"
+      "throughput"
+      "--backend"
+      backend
+      "--dataset-name"
+      datasetName
+      "--input-len"
+      inputLen
+      "--output-len"
+      outputLen
+      "--num-prompts"
+      numPrompts
+    ]
+    ++ optionalFlag "--disable-detokenize" disableDetokenize
+    ++ optionalFlag "--async-engine" asyncEngine
+    ++ mkCommonArgs model case;
+
+  mkLatencyArgs =
+    model:
+    {
+      inputLen,
+      outputLen,
+      batchSize,
+      numItersWarmup,
+      numIters,
+      n ? null,
+      disableDetokenize ? false,
+      useBeamSearch ? false,
+      ...
+    }@case:
+    [
+      "bench"
+      "latency"
+      "--input-len"
+      inputLen
+      "--output-len"
+      outputLen
+      "--batch-size"
+      batchSize
+      "--num-iters-warmup"
+      numItersWarmup
+      "--num-iters"
+      numIters
+    ]
+    ++ optionalValueArg "--n" n
+    ++ optionalFlag "--disable-detokenize" disableDetokenize
+    ++ optionalFlag "--use-beam-search" useBeamSearch
+    ++ mkCommonArgs model case;
+
+  mkArgs =
+    model:
+    {
+      mode,
+      ...
+    }@case:
+    if mode == "throughput" then
+      mkThroughputArgs model case
+    else if mode == "latency" then
+      mkLatencyArgs model case
+    else
+      throw "unsupported vLLM benchmark mode: ${mode}";
+
+  mkRunner =
+    model: case:
+    let
+      vllmArgs = mkArgs model case;
+    in
+    pkgs.writeShellScript "vllm-${target.packageSuffix}-${case.mode}-${case.scenario}-runner" ''
+      set -euo pipefail
+
+      export HOME="$TMPDIR/home"
+      export XDG_CACHE_HOME="$TMPDIR/cache"
+      export VLLM_CACHE_ROOT="$TMPDIR/vllm-cache"
+      export TORCHINDUCTOR_CACHE_DIR="$TMPDIR/torchinductor-cache"
+      export TRITON_CACHE_DIR="$TMPDIR/triton-cache"
+      mkdir -p \
+        "$HOME" \
+        "$XDG_CACHE_HOME" \
+        "$VLLM_CACHE_ROOT" \
+        "$TORCHINDUCTOR_CACHE_DIR" \
+        "$TRITON_CACHE_DIR"
+
+      ${package}/bin/vllm ${benchLib.shellArgs vllmArgs} --output-json "$out/results.json"
+      cat "$out/results.json"
+    '';
+
+  caseParams =
+    case:
+    lib.filterAttrs (_: value: value != null) (
+      removeAttrs case [
+        "backend"
+        "datasetName"
+        "disableDetokenize"
+        "extraArgs"
+        "mode"
+        "scenario"
+        "trustRemoteCode"
+      ]
+    );
+
+  mkBenchmark =
+    modelName: model:
+    {
+      mode,
+      scenario,
+      ...
+    }@case:
+    let
+      name = mkCaseName case;
+      params = caseParams case;
+    in
+    benchLib.mkBenchmark {
+      inherit
+        pkgs
+        name
+        package
+        ;
+      command = [ (mkRunner model case) ];
+      env = {
+        HF_HOME = hfCacheHome;
+        HF_HUB_OFFLINE = "1";
+        TRANSFORMERS_OFFLINE = "1";
+        VLLM_NO_USAGE_STATS = "1";
+        VLLM_DO_NOT_TRACK = "1";
+        RAY_USAGE_STATS_ENABLED = "0";
+      }
+      // lib.optionalAttrs ((target.hsaOverride or null) != null) {
+        HSA_OVERRIDE_GFX_VERSION = target.hsaOverride;
+      };
+      requirements = {
+        systemFeatures = [ target.systemFeature ];
+        hostProfiles = [ hostProfile ];
+        sandboxPaths = [
+          "/dev/dri"
+          "/dev/kfd"
+          "/sys/class/drm"
+          "/sys/class/kfd"
+          modelRoot
+        ];
+      };
+      metadata = lib.recursiveUpdate {
+        kind = "vllm";
+        suite = "vllm";
+        accelerator = "rocm";
+        backend = "vllm";
+        inherit
+          mode
+          params
+          scenario
+          ;
+        target = {
+          inherit (target)
+            packageSuffix
+            runtimeArch
+            systemFeature
+            ;
+        };
+        model = {
+          name = modelName;
+          cacheRoot = hfCacheHome;
+          inherit (model)
+            description
+            id
+            ;
+        };
+        tool = {
+          backend = "rocm";
+          executable = "vllm bench ${mode}";
+          packageRole = "vllm-rocm-therock";
+        };
+      } matrixMetadata;
+      meta.platforms = [ "x86_64-linux" ];
+      description = "Run vLLM ${mode} benchmark ${modelName}/${scenario}";
+    };
+
+  generateModelBenchmarks =
+    modelName: model:
+    builtins.listToAttrs (
+      map (case: {
+        name = mkCaseName case;
+        value = mkBenchmark modelName model case;
+      }) model.cases
+    );
+
+  benchmarks = lib.mapAttrs generateModelBenchmarks modelConfigs;
+in
+{
+  inherit
+    benchmarks
+    mkBenchmark
+    ;
+}

--- a/flake.lock
+++ b/flake.lock
@@ -143,6 +143,7 @@
         "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf",
         "therock-src-7-13-gfx1151-root": "therock-src-7-13-gfx1151-root",
         "therock-src-7-13-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c": "therock-src-7-13-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c",
+        "vllm-src": "vllm-src",
         "xdna-driver-src": "xdna-driver-src",
         "xrt-src": "xrt-src"
       }
@@ -1079,6 +1080,23 @@
         "owner": "ROCm",
         "repo": "mesa-fork",
         "rev": "9a0d5b03fd540cb2448c64bbda17dbf17ccb12bf",
+        "type": "github"
+      }
+    },
+    "vllm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778819314,
+        "narHash": "sha256-lVgzo6R+l86IH5yxCtfJckVCP86jlgN7ufF5i0Pn2/A=",
+        "owner": "vllm-project",
+        "repo": "vllm",
+        "rev": "ad7125a431e176d4161099480a66f0169609a690",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vllm-project",
+        "ref": "v0.21.0",
+        "repo": "vllm",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -383,10 +383,14 @@
           target = args.target or (builtins.head args.rocmTargets);
           rocmOverlay = mkTherockRocmOverlay args;
           pythonOverlay = mkTherockPythonOverlay { inherit target; };
+          vllmOverlay = import ./overlays/therock-vllm.nix {
+            inherit lib target;
+          };
         in
         {
           rocm = rocmOverlay;
           python = pythonOverlay;
+          vllm = vllmOverlay;
         };
 
       therockOverlays = mkTherockOverlays {
@@ -396,6 +400,7 @@
 
       therockRocmOverlay = therockOverlays.rocm;
       therockPythonOverlay = therockOverlays.python;
+      therockVllmOverlay = therockOverlays.vllm;
 
       pkgsFor =
         system:
@@ -678,11 +683,20 @@
             // llamaCppRocmTargetPackages
             // llamaCppMasterRocmTargetPackages
             // (therockRocmOverlay final prev)
+            // (therockPythonOverlay final prev)
+            // (therockVllmOverlay final prev)
           );
 
         therock-rocm = final: prev: lib.optionalAttrs prev.stdenv.isLinux (therockRocmOverlay final prev);
         therock-python =
           final: prev: lib.optionalAttrs prev.stdenv.isLinux (therockPythonOverlay final prev);
+        therock-vllm =
+          final: prev:
+          lib.optionalAttrs prev.stdenv.isLinux (
+            (therockRocmOverlay final prev)
+            // (therockPythonOverlay final prev)
+            // (therockVllmOverlay final prev)
+          );
       };
 
       # NixOS modules
@@ -743,6 +757,7 @@
                   "therock-python-wheels-${s}"
                   "therock-amdsmi-${s}"
                   "torch-rocm-${s}"
+                  "vllm-rocm-therock-${s}"
                 ];
               therockPackageNames = lib.concatMap therockPackageNamesFor rocmTargets;
               requiredTherockPackageNames = therockPackageNamesFor defaultRocmTarget;
@@ -1236,6 +1251,7 @@
 
             "package-llama-cpp-rocm-${s}" = pkgs."llama-cpp-rocm-${s}";
             "package-ds4-rocm-${s}" = pkgs."ds4-rocm-${s}";
+            "package-vllm-rocm-therock-${s}" = pkgs."vllm-rocm-therock-${s}";
             package-fastflowlm = pkgs.fastflowlm;
             package-strix-halo-mes-firmware = pkgs.strix-halo-mes-firmware;
             "therock-pytorch-${s}" = pkgs.${therockPytorchPackage};

--- a/flake.nix
+++ b/flake.nix
@@ -1296,6 +1296,9 @@
           }
           // lib.optionalAttrs (system == "x86_64-linux") {
             system = afterPrQuick "system" self.nixosConfigurations.fevm-faex9.config.system.build.toplevel;
+            vllm =
+              afterPrQuick "vllm"
+                self.packages.${system}."vllm-rocm-therock-${defaultRocmTarget.packageSuffix}";
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -1363,6 +1363,9 @@
             vllm =
               afterPrQuick "vllm"
                 self.packages.${system}."vllm-rocm-therock-${defaultRocmTarget.packageSuffix}";
+            vllm-throughput-smoke =
+              afterPrQuick "vllm-throughput-smoke"
+                self.benchmarks.${system}.bench-qwen3-0-6b-vllm-rocm-gfx1151-throughput-smoke;
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,11 @@
       flake = false;
     };
 
+    vllm-src = {
+      url = "github:vllm-project/vllm/v0.21.0";
+      flake = false;
+    };
+
     xrt-src = {
       url = "git+https://github.com/Xilinx/XRT?ref=XRT-2.21&submodules=1";
       flake = false;
@@ -332,10 +337,7 @@
     let
       inherit (nixpkgs) lib;
       linuxSystems = [ "x86_64-linux" ];
-      darwinSystems = [
-        "aarch64-darwin"
-        "x86_64-darwin"
-      ];
+      darwinSystems = [ "aarch64-darwin" ];
       systems = linuxSystems ++ darwinSystems;
       forAllSystems = lib.genAttrs systems;
 
@@ -385,6 +387,8 @@
           pythonOverlay = mkTherockPythonOverlay { inherit target; };
           vllmOverlay = import ./overlays/therock-vllm.nix {
             inherit lib target;
+            vllmSrc = inputs.vllm-src;
+            vllmVersion = "0.21.0";
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -516,10 +516,17 @@
                   package = pkgs.${"ds4-rocm-${defaultRocmTarget.packageSuffix}"};
                   target = defaultTargetMetadata;
                 }).benchmarks;
+              vllmBenchmarks =
+                (import ./bench/suites/vllm.nix {
+                  inherit pkgs;
+                  package = pkgs.${"vllm-rocm-therock-${defaultRocmTarget.packageSuffix}"};
+                  target = defaultTargetMetadata;
+                }).benchmarks;
             in
             flattenBenchmarks acceleratedBenchmarks
             // flattenBenchmarks fastflowlmBenchmarks
             // flattenBenchmarks ds4Benchmarks
+            // flattenBenchmarks vllmBenchmarks
           );
         in
         flattenBenchmarks genericBenchmarks // linuxBenchmarks;
@@ -1173,6 +1180,14 @@
             fastflowlmBenchmarkMetadata = builtins.toJSON fastflowlmBenchmark.passthru.benchmark;
             ds4Benchmark = benchmarkSet.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke;
             ds4BenchmarkMetadata = builtins.toJSON ds4Benchmark.passthru.benchmark;
+            vllmThroughputBenchmark = benchmarkSet.bench-qwen3-0-6b-vllm-rocm-gfx1151-throughput-smoke;
+            vllmThroughputBenchmarkMetadata = builtins.toJSON (
+              removeAttrs vllmThroughputBenchmark.passthru.benchmark [ "command" ]
+            );
+            vllmLatencyBenchmark = benchmarkSet.bench-qwen3-0-6b-vllm-rocm-gfx1151-latency-smoke;
+            vllmLatencyBenchmarkMetadata = builtins.toJSON (
+              removeAttrs vllmLatencyBenchmark.passthru.benchmark [ "command" ]
+            );
           in
           {
             benchmark-runner-profiles =
@@ -1249,6 +1264,55 @@
                     and .params.ctxMax == 256
                     and .params.genTokens == 8
                   ' metadata.json
+
+                  touch "$out"
+                '';
+
+            vllm-benchmark-metadata =
+              pkgs.runCommandLocal "ci-vllm-benchmark-metadata"
+                {
+                  nativeBuildInputs = [ pkgs.jq ];
+                }
+                ''
+                  cat > throughput.json <<'JSON'
+                  ${vllmThroughputBenchmarkMetadata}
+                  JSON
+
+                  cat > latency.json <<'JSON'
+                  ${vllmLatencyBenchmarkMetadata}
+                  JSON
+
+                  jq -e '
+                    .kind == "vllm"
+                    and .mode == "throughput"
+                    and .accelerator == "rocm"
+                    and .requirements.systemFeatures == [ "gfx1151" ]
+                    and .requirements.hostProfiles == [ "linux-amd-kfd" ]
+                    and (.requirements.sandboxPaths | index("/dev/kfd") != null)
+                    and (.requirements.sandboxPaths | index("/models") != null)
+                    and .model.id == "Qwen/Qwen3-0.6B"
+                    and .env.HF_HOME == "/models/.cache/huggingface"
+                    and .env.HF_HUB_OFFLINE == "1"
+                    and .packages == [ "vllm" ]
+                    and .params.inputLen == 128
+                    and .params.outputLen == 32
+                    and .params.numPrompts == 8
+                    and .tool.executable == "vllm bench throughput"
+                  ' throughput.json
+
+                  jq -e '
+                    .kind == "vllm"
+                    and .mode == "latency"
+                    and .accelerator == "rocm"
+                    and .requirements.systemFeatures == [ "gfx1151" ]
+                    and .requirements.hostProfiles == [ "linux-amd-kfd" ]
+                    and .model.id == "Qwen/Qwen3-0.6B"
+                    and .packages == [ "vllm" ]
+                    and .params.batchSize == 1
+                    and .params.numItersWarmup == 1
+                    and .params.numIters == 3
+                    and .tool.executable == "vllm bench latency"
+                  ' latency.json
 
                   touch "$out"
                 '';

--- a/overlays/therock-python.nix
+++ b/overlays/therock-python.nix
@@ -4,6 +4,12 @@
 { lib, target }:
 let
   s = target.packageSuffix;
+  disablePythonChecks =
+    pkg:
+    pkg.overridePythonAttrs (_old: {
+      doCheck = false;
+      pythonImportsCheck = [ ];
+    });
 in
 final: prev: {
   pythonPackagesExtensions = (prev.pythonPackagesExtensions or [ ]) ++ [
@@ -23,6 +29,22 @@ final: prev: {
           "rocm-sdk-core" = wheels;
           "rocm-sdk-devel" = wheels;
           "rocm-sdk-libraries-${s}" = wheels;
+
+          "compressed-tensors" = pyprev."compressed-tensors".overridePythonAttrs (old: {
+            dependencies = (old.dependencies or [ ]) ++ [
+              _pyfinal.psutil
+            ];
+            nativeCheckInputs = (old.nativeCheckInputs or [ ]) ++ [
+              final.openssl
+            ];
+            propagatedBuildInputs = (old.propagatedBuildInputs or [ ]) ++ [
+              _pyfinal.psutil
+            ];
+          });
+          depyf = disablePythonChecks pyprev.depyf;
+          llguidance = disablePythonChecks pyprev.llguidance;
+          pydevd = disablePythonChecks pyprev.pydevd;
+          "mistral-common" = disablePythonChecks pyprev."mistral-common";
         }
       else
         { }

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -197,7 +197,7 @@ let
       cudaSupport = false;
       gpuTargets = vllmGpuTargets;
       rocmPackages = therockRocmPackages;
-      amdsmi = py.amdsmi;
+      inherit (py) amdsmi;
     }).overridePythonAttrs
       (old: {
         version = vllmVersion;

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -19,6 +19,19 @@ let
   opentelemetrySemanticConventionsAi =
     py.callPackage ../pkgs/opentelemetry-semantic-conventions-ai
       { };
+  mistralCommon = py.mistral-common.overridePythonAttrs (old: rec {
+    version = "1.11.2";
+    src = py.fetchPypi {
+      pname = "mistral_common";
+      inherit version;
+      hash = "sha256-efaPwtEZDyhjf0DgU/kZyMJpfgCyqmed3uViqVGD9K0=";
+    };
+    dependencies = lib.unique ((old.dependencies or [ ]) ++ [ py.pycountry ]);
+    propagatedBuildInputs = lib.unique ((old.propagatedBuildInputs or [ ]) ++ [ py.pycountry ]);
+    pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [ "numpy" ];
+    # PyPI sdists do not include all fixtures needed by the upstream tests.
+    doCheck = false;
+  });
   tritonKernels = prev.fetchFromGitHub {
     owner = "triton-lang";
     repo = "triton";
@@ -159,9 +172,8 @@ let
           py.av
           py.scipy
           py.soundfile
-          py.mistral-common
         ]
-        ++ (py.mistral-common.optional-dependencies.audio or [ ]);
+        ++ (mistralCommon.optional-dependencies.audio or [ ]);
         flashinfer = [ ];
         otel = [
           py.opentelemetry-api
@@ -182,6 +194,7 @@ let
         py.cloudpickle
         py.diskcache
         py.lark
+        mistralCommon
         py.outlines-core
         py.pillow
         py.prometheus-client

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -1,6 +1,8 @@
 {
   lib,
   target,
+  vllmSrc,
+  vllmVersion,
 }:
 let
   s = target.packageSuffix;
@@ -12,6 +14,12 @@ let
   sdk = sdkBase // {
     localGpuTargets = vllmGpuTargets;
     gpuTargets = vllmGpuTargets;
+  };
+  tritonKernels = prev.fetchFromGitHub {
+    owner = "triton-lang";
+    repo = "triton";
+    tag = "v3.6.0";
+    hash = "sha256-JFSpQn+WsNnh7CAPlcpOcUp0nyKXNbJEANdXqmkt4Tc=";
   };
 
   therockRocmPackages = {
@@ -44,18 +52,22 @@ let
   };
 
   dropVllmDependencyNames = [
+    "amd-quark"
     "bitsandbytes"
+    "conch-triton-kernels"
     "datasets"
-    "diskcache"
-    "lark"
     "mistral-common"
     "mistral_common"
     "mistralai"
     "opencv-python-headless"
     "outlines"
-    "outlines-core"
     "peft"
     "pyarrow"
+    "pytest-asyncio"
+    "runai-model-streamer"
+    "runai_model_streamer"
+    "tensorizer"
+    "tilelang"
     "timm"
     "torchcodec"
     "torchvision"
@@ -81,25 +93,43 @@ let
       amdsmi = final.python312Packages.amdsmi;
     }).overridePythonAttrs
       (old: {
-        patches = (old.patches or [ ]) ++ [
-          ../pkgs/vllm/patches/0001-hipify-copy-unchanged-cu-to-hip.patch
-        ];
+        version = vllmVersion;
+        src = vllmSrc;
 
-        postPatch = (old.postPatch or "") + ''
-          substituteInPlace csrc/quantization/gptq/compat.cuh \
-            --replace-fail 'namespace gptq {' 'namespace gptq {
+        patches =
+          builtins.filter (patch: !(lib.hasSuffix "0006-drop-rocm-extra-reqs.patch" (toString patch))) (
+            old.patches or [ ]
+          )
+          ++ [
+            ../pkgs/vllm/patches/0001-hipify-copy-unchanged-cu-to-hip.patch
+          ];
 
-          #if defined(USE_ROCM) && defined(TORCH_HIP_VERSION) && TORCH_HIP_VERSION >= 713
-          #define VLLM_GPTQ_SKIP_LEGACY_HALF_ATOMIC_ADD 1
-          #endif'
-          substituteInPlace csrc/quantization/gptq/compat.cuh \
-            --replace-fail '#if defined(__CUDA_ARCH__) || defined(USE_ROCM)' \
-              '#if !defined(VLLM_GPTQ_SKIP_LEGACY_HALF_ATOMIC_ADD) && (defined(__CUDA_ARCH__) || defined(USE_ROCM))'
+        postPatch = ''
+          rm vllm/third_party/pynvml.py
+          substituteInPlace tests/utils.py \
+            --replace-fail \
+              "from vllm.third_party.pynvml import" \
+              "from pynvml import"
+          substituteInPlace vllm/utils/import_utils.py \
+            --replace-fail \
+              "import vllm.third_party.pynvml as pynvml" \
+              "import pynvml"
+
+          substituteInPlace pyproject.toml \
+            --replace-fail '"torch == 2.11.0"' '"torch"' \
+            --replace-fail "setuptools>=77.0.3,<81.0.0" "setuptools"
+
+          substituteInPlace CMakeLists.txt \
+            --replace-fail \
+              'set(PYTHON_SUPPORTED_VERSIONS' \
+              'set(PYTHON_SUPPORTED_VERSIONS "${lib.versions.majorMinor final.python312.version}"'
         '';
 
         env = (old.env or { }) // {
+          VLLM_VERSION_OVERRIDE = vllmVersion;
           HIP_PATH = "${sdk}";
           HIP_PLATFORM = "amd";
+          TRITON_KERNELS_SRC_DIR = "${tritonKernels}/python/triton_kernels/triton_kernels";
           CMAKE_ARGS = prev.lib.concatStringsSep " " [
             ((old.env or { }).CMAKE_ARGS or "")
             "-DCMAKE_HIP_COMPILER=${sdk}/bin/therock-hip-clang++"
@@ -115,12 +145,36 @@ let
         dependencies = dropNamedDeps dropVllmDependencyNames (old.dependencies or [ ]) ++ [
           final.python312Packages.amdsmi
           final.python312Packages.cloudpickle
+          final.python312Packages.diskcache
+          final.python312Packages.lark
+          final.python312Packages.outlines-core
+          final.python312Packages.pillow
+          final.python312Packages.prometheus-client
+          final.python312Packages.protobuf
+          final.python312Packages.pyyaml
+          final.python312Packages.regex
+          final.python312Packages.requests
+          final.python312Packages.six
+          final.python312Packages.tqdm
+          final.python312Packages.watchfiles
         ];
         propagatedBuildInputs =
           dropNamedDeps dropVllmDependencyNames (old.propagatedBuildInputs or [ ])
           ++ [
             final.python312Packages.amdsmi
             final.python312Packages.cloudpickle
+            final.python312Packages.diskcache
+            final.python312Packages.lark
+            final.python312Packages.outlines-core
+            final.python312Packages.pillow
+            final.python312Packages.prometheus-client
+            final.python312Packages.protobuf
+            final.python312Packages.pyyaml
+            final.python312Packages.regex
+            final.python312Packages.requests
+            final.python312Packages.six
+            final.python312Packages.tqdm
+            final.python312Packages.watchfiles
           ];
       });
 in

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -16,6 +16,9 @@ let
     gpuTargets = vllmGpuTargets;
   };
   py = final.python312Packages;
+  opentelemetrySemanticConventionsAi =
+    py.callPackage ../pkgs/opentelemetry-semantic-conventions-ai
+      { };
   tritonKernels = prev.fetchFromGitHub {
     owner = "triton-lang";
     repo = "triton";
@@ -91,7 +94,6 @@ let
     grpc = "smg-grpc-servicer is not packaged in this nixpkgs input";
     helion = "helion is marked broken in this nixpkgs input";
     instanttensor = "instanttensor is not packaged in this nixpkgs input";
-    otel = "opentelemetry-semantic-conventions-ai is not packaged in this nixpkgs input";
     rixl = "RIXL needs separate ROCm RIXL/UCX/RDMA packaging and is only used by KV-transfer/disaggregated serving paths";
     runai = "runai-model-streamer is not packaged in this nixpkgs input";
     tensorizer = "tensorizer is not packaged in this nixpkgs input";
@@ -108,7 +110,7 @@ let
       grpcSupport ? false,
       helionSupport ? false,
       instanttensorSupport ? false,
-      otelSupport ? false,
+      otelSupport ? true,
       rixlSupport ? false,
       runaiSupport ? false,
       tensorizerSupport ? false,
@@ -161,12 +163,19 @@ let
         ]
         ++ (py.mistral-common.optional-dependencies.audio or [ ]);
         flashinfer = [ ];
+        otel = [
+          py.opentelemetry-api
+          py.opentelemetry-exporter-otlp
+          py.opentelemetry-sdk
+          opentelemetrySemanticConventionsAi
+        ];
         video = [ ];
       };
       featureDependencies =
         lib.optionals benchSupport optionalDependencies.bench
         ++ lib.optionals audioSupport optionalDependencies.audio
         ++ lib.optionals flashinferSupport optionalDependencies.flashinfer
+        ++ lib.optionals otelSupport optionalDependencies.otel
         ++ lib.optionals videoSupport optionalDependencies.video;
       baseExtraDependencies = [
         py.amdsmi
@@ -189,6 +198,8 @@ let
     assert lib.assertMsg tritonSupport "TheRock vLLM currently requires tritonSupport=true";
     assert lib.assertMsg tritonKernelsSupport
       "TheRock vLLM currently requires tritonKernelsSupport=true";
+    assert lib.assertMsg otelSupport
+      "TheRock vLLM currently requires otelSupport=true because upstream vLLM lists OpenTelemetry in common requirements";
     assert lib.assertMsg (
       unsupportedEnabledFeatures == [ ]
     ) "unsupported TheRock vLLM feature(s): ${lib.concatStringsSep "; " unsupportedEnabledMessages}";

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -1,0 +1,129 @@
+{
+  lib,
+  target,
+}:
+let
+  s = target.packageSuffix;
+in
+final: prev:
+let
+  sdkBase = final."therock-rocm-${s}";
+  vllmGpuTargets = target.buildTargets;
+  sdk = sdkBase // {
+    localGpuTargets = vllmGpuTargets;
+    gpuTargets = vllmGpuTargets;
+  };
+
+  therockRocmPackages = {
+    clr = sdk;
+    hipcc = sdk;
+    rocminfo = sdk;
+    rocm-device-libs = sdk;
+    llvm = sdk;
+    rocthrust = sdk;
+    rocprim = sdk;
+    hipcub = sdk;
+    hipblas = sdk;
+    hipblas-common = sdk;
+    hipblaslt = sdk;
+    hipfft = sdk;
+    hipsparse = sdk;
+    hiprand = sdk;
+    hipsolver = sdk;
+    miopen-hip = sdk;
+    miopen = sdk;
+    rccl = sdk;
+    rocblas = sdk;
+    rocm-comgr = sdk;
+    rocfft = sdk;
+    rocrand = sdk;
+    rocm-runtime = sdk;
+    rocsolver = sdk;
+    rocsparse = sdk;
+    composable_kernel = sdk;
+  };
+
+  dropVllmDependencyNames = [
+    "bitsandbytes"
+    "datasets"
+    "diskcache"
+    "lark"
+    "mistral-common"
+    "mistral_common"
+    "mistralai"
+    "opencv-python-headless"
+    "outlines"
+    "outlines-core"
+    "peft"
+    "pyarrow"
+    "timm"
+    "torchcodec"
+    "torchvision"
+    "xformers"
+  ];
+
+  dropNamedDeps =
+    names: deps:
+    prev.lib.filter (
+      dep:
+      let
+        name = dep.pname or dep.name or "";
+      in
+      !(prev.lib.elem name names)
+    ) deps;
+
+  vllmTherock =
+    (final.python312Packages.vllm.override {
+      rocmSupport = true;
+      cudaSupport = false;
+      gpuTargets = vllmGpuTargets;
+      rocmPackages = therockRocmPackages;
+      amdsmi = final.python312Packages.amdsmi;
+    }).overridePythonAttrs
+      (old: {
+        patches = (old.patches or [ ]) ++ [
+          ../pkgs/vllm/patches/0001-hipify-copy-unchanged-cu-to-hip.patch
+        ];
+
+        postPatch = (old.postPatch or "") + ''
+          substituteInPlace csrc/quantization/gptq/compat.cuh \
+            --replace-fail 'namespace gptq {' 'namespace gptq {
+
+          #if defined(USE_ROCM) && defined(TORCH_HIP_VERSION) && TORCH_HIP_VERSION >= 713
+          #define VLLM_GPTQ_SKIP_LEGACY_HALF_ATOMIC_ADD 1
+          #endif'
+          substituteInPlace csrc/quantization/gptq/compat.cuh \
+            --replace-fail '#if defined(__CUDA_ARCH__) || defined(USE_ROCM)' \
+              '#if !defined(VLLM_GPTQ_SKIP_LEGACY_HALF_ATOMIC_ADD) && (defined(__CUDA_ARCH__) || defined(USE_ROCM))'
+        '';
+
+        env = (old.env or { }) // {
+          HIP_PATH = "${sdk}";
+          HIP_PLATFORM = "amd";
+          CMAKE_ARGS = prev.lib.concatStringsSep " " [
+            ((old.env or { }).CMAKE_ARGS or "")
+            "-DCMAKE_HIP_COMPILER=${sdk}/bin/therock-hip-clang++"
+            "-DCMAKE_HIP_COMPILER_ROCM_ROOT=${sdk}"
+            "-DHIP_ROOT_DIR=${sdk}"
+          ];
+        };
+
+        nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+          final.pkg-config
+        ];
+        pythonRemoveDeps = (old.pythonRemoveDeps or [ ]) ++ dropVllmDependencyNames;
+        dependencies = dropNamedDeps dropVllmDependencyNames (old.dependencies or [ ]) ++ [
+          final.python312Packages.amdsmi
+          final.python312Packages.cloudpickle
+        ];
+        propagatedBuildInputs =
+          dropNamedDeps dropVllmDependencyNames (old.propagatedBuildInputs or [ ])
+          ++ [
+            final.python312Packages.amdsmi
+            final.python312Packages.cloudpickle
+          ];
+      });
+in
+{
+  "vllm-rocm-therock-${s}" = vllmTherock;
+}

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -15,6 +15,7 @@ let
     localGpuTargets = vllmGpuTargets;
     gpuTargets = vllmGpuTargets;
   };
+  py = final.python312Packages;
   tritonKernels = prev.fetchFromGitHub {
     owner = "triton-lang";
     repo = "triton";
@@ -84,13 +85,116 @@ let
       !(prev.lib.elem name names)
     ) deps;
 
-  vllmTherock =
-    (final.python312Packages.vllm.override {
+  unsupportedFeatureReasons = {
+    aiter = "AITer needs a separately packaged ROCm aiter build and upstream only enables it on MI300-class targets";
+    fastsafetensors = "fastsafetensors is not packaged in this nixpkgs input";
+    grpc = "smg-grpc-servicer is not packaged in this nixpkgs input";
+    helion = "helion is marked broken in this nixpkgs input";
+    instanttensor = "instanttensor is not packaged in this nixpkgs input";
+    otel = "opentelemetry-semantic-conventions-ai is not packaged in this nixpkgs input";
+    runai = "runai-model-streamer is not packaged in this nixpkgs input";
+    tensorizer = "tensorizer is not packaged in this nixpkgs input";
+    zen = "zentorch-weekly is not packaged and is a CPU optimization";
+  };
+
+  mkVllmTherock =
+    {
+      aiterSupport ? false,
+      audioSupport ? false,
+      benchSupport ? true,
+      fastsafetensorsSupport ? false,
+      flashinferSupport ? false,
+      grpcSupport ? false,
+      helionSupport ? false,
+      instanttensorSupport ? false,
+      otelSupport ? false,
+      runaiSupport ? false,
+      tensorizerSupport ? false,
+      tritonSupport ? true,
+      tritonKernelsSupport ? true,
+      videoSupport ? false,
+      zenSupport ? false,
+    }:
+    let
+      featureFlags = {
+        aiter = aiterSupport;
+        audio = audioSupport;
+        bench = benchSupport;
+        fastsafetensors = fastsafetensorsSupport;
+        flashinfer = flashinferSupport;
+        grpc = grpcSupport;
+        helion = helionSupport;
+        instanttensor = instanttensorSupport;
+        otel = otelSupport;
+        runai = runaiSupport;
+        tensorizer = tensorizerSupport;
+        triton = tritonSupport;
+        triton-kernels = tritonKernelsSupport;
+        video = videoSupport;
+        zen = zenSupport;
+      };
+      unsupportedEnabledFeatures = lib.attrNames (
+        lib.filterAttrs (
+          name: enabled: enabled && builtins.hasAttr name unsupportedFeatureReasons
+        ) featureFlags
+      );
+      unsupportedEnabledMessages = map (
+        name: "${name}: ${unsupportedFeatureReasons.${name}}"
+      ) unsupportedEnabledFeatures;
+      optionalDependencies = {
+        bench = [
+          py.pandas
+          py.matplotlib
+          py.seaborn
+          py.datasets
+          py.scipy
+          py.plotly
+        ];
+        audio = [
+          py.av
+          py.scipy
+          py.soundfile
+          py.mistral-common
+        ]
+        ++ (py.mistral-common.optional-dependencies.audio or [ ]);
+        flashinfer = [ ];
+        video = [ ];
+      };
+      featureDependencies =
+        lib.optionals benchSupport optionalDependencies.bench
+        ++ lib.optionals audioSupport optionalDependencies.audio
+        ++ lib.optionals flashinferSupport optionalDependencies.flashinfer
+        ++ lib.optionals videoSupport optionalDependencies.video;
+      baseExtraDependencies = [
+        py.amdsmi
+        py.cloudpickle
+        py.diskcache
+        py.lark
+        py.outlines-core
+        py.pillow
+        py.prometheus-client
+        py.protobuf
+        py.pyyaml
+        py.regex
+        py.requests
+        py.six
+        py.tqdm
+        py.watchfiles
+      ];
+      extraDependencies = lib.unique (baseExtraDependencies ++ featureDependencies);
+    in
+    assert lib.assertMsg tritonSupport "TheRock vLLM currently requires tritonSupport=true";
+    assert lib.assertMsg tritonKernelsSupport
+      "TheRock vLLM currently requires tritonKernelsSupport=true";
+    assert lib.assertMsg (
+      unsupportedEnabledFeatures == [ ]
+    ) "unsupported TheRock vLLM feature(s): ${lib.concatStringsSep "; " unsupportedEnabledMessages}";
+    (py.vllm.override {
       rocmSupport = true;
       cudaSupport = false;
       gpuTargets = vllmGpuTargets;
       rocmPackages = therockRocmPackages;
-      amdsmi = final.python312Packages.amdsmi;
+      amdsmi = py.amdsmi;
     }).overridePythonAttrs
       (old: {
         version = vllmVersion;
@@ -142,41 +246,20 @@ let
           final.pkg-config
         ];
         pythonRemoveDeps = (old.pythonRemoveDeps or [ ]) ++ dropVllmDependencyNames;
-        dependencies = dropNamedDeps dropVllmDependencyNames (old.dependencies or [ ]) ++ [
-          final.python312Packages.amdsmi
-          final.python312Packages.cloudpickle
-          final.python312Packages.diskcache
-          final.python312Packages.lark
-          final.python312Packages.outlines-core
-          final.python312Packages.pillow
-          final.python312Packages.prometheus-client
-          final.python312Packages.protobuf
-          final.python312Packages.pyyaml
-          final.python312Packages.regex
-          final.python312Packages.requests
-          final.python312Packages.six
-          final.python312Packages.tqdm
-          final.python312Packages.watchfiles
-        ];
-        propagatedBuildInputs =
-          dropNamedDeps dropVllmDependencyNames (old.propagatedBuildInputs or [ ])
-          ++ [
-            final.python312Packages.amdsmi
-            final.python312Packages.cloudpickle
-            final.python312Packages.diskcache
-            final.python312Packages.lark
-            final.python312Packages.outlines-core
-            final.python312Packages.pillow
-            final.python312Packages.prometheus-client
-            final.python312Packages.protobuf
-            final.python312Packages.pyyaml
-            final.python312Packages.regex
-            final.python312Packages.requests
-            final.python312Packages.six
-            final.python312Packages.tqdm
-            final.python312Packages.watchfiles
-          ];
+        dependencies = lib.unique (
+          dropNamedDeps dropVllmDependencyNames (old.dependencies or [ ]) ++ extraDependencies
+        );
+        propagatedBuildInputs = lib.unique (
+          dropNamedDeps dropVllmDependencyNames (old.propagatedBuildInputs or [ ]) ++ extraDependencies
+        );
+        optional-dependencies = optionalDependencies;
+        passthru = (old.passthru or { }) // {
+          vllmFeatureOptions = featureFlags;
+          vllmUnsupportedFeatures = unsupportedFeatureReasons;
+        };
       });
+
+  vllmTherock = lib.makeOverridable mkVllmTherock { };
 in
 {
   "vllm-rocm-therock-${s}" = vllmTherock;

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -92,6 +92,7 @@ let
     helion = "helion is marked broken in this nixpkgs input";
     instanttensor = "instanttensor is not packaged in this nixpkgs input";
     otel = "opentelemetry-semantic-conventions-ai is not packaged in this nixpkgs input";
+    rixl = "RIXL needs separate ROCm RIXL/UCX/RDMA packaging and is only used by KV-transfer/disaggregated serving paths";
     runai = "runai-model-streamer is not packaged in this nixpkgs input";
     tensorizer = "tensorizer is not packaged in this nixpkgs input";
     zen = "zentorch-weekly is not packaged and is a CPU optimization";
@@ -100,7 +101,7 @@ let
   mkVllmTherock =
     {
       aiterSupport ? false,
-      audioSupport ? false,
+      audioSupport ? true,
       benchSupport ? true,
       fastsafetensorsSupport ? false,
       flashinferSupport ? false,
@@ -108,6 +109,7 @@ let
       helionSupport ? false,
       instanttensorSupport ? false,
       otelSupport ? false,
+      rixlSupport ? false,
       runaiSupport ? false,
       tensorizerSupport ? false,
       tritonSupport ? true,
@@ -126,6 +128,7 @@ let
         helion = helionSupport;
         instanttensor = instanttensorSupport;
         otel = otelSupport;
+        rixl = rixlSupport;
         runai = runaiSupport;
         tensorizer = tensorizerSupport;
         triton = tritonSupport;

--- a/pkgs/opentelemetry-semantic-conventions-ai/default.nix
+++ b/pkgs/opentelemetry-semantic-conventions-ai/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  poetry-core,
+}:
+
+buildPythonPackage rec {
+  pname = "opentelemetry-semantic-conventions-ai";
+  version = "0.4.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "opentelemetry_semantic_conventions_ai";
+    inherit version;
+    hash = "sha256-qvWbLyTXRWkhcLlthtfFVg9CRD3PiM7UmunUVC2xkC8=";
+  };
+
+  build-system = [ poetry-core ];
+
+  pythonImportsCheck = [ "opentelemetry.semconv_ai" ];
+
+  meta = {
+    description = "OpenTelemetry semantic conventions extension for generative AI";
+    homepage = "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-semantic-conventions-ai";
+    license = lib.licenses.asl20;
+    maintainers = [ ];
+  };
+}

--- a/pkgs/vllm/patches/0001-hipify-copy-unchanged-cu-to-hip.patch
+++ b/pkgs/vllm/patches/0001-hipify-copy-unchanged-cu-to-hip.patch
@@ -1,0 +1,33 @@
+--- a/cmake/hipify.py
++++ b/cmake/hipify.py
+@@ -41,0 +42,2 @@
++    output_dir = os.path.abspath(args.output_dir)
++    project_dir = os.path.abspath(args.project_dir)
+@@ -74,0 +77,27 @@
++        if hipified_s_abs == s_abs and s_abs.endswith(".cu"):
++            # Newer torch hipify can report "skipped, no changes" for a CUDA
++            # source while vLLM's CMake rule still declares the corresponding
++            # .hip file as a byproduct and compiles that path.
++            try:
++                common = os.path.commonpath([output_dir, s_abs])
++            except ValueError:
++                common = None
++
++            if common == output_dir:
++                hipified_s_abs = os.path.splitext(s_abs)[0] + ".hip"
++            else:
++                try:
++                    common = os.path.commonpath([project_dir, s_abs])
++                except ValueError:
++                    common = None
++
++                if common == project_dir:
++                    rel = os.path.relpath(s_abs, project_dir)
++                    hipified_s_abs = os.path.join(
++                        output_dir, os.path.splitext(rel)[0] + ".hip"
++                    )
++
++            if hipified_s_abs != s_abs:
++                os.makedirs(os.path.dirname(hipified_s_abs), exist_ok=True)
++                shutil.copyfile(s_abs, hipified_s_abs)
++


### PR DESCRIPTION
## Summary
- add a source-built vLLM ROCm package against the TheRock Python/ROCm stack
- pin vLLM with a flake input at upstream stable v0.21.0
- expose vllm-rocm-therock-gfx1151 and wire it into PR checks
- remove x86_64-darwin flake outputs
- keep this independent of Lemonade/prebuilt release artifacts

## Local validation
- `nix eval --impure --json --expr 'let f = builtins.getFlake "git+file:///mnt/Home/src/nix-strix-halo-vllm-lemonade"; in builtins.attrNames f.packages'` -> `["aarch64-darwin","x86_64-linux"]`
- `nix eval --impure --raw .#packages.x86_64-linux.vllm-rocm-therock-gfx1151.version` -> `0.21.0`
- `nix build --builders '' --no-link .#checks.x86_64-linux.package-vllm-rocm-therock-gfx1151` reached the TheRock HIP/CMake compile for gfx1151 before being stopped so the buildbot can own the full build
