### PR TITLE
ci: run source checks on x86 only

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1331,6 +1331,7 @@
         pkgs:
         let
           system = pkgs.stdenv.hostPlatform.system;
+          isSourceCheckSystem = system == "x86_64-linux";
 
           mkAggregate =
             aggregateName: jobs:
@@ -1340,20 +1341,24 @@
               }) jobs
             );
 
-          prQuickJobs = self.checks.${system};
+          prQuickJobs = lib.optionalAttrs isSourceCheckSystem self.checks.${system};
           prQuick = mkAggregate "pr-quick" prQuickJobs;
 
           afterPrQuick =
             name: path:
-            pkgs.linkFarm "nix-strix-halo-pr-full-${name}" [
-              {
-                name = "pr-quick";
-                path = prQuick;
-              }
-              {
-                inherit name path;
-              }
-            ];
+            pkgs.linkFarm "nix-strix-halo-pr-full-${name}" (
+              lib.optionals isSourceCheckSystem [
+                {
+                  name = "pr-quick";
+                  path = prQuick;
+                }
+              ]
+              ++ [
+                {
+                  inherit name path;
+                }
+              ]
+            );
 
           prFullJobs = {
             default = afterPrQuick "default" self.packages.${system}.default;
@@ -1368,11 +1373,12 @@
                 self.benchmarks.${system}.bench-qwen3-0-6b-vllm-rocm-gfx1151-throughput-smoke;
           };
         in
-        {
+        lib.optionalAttrs isSourceCheckSystem {
           "pr-quick" = prQuickJobs // {
             all = prQuick;
           };
-
+        }
+        // {
           "pr-full" = prFullJobs // {
             all = mkAggregate "pr-full" prFullJobs;
           };

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -16,6 +16,9 @@ let
     gpuTargets = vllmGpuTargets;
   };
   py = final.python312Packages;
+  vllmSrcWithTag = vllmSrc // {
+    tag = vllmSrc.tag or "v${vllmVersion}";
+  };
   opentelemetrySemanticConventionsAi =
     py.callPackage ../pkgs/opentelemetry-semantic-conventions-ai
       { };
@@ -225,7 +228,7 @@ let
     }).overridePythonAttrs
       (old: {
         version = vllmVersion;
-        src = vllmSrc;
+        src = vllmSrcWithTag;
 
         patches =
           builtins.filter (patch: !(lib.hasSuffix "0006-drop-rocm-extra-reqs.patch" (toString patch))) (


### PR DESCRIPTION
Hydra source checks like format, deadnix, and statix do not need to fan out per architecture.\n\nThis keeps them under the x86_64-linux pr-quick set while leaving heavier build jobs in pr-full.