### PR TITLE
ds4: add Metal package for Darwin

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ nix build --impure --file ./examples/fevm-faex9 \
 
 ## Benchmarks
 
-Benchmark derivations are generated from structured tool/model/scenario records and exposed under `benchmarks.<system>`. The default cross-platform matrix runs CPU `llama-bench` against local GGUF files under `/models`. Linux also exposes this flake's ROCm and Vulkan llama.cpp tool variants.
+Benchmark derivations are generated from structured tool/model/scenario records and exposed under `benchmarks.<system>`. The default cross-platform matrix runs CPU `llama-bench` against local GGUF files under the platform model root. Linux uses `/models`; Darwin uses `/Users/Shared/models`. Linux also exposes this flake's ROCm and Vulkan llama.cpp tool variants.
 
 ```bash
 nix build .#benchmarks.x86_64-linux.bench-llama2-7b-llama-cpp-cpu-b512-fa1

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ nix flake show
 Main package outputs:
 
 - `packages.aarch64-darwin.default`
+- `packages.aarch64-darwin.ds4`
 - `packages.aarch64-darwin.llama-cpp`
 - `packages.x86_64-linux.default`
 - `packages.x86_64-linux.ds4-rocm`
@@ -49,6 +50,9 @@ Main app outputs:
 
 - `apps.aarch64-darwin.llama-cli`
 - `apps.aarch64-darwin.llama-server`
+- `apps.aarch64-darwin.ds4`
+- `apps.aarch64-darwin.ds4-server`
+- `apps.aarch64-darwin.ds4-bench`
 - `apps.x86_64-linux.llama-cli`
 - `apps.x86_64-linux.llama-server`
 - `apps.x86_64-linux.llama-cli-rocm`
@@ -85,7 +89,11 @@ Example configuration helper:
 }
 ```
 
-On macOS, the overlay intentionally exposes only generic non-ROCm outputs such as `llama-cpp`, CPU `llama-cli`/`llama-server` apps, and CPU benchmark derivations. ROCm, TheRock, EC, and firmware outputs are Linux-only.
+On macOS, the overlay intentionally exposes only generic non-ROCm outputs such as `llama-cpp`, CPU `llama-cli`/`llama-server` apps, DS4 Metal outputs, and CPU benchmark derivations. ROCm, TheRock, EC, and firmware outputs are Linux-only.
+
+The DS4 Metal package builds against nixpkgs' `apple-sdk_26` by default because
+it uses newer Metal APIs than the default Darwin SDK. Override `darwinSdk`,
+`darwinSdkRoot`, or `darwinDeploymentTarget` for a different SDK policy.
 
 ## TheRock ROCm Targets
 
@@ -229,6 +237,15 @@ the Nix sandbox:
 
 ```bash
 nix build .#benchmarks.x86_64-linux.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke
+cat result/results.csv
+```
+
+DS4 Metal benchmarks use the same benchmark shape on macOS. They expect the
+GGUF model at `/Users/Shared/models/ds4/ds4flash.gguf` and a Darwin runner
+advertising the `metal` and `benchmark` system features:
+
+```bash
+nix build .#benchmarks.aarch64-darwin.bench-deepseek-v4-flash-ds4-metal-smoke
 cat result/results.csv
 ```
 

--- a/bench/lib.nix
+++ b/bench/lib.nix
@@ -131,12 +131,30 @@ let
       env = nonNullAttrs env;
       requirements = mergeRequirements [ requirements ];
     };
+
+  modelPath =
+    root: components:
+    let
+      cleanRoot = lib.removeSuffix "/" (toString root);
+      cleanComponents = map (
+        component: lib.removePrefix "/" (lib.removeSuffix "/" (toString component))
+      ) components;
+    in
+    lib.concatStringsSep "/" ([ cleanRoot ] ++ cleanComponents);
+
+  defaultModelsRootFor =
+    system: if lib.hasSuffix "-darwin" system then "/Users/Shared/models" else "/models";
+
+  defaultModelsRoot = pkgs: defaultModelsRootFor pkgs.stdenv.hostPlatform.system;
 in
 rec {
   inherit
+    defaultModelsRoot
+    defaultModelsRootFor
     emptyRequirements
     envExports
     mergeRequirements
+    modelPath
     normalizeRequirements
     normalizePackages
     normalizeTool

--- a/bench/suites/ds4.nix
+++ b/bench/suites/ds4.nix
@@ -1,11 +1,23 @@
 {
   pkgs,
   package,
-  modelRoot ? "/models/ds4",
-  target,
-  hostProfile ? "linux-amd-kfd",
+  modelRoot ? if pkgs.stdenv.isDarwin then "/Users/Shared/models/ds4" else "/models/ds4",
+  modelPath ? "${modelRoot}/ds4flash.gguf",
+  target ? null,
+  accelerator ? if pkgs.stdenv.isDarwin then "metal" else "rocm",
+  hostProfile ? if accelerator == "metal" then "darwin-metal" else "linux-amd-kfd",
   matrixMetadata ? { },
+  extraSystemFeatures ? [ ],
+  extraSandboxPaths ? [ ],
+  cases ? null,
 }:
+
+assert pkgs.lib.assertMsg (
+  accelerator == "metal" || accelerator == "rocm"
+) "unsupported DS4 benchmark accelerator: ${accelerator}";
+assert pkgs.lib.assertMsg (
+  accelerator == "metal" || target != null
+) "DS4 ROCm benchmarks require a target record";
 
 let
   inherit (pkgs) lib;
@@ -13,31 +25,80 @@ let
 
   clean = lib.replaceStrings [ ":" "." "/" "_" ] [ "-" "-" "-" "-" ];
 
+  isMetal = accelerator == "metal";
+  backend = if isMetal then "metal" else "hip";
+  packageRole = if isMetal then "ds4" else "ds4-rocm";
+  backendFlag = if isMetal then "--metal" else "--cuda";
+  namePrefix = if isMetal then "ds4-metal" else "ds4-rocm-${target.packageSuffix}";
+  promptBackend = if isMetal then "Metal" else "ROCm";
+  metaPlatforms = if isMetal then [ "aarch64-darwin" ] else [ "x86_64-linux" ];
+  systemFeatures =
+    (
+      if isMetal then
+        [
+          "metal"
+          "benchmark"
+        ]
+      else
+        [ target.systemFeature ]
+    )
+    ++ extraSystemFeatures;
+  sandboxPaths =
+    (
+      if isMetal then
+        [ modelRoot ]
+      else
+        [
+          "/dev/dri"
+          "/dev/kfd"
+          "/sys/class/drm"
+          "/sys/class/kfd"
+          modelRoot
+        ]
+    )
+    ++ extraSandboxPaths;
+  targetMetadata =
+    if isMetal then
+      {
+        packageSuffix = "metal";
+        runtimeArch = "metal";
+        systemFeature = "metal";
+      }
+    else
+      {
+        inherit (target)
+          packageSuffix
+          runtimeArch
+          systemFeature
+          ;
+      };
+
+  smokeCase = {
+    scenario = "smoke";
+    ctxStart = 128;
+    ctxMax = 256;
+    stepIncr = 128;
+    genTokens = 8;
+    promptRepeats = 1024;
+    fastFull = false;
+  };
+
+  fastFullCase = {
+    scenario = "fast-full";
+    ctxStart = 2048;
+    ctxMax = 16384;
+    stepIncr = 2048;
+    genTokens = 32;
+    promptRepeats = 32768;
+    fastFull = true;
+  };
+
   modelConfigs = {
     deepseek-v4-flash = {
-      path = "${modelRoot}/ds4flash.gguf";
+      path = modelPath;
       repo = "antirez/deepseek-v4-gguf";
       description = "DeepSeek V4 Flash GGUF for DwarfStar 4";
-      cases = [
-        {
-          scenario = "smoke";
-          ctxStart = 128;
-          ctxMax = 256;
-          stepIncr = 128;
-          genTokens = 8;
-          promptRepeats = 1024;
-          fastFull = false;
-        }
-        {
-          scenario = "fast-full";
-          ctxStart = 2048;
-          ctxMax = 16384;
-          stepIncr = 2048;
-          genTokens = 32;
-          promptRepeats = 32768;
-          fastFull = true;
-        }
-      ];
+      cases = if cases == null then [ smokeCase ] ++ lib.optionals (!isMetal) [ fastFullCase ] else cases;
     };
   };
 
@@ -46,7 +107,7 @@ let
       scenario,
       ...
     }:
-    "ds4-rocm-${target.packageSuffix}-${clean scenario}";
+    "${namePrefix}-${clean scenario}";
 
   mkRunner =
     model:
@@ -62,17 +123,17 @@ let
     let
       executable = if fastFull then "ds4-bench-fast-full" else "ds4-bench";
     in
-    pkgs.writeShellScript "ds4-rocm-${target.packageSuffix}-benchmark-runner" ''
+    pkgs.writeShellScript "${namePrefix}-benchmark-runner" ''
       set -euo pipefail
 
       prompt="$TMPDIR/ds4-prompt.txt"
       for i in $(seq 1 ${toString promptRepeats}); do
-        printf 'DwarfStar 4 ROCm benchmark prompt paragraph %05d. This text is intentionally repetitive and deterministic so the fixed token sequence is long enough for context frontier measurement. It discusses GPU memory bandwidth, attention prefill, routed experts, and decode throughput on AMD Strix Halo. ' "$i"
+        printf 'DwarfStar 4 ${promptBackend} benchmark prompt paragraph %05d. This text is intentionally repetitive and deterministic so the fixed token sequence is long enough for context frontier measurement. It discusses GPU memory bandwidth, attention prefill, routed experts, and decode throughput. ' "$i"
       done > "$prompt"
 
       ${package}/bin/${executable} \
         -m ${lib.escapeShellArg model.path} \
-        --cuda \
+        ${backendFlag} \
         --prompt-file "$prompt" \
         --ctx-start ${toString ctxStart} \
         --ctx-max ${toString ctxMax} \
@@ -117,34 +178,28 @@ let
         DS4_MODEL = model.path;
         DS4_SERVER_PERFLEVEL = "skip";
         DS4_SERVER_FAST_FULL = if fastFull then "1" else null;
+        DS4_METAL_NO_RESIDENCY = if isMetal then "1" else null;
+        DS4_METAL_NO_MODEL_WARMUP = if isMetal then "1" else null;
       };
       requirements = {
-        systemFeatures = [ target.systemFeature ];
+        inherit
+          systemFeatures
+          sandboxPaths
+          ;
         hostProfiles = [ hostProfile ];
-        sandboxPaths = [
-          "/dev/dri"
-          "/dev/kfd"
-          "/sys/class/drm"
-          "/sys/class/kfd"
-          modelRoot
-        ];
       };
       metadata = lib.recursiveUpdate {
         kind = "ds4";
         suite = "ds4";
-        accelerator = "rocm";
-        backend = "hip";
+        inherit
+          accelerator
+          backend
+          ;
         inherit
           params
           scenario
           ;
-        target = {
-          inherit (target)
-            packageSuffix
-            runtimeArch
-            systemFeature
-            ;
-        };
+        target = targetMetadata;
         model = {
           name = modelName;
           inherit (model)
@@ -154,12 +209,14 @@ let
             ;
         };
         tool = {
-          backend = "rocm";
-          packageRole = "ds4-rocm";
+          inherit
+            backend
+            packageRole
+            ;
         };
       } matrixMetadata;
-      meta.platforms = [ "x86_64-linux" ];
-      description = "Run DS4 ROCm benchmark ${modelName}/${name}";
+      meta.platforms = metaPlatforms;
+      description = "Run DS4 ${promptBackend} benchmark ${modelName}/${name}";
     };
 
   generateModelBenchmarks =

--- a/bench/suites/ds4.nix
+++ b/bench/suites/ds4.nix
@@ -1,8 +1,9 @@
 {
   pkgs,
   package,
-  modelRoot ? if pkgs.stdenv.isDarwin then "/Users/Shared/models/ds4" else "/models/ds4",
-  modelPath ? "${modelRoot}/ds4flash.gguf",
+  modelsRoot ? null,
+  modelRoot ? null,
+  modelPath ? null,
   target ? null,
   accelerator ? if pkgs.stdenv.isDarwin then "metal" else "rocm",
   hostProfile ? if accelerator == "metal" then "darwin-metal" else "linux-amd-kfd",
@@ -25,6 +26,12 @@ let
 
   clean = lib.replaceStrings [ ":" "." "/" "_" ] [ "-" "-" "-" "-" ];
 
+  resolvedModelsRoot = if modelsRoot != null then modelsRoot else benchLib.defaultModelsRoot pkgs;
+  resolvedModelRoot =
+    if modelRoot != null then modelRoot else benchLib.modelPath resolvedModelsRoot [ "ds4" ];
+  resolvedModelPath =
+    if modelPath != null then modelPath else benchLib.modelPath resolvedModelRoot [ "ds4flash.gguf" ];
+
   isMetal = accelerator == "metal";
   backend = if isMetal then "metal" else "hip";
   packageRole = if isMetal then "ds4" else "ds4-rocm";
@@ -46,14 +53,14 @@ let
   sandboxPaths =
     (
       if isMetal then
-        [ modelRoot ]
+        [ resolvedModelRoot ]
       else
         [
           "/dev/dri"
           "/dev/kfd"
           "/sys/class/drm"
           "/sys/class/kfd"
-          modelRoot
+          resolvedModelRoot
         ]
     )
     ++ extraSandboxPaths;
@@ -95,7 +102,7 @@ let
 
   modelConfigs = {
     deepseek-v4-flash = {
-      path = modelPath;
+      path = resolvedModelPath;
       repo = "antirez/deepseek-v4-gguf";
       description = "DeepSeek V4 Flash GGUF for DwarfStar 4";
       cases = if cases == null then [ smokeCase ] ++ lib.optionals (!isMetal) [ fastFullCase ] else cases;

--- a/bench/suites/fastflowlm.nix
+++ b/bench/suites/fastflowlm.nix
@@ -1,7 +1,8 @@
 {
   pkgs,
   package,
-  modelRoot ? "/models/flm",
+  modelsRoot ? null,
+  modelRoot ? null,
   npuSystemFeature ? "xdna2",
   hostProfile ? "linux-amd-xdna",
   matrixMetadata ? { },
@@ -10,6 +11,10 @@
 let
   inherit (pkgs) lib;
   benchLib = import ../lib.nix { inherit lib; };
+
+  resolvedModelsRoot = if modelsRoot != null then modelsRoot else benchLib.defaultModelsRoot pkgs;
+  resolvedModelRoot =
+    if modelRoot != null then modelRoot else benchLib.modelPath resolvedModelsRoot [ "flm" ];
 
   prompts = {
     short = "Explain in one sentence what an NPU is.";
@@ -152,7 +157,7 @@ let
         ;
       command = [ runner ];
       env = {
-        FLM_MODEL_PATH = modelRoot;
+        FLM_MODEL_PATH = resolvedModelRoot;
         FLM_DISABLE_UPDATE_CHECK = "1";
       };
       requirements = {
@@ -172,7 +177,7 @@ let
         model = {
           name = modelName;
           inherit (model) tag description;
-          path = modelRoot;
+          path = resolvedModelRoot;
         };
         tool = {
           backend = "npu";

--- a/bench/suites/llama-cpp.nix
+++ b/bench/suites/llama-cpp.nix
@@ -1,12 +1,15 @@
 {
   pkgs,
   tools,
-  modelRoot ? "/models",
+  modelsRoot ? null,
+  modelRoot ? null,
   matrixMetadata ? { },
 }:
 let
   inherit (pkgs) lib;
   benchLib = import ../lib.nix { inherit lib; };
+  resolvedModelsRoot = if modelsRoot != null then modelsRoot else benchLib.defaultModelsRoot pkgs;
+  resolvedModelRoot = if modelRoot != null then modelRoot else resolvedModelsRoot;
 
   benchmarkTools = map benchLib.normalizeTool tools;
 
@@ -14,7 +17,10 @@ let
     llama2-7b =
       benchLib.mkModel {
         name = "llama2-7b";
-        path = "${modelRoot}/llama-2-7b/llama-2-7b.Q4_K_M.gguf";
+        path = benchLib.modelPath resolvedModelRoot [
+          "llama-2-7b"
+          "llama-2-7b.Q4_K_M.gguf"
+        ];
       }
       // {
         benchmarks = {
@@ -56,7 +62,10 @@ let
     qwen25-32b =
       benchLib.mkModel {
         name = "qwen25-32b";
-        path = "${modelRoot}/qwen2.5-32b-instruct/qwen2.5-32b-instruct-q8_0-00001-of-00009.gguf";
+        path = benchLib.modelPath resolvedModelRoot [
+          "qwen2.5-32b-instruct"
+          "qwen2.5-32b-instruct-q8_0-00001-of-00009.gguf"
+        ];
       }
       // {
         benchmarks = {
@@ -78,7 +87,11 @@ let
     qwen3-coder-30b =
       benchLib.mkModel {
         name = "qwen3-coder-30b";
-        path = "${modelRoot}/qwen3-coder-30b-a3b/BF16/Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf";
+        path = benchLib.modelPath resolvedModelRoot [
+          "qwen3-coder-30b-a3b"
+          "BF16"
+          "Qwen3-Coder-30B-A3B-Instruct-BF16-00001-of-00002.gguf"
+        ];
       }
       // {
         benchmarks = {

--- a/bench/suites/vllm.nix
+++ b/bench/suites/vllm.nix
@@ -1,8 +1,9 @@
 {
   pkgs,
   package,
-  modelRoot ? "/models",
-  hfCacheHome ? "${modelRoot}/.cache/huggingface",
+  modelsRoot ? null,
+  modelRoot ? null,
+  hfCacheHome ? null,
   target,
   hostProfile ? "linux-amd-kfd",
   matrixMetadata ? { },
@@ -11,6 +12,17 @@
 let
   inherit (pkgs) lib;
   benchLib = import ../lib.nix { inherit lib; };
+
+  resolvedModelsRoot = if modelsRoot != null then modelsRoot else benchLib.defaultModelsRoot pkgs;
+  resolvedModelRoot = if modelRoot != null then modelRoot else resolvedModelsRoot;
+  resolvedHfCacheHome =
+    if hfCacheHome != null then
+      hfCacheHome
+    else
+      benchLib.modelPath resolvedModelRoot [
+        ".cache"
+        "huggingface"
+      ];
 
   clean = lib.replaceStrings [ ":" "." "/" "_" ] [ "-" "-" "-" "-" ];
 
@@ -254,7 +266,7 @@ let
         ;
       command = [ (mkRunner model case) ];
       env = {
-        HF_HOME = hfCacheHome;
+        HF_HOME = resolvedHfCacheHome;
         HF_HUB_OFFLINE = "1";
         TRANSFORMERS_OFFLINE = "1";
         VLLM_NO_USAGE_STATS = "1";
@@ -272,7 +284,7 @@ let
           "/dev/kfd"
           "/sys/class/drm"
           "/sys/class/kfd"
-          modelRoot
+          resolvedModelRoot
         ];
       };
       metadata = lib.recursiveUpdate {
@@ -294,7 +306,7 @@ let
         };
         model = {
           name = modelName;
-          cacheRoot = hfCacheHome;
+          cacheRoot = resolvedHfCacheHome;
           inherit (model)
             description
             id

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "ds4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779778674,
+        "narHash": "sha256-ICjNBjLL/KvleDJZksTCgUVaHipeoOT752/BiE9SVeE=",
+        "owner": "antirez",
+        "repo": "ds4",
+        "rev": "ec6a82aaa9a3a98bee803801440b0e803aa48f09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "antirez",
+        "repo": "ds4",
+        "type": "github"
+      }
+    },
     "ds4-hip": {
       "flake": false,
       "locked": {
@@ -83,6 +99,7 @@
     },
     "root": {
       "inputs": {
+        "ds4": "ds4",
         "ds4-hip": "ds4-hip",
         "ec-su-axb35": "ec-su-axb35",
         "fastflowlm": "fastflowlm",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,11 @@
       flake = false;
     };
 
+    ds4 = {
+      url = "github:antirez/ds4";
+      flake = false;
+    };
+
     ds4-hip = {
       url = "github:ejpir/ds4-hip/rocm-upstream-shape-cyberneurova";
       flake = false;
@@ -340,6 +345,10 @@
       darwinSystems = [ "aarch64-darwin" ];
       systems = linuxSystems ++ darwinSystems;
       forAllSystems = lib.genAttrs systems;
+      inputShortRev =
+        input: input.shortRev or (if input ? rev then builtins.substring 0 7 input.rev else "unknown");
+      inputVersion = prefix: input: "${prefix}-unstable-${inputShortRev input}";
+      unstableInputVersion = input: "unstable-${inputShortRev input}";
 
       rocmTargetLib = import ./lib/rocm-targets.nix;
       therockTargetConfig = import ./pkgs/therock/targets.nix {
@@ -439,6 +448,7 @@
       mkBenchmarkSuites =
         pkgs:
         let
+          system = pkgs.stdenv.hostPlatform.system;
           defaultTargetMetadata = {
             inherit (defaultRocmTarget)
               packageSuffix
@@ -528,8 +538,20 @@
             // flattenBenchmarks ds4Benchmarks
             // flattenBenchmarks vllmBenchmarks
           );
+
+          darwinBenchmarks = lib.optionalAttrs pkgs.stdenv.isDarwin (
+            let
+              ds4MetalBenchmarks =
+                (import ./bench/suites/ds4.nix {
+                  inherit pkgs;
+                  package = self.packages.${system}.ds4;
+                  accelerator = "metal";
+                }).benchmarks;
+            in
+            flattenBenchmarks ds4MetalBenchmarks
+          );
         in
-        flattenBenchmarks genericBenchmarks // linuxBenchmarks;
+        flattenBenchmarks genericBenchmarks // linuxBenchmarks // darwinBenchmarks;
 
       mkFevmFaex9Configuration =
         {
@@ -630,11 +652,6 @@
                 cudaSupport = true;
                 rpcSupport = true;
               };
-              inputVersion =
-                prefix: input:
-                "${prefix}-unstable-${
-                  input.shortRev or (if input ? rev then builtins.substring 0 7 input.rev else "unknown")
-                }";
               ds4RocmTargets = builtins.filter (
                 rocmTarget: builtins.hasAttr rocmTarget.packageSuffix defaultTherockSources.rocm.linux
               ) rocmTargets;
@@ -818,13 +835,22 @@
             // ds4RocmPackages
             // llamaCppTargetPackages
             // therockPackages;
+          darwinPackages = {
+            ds4 = pkgs.callPackage ./pkgs/ds4 {
+              src = inputs.ds4;
+              version = unstableInputVersion inputs.ds4;
+            };
+          };
         in
-        genericPackages // lib.optionalAttrs pkgs.stdenv.isLinux linuxPackages
+        genericPackages
+        // lib.optionalAttrs pkgs.stdenv.isLinux linuxPackages
+        // lib.optionalAttrs pkgs.stdenv.isDarwin darwinPackages
       );
 
       apps = perSystem (
         pkgs:
         let
+          system = pkgs.stdenv.hostPlatform.system;
           s = defaultRocmTarget.packageSuffix;
           mkApp =
             {
@@ -952,8 +978,28 @@
               description = "Run a command in the pinned TheRock ROCm/PyTorch wheel environment";
             };
           };
+
+          darwinApps =
+            let
+              ds4Package = self.packages.${system}.ds4;
+              mkDs4App = binary: description: {
+                type = "app";
+                program = "${ds4Package}/bin/${binary}";
+                meta.description = description;
+              };
+            in
+            {
+              ds4 = mkDs4App "ds4" "Run DwarfStar 4 with Metal";
+              ds4-server = mkDs4App "ds4-server" "Run the DwarfStar 4 HTTP server with Metal";
+              ds4-bench = mkDs4App "ds4-bench" "Run the DwarfStar 4 benchmark with Metal";
+              ds4-eval = mkDs4App "ds4-eval" "Run DwarfStar 4 eval with Metal";
+              ds4-agent = mkDs4App "ds4-agent" "Run the DwarfStar 4 agent with Metal";
+              ds4-download-model = mkDs4App "ds4-download-model" "Download DS4 DeepSeek V4 Flash GGUF weights";
+            };
         in
-        genericApps // lib.optionalAttrs pkgs.stdenv.isLinux linuxApps
+        genericApps
+        // lib.optionalAttrs pkgs.stdenv.isLinux linuxApps
+        // lib.optionalAttrs pkgs.stdenv.isDarwin darwinApps
       );
 
       devShells = perSystem (pkgs: {
@@ -1325,6 +1371,44 @@
             "therock-pytorch-${s}" = pkgs.${therockPytorchPackage};
           }
         )
+        // lib.optionalAttrs pkgs.stdenv.isDarwin (
+          let
+            ds4MetalBenchmark = benchmarkSet.bench-deepseek-v4-flash-ds4-metal-smoke;
+            ds4MetalBenchmarkMetadata = builtins.toJSON ds4MetalBenchmark.passthru.benchmark;
+          in
+          {
+            ds4-metal-benchmark-metadata =
+              pkgs.runCommandLocal "ci-ds4-metal-benchmark-metadata"
+                {
+                  nativeBuildInputs = [ pkgs.jq ];
+                }
+                ''
+                  cat > metadata.json <<'JSON'
+                  ${ds4MetalBenchmarkMetadata}
+                  JSON
+
+                  jq -e '
+                    .kind == "ds4"
+                    and .accelerator == "metal"
+                    and .backend == "metal"
+                    and .requirements.systemFeatures == [ "metal", "benchmark" ]
+                    and .requirements.hostProfiles == [ "darwin-metal" ]
+                    and (.requirements.sandboxPaths | index("/Users/Shared/models/ds4") != null)
+                    and .model.path == "/Users/Shared/models/ds4/ds4flash.gguf"
+                    and .packages == [ "ds4" ]
+                    and .env.DS4_METAL_NO_RESIDENCY == "1"
+                    and .env.DS4_METAL_NO_MODEL_WARMUP == "1"
+                    and .target.packageSuffix == "metal"
+                    and .tool.packageRole == "ds4"
+                    and .params.ctxStart == 128
+                    and .params.ctxMax == 256
+                    and .params.genTokens == 8
+                  ' metadata.json
+
+                  touch "$out"
+                '';
+          }
+        )
       );
 
       hydraJobs = perSystem (
@@ -1362,6 +1446,12 @@
 
           prFullJobs = {
             default = afterPrQuick "default" self.packages.${system}.default;
+          }
+          // lib.optionalAttrs (system == "aarch64-darwin") {
+            ds4 = afterPrQuick "ds4" self.packages.${system}.ds4;
+            ds4-metal-smoke =
+              afterPrQuick "ds4-metal-smoke"
+                self.benchmarks.${system}.bench-deepseek-v4-flash-ds4-metal-smoke;
           }
           // lib.optionalAttrs (system == "x86_64-linux") {
             system = afterPrQuick "system" self.nixosConfigurations.fevm-faex9.config.system.build.toplevel;

--- a/flake.nix
+++ b/flake.nix
@@ -449,6 +449,8 @@
         pkgs:
         let
           system = pkgs.stdenv.hostPlatform.system;
+          benchLib = import ./bench/lib.nix { inherit lib; };
+          modelsRoot = benchLib.defaultModelsRoot pkgs;
           defaultTargetMetadata = {
             inherit (defaultRocmTarget)
               packageSuffix
@@ -462,7 +464,7 @@
           };
 
           genericBenchmarks = import ./bench/default.nix {
-            inherit pkgs;
+            inherit pkgs modelsRoot;
             tools = [
               {
                 name = "cpu";
@@ -477,7 +479,7 @@
           };
 
           acceleratedBenchmarks = import ./bench/default.nix {
-            inherit pkgs;
+            inherit pkgs modelsRoot;
             tools = [
               {
                 name = "rocm";
@@ -517,18 +519,18 @@
             let
               fastflowlmBenchmarks =
                 (import ./bench/suites/fastflowlm.nix {
-                  inherit pkgs;
+                  inherit pkgs modelsRoot;
                   package = pkgs.fastflowlm;
                 }).benchmarks;
               ds4Benchmarks =
                 (import ./bench/suites/ds4.nix {
-                  inherit pkgs;
+                  inherit pkgs modelsRoot;
                   package = pkgs.${"ds4-rocm-${defaultRocmTarget.packageSuffix}"};
                   target = defaultTargetMetadata;
                 }).benchmarks;
               vllmBenchmarks =
                 (import ./bench/suites/vllm.nix {
-                  inherit pkgs;
+                  inherit pkgs modelsRoot;
                   package = pkgs.${"vllm-rocm-therock-${defaultRocmTarget.packageSuffix}"};
                   target = defaultTargetMetadata;
                 }).benchmarks;
@@ -543,7 +545,7 @@
             let
               ds4MetalBenchmarks =
                 (import ./bench/suites/ds4.nix {
-                  inherit pkgs;
+                  inherit pkgs modelsRoot;
                   package = self.packages.${system}.ds4;
                   accelerator = "metal";
                 }).benchmarks;

--- a/hydra/benchmark/flake.nix
+++ b/hydra/benchmark/flake.nix
@@ -30,14 +30,14 @@
 
       supportedOn =
         system: drv:
-        lib.all
-          (feature: lib.elem feature supportedFeatures.${system})
-          (drv.requiredSystemFeatures or [ ]);
+        lib.all (feature: lib.elem feature supportedFeatures.${system}) (drv.requiredSystemFeatures or [ ]);
     in
     {
-      hydraJobs = lib.genAttrs benchmarkSystems (system:
+      hydraJobs = lib.genAttrs benchmarkSystems (
+        system:
         lib.filterAttrs (_: supportedOn system) (
           lib.mapAttrs (_: addBenchmarkFeature) src.benchmarks.${system}
-        ));
+        )
+      );
     };
 }

--- a/pkgs/ds4/default.nix
+++ b/pkgs/ds4/default.nix
@@ -1,0 +1,150 @@
+{
+  lib,
+  stdenv,
+  gnumake,
+  makeWrapper,
+  coreutils,
+  curl,
+  gnused,
+  apple-sdk_26,
+  src,
+  version ? "unstable",
+  darwinSdk ? apple-sdk_26,
+  darwinSdkRoot ? darwinSdk.sdkroot,
+  darwinDeploymentTarget ? "26.0",
+}:
+
+let
+  metalSources = {
+    DS4_METAL_FLASH_ATTN_SOURCE = "flash_attn.metal";
+    DS4_METAL_DENSE_SOURCE = "dense.metal";
+    DS4_METAL_MOE_SOURCE = "moe.metal";
+    DS4_METAL_DSV4_HC_SOURCE = "dsv4_hc.metal";
+    DS4_METAL_UNARY_SOURCE = "unary.metal";
+    DS4_METAL_DSV4_KV_SOURCE = "dsv4_kv.metal";
+    DS4_METAL_DSV4_ROPE_SOURCE = "dsv4_rope.metal";
+    DS4_METAL_DSV4_MISC_SOURCE = "dsv4_misc.metal";
+    DS4_METAL_ARGSORT_SOURCE = "argsort.metal";
+    DS4_METAL_CPY_SOURCE = "cpy.metal";
+    DS4_METAL_CONCAT_SOURCE = "concat.metal";
+    DS4_METAL_GET_ROWS_SOURCE = "get_rows.metal";
+    DS4_METAL_SUM_ROWS_SOURCE = "sum_rows.metal";
+    DS4_METAL_SOFTMAX_SOURCE = "softmax.metal";
+    DS4_METAL_REPEAT_SOURCE = "repeat.metal";
+    DS4_METAL_GLU_SOURCE = "glu.metal";
+    DS4_METAL_NORM_SOURCE = "norm.metal";
+    DS4_METAL_BIN_SOURCE = "bin.metal";
+    DS4_METAL_SET_ROWS_SOURCE = "set_rows.metal";
+  };
+
+  metalSourceWrapperArgs = lib.concatStringsSep " " (
+    lib.mapAttrsToList (
+      envName: fileName: "--set ${envName} \"$out/share/ds4/metal/${fileName}\""
+    ) metalSources
+  );
+
+  optionalDarwinSdkRoot = lib.optionalString (darwinSdkRoot != null) ''
+    sdk_root=${lib.escapeShellArg darwinSdkRoot}
+  '';
+
+  optionalDarwinDeploymentTarget = lib.optionalString (darwinDeploymentTarget != null) ''
+    deployment_target=${lib.escapeShellArg darwinDeploymentTarget}
+  '';
+in
+stdenv.mkDerivation {
+  pname = "ds4";
+  inherit src version;
+
+  nativeBuildInputs = [
+    gnumake
+    makeWrapper
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isDarwin [
+    darwinSdk
+  ];
+
+  dontConfigure = true;
+
+  preBuild = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    ${optionalDarwinSdkRoot}
+    ${optionalDarwinDeploymentTarget}
+
+    if [ -z "''${sdk_root:-}" ]; then
+      sdk_root="''${SDKROOT:-}"
+    fi
+
+    if [ ! -d "$sdk_root" ]; then
+      echo "ds4: missing macOS SDK: $sdk_root" >&2
+      echo "ds4: override darwinSdk or darwinSdkRoot with a newer macOS SDK" >&2
+      exit 1
+    fi
+
+    echo "ds4: using macOS SDK: $sdk_root"
+
+    export DS4_DARWIN_SDK_ROOT="$sdk_root"
+    export SDKROOT="$sdk_root"
+    if [ -n "''${deployment_target:-}" ]; then
+      export MACOSX_DEPLOYMENT_TARGET="$deployment_target"
+    fi
+  '';
+
+  buildPhase = ''
+    runHook preBuild
+
+    darwin_sdk_flags=()
+    if [ -n "''${DS4_DARWIN_SDK_ROOT:-}" ]; then
+      darwin_sdk_flags+=("-isysroot" "$DS4_DARWIN_SDK_ROOT")
+    fi
+    if [ -n "''${MACOSX_DEPLOYMENT_TARGET:-}" ]; then
+      darwin_sdk_flags+=("-mmacosx-version-min=$MACOSX_DEPLOYMENT_TARGET")
+    fi
+
+    make -j"$NIX_BUILD_CORES" \
+      CC="$CC" \
+      NATIVE_CPU_FLAG= \
+      CFLAGS="-O3 -ffast-math -g -Wall -Wextra ''${darwin_sdk_flags[*]} -std=c99" \
+      OBJCFLAGS="-O3 -ffast-math -g -Wall -Wextra ''${darwin_sdk_flags[*]} -fobjc-arc"
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    for bin in ds4 ds4-server ds4-bench ds4-eval ds4-agent; do
+      install -Dm755 "$bin" "$out/bin/$bin-unwrapped"
+      makeWrapper "$out/bin/$bin-unwrapped" "$out/bin/$bin" \
+        ${metalSourceWrapperArgs}
+    done
+
+    mkdir -p "$out/share/ds4"
+    cp -R metal speed-bench "$out/share/ds4/"
+    install -Dm644 README.md "$out/share/ds4/README.md"
+    install -Dm644 LICENSE "$out/share/ds4/LICENSE"
+    install -Dm644 MODEL_CARD.md "$out/share/ds4/MODEL_CARD.md"
+
+    install -Dm755 download_model.sh "$out/bin/ds4-download-model"
+    substituteInPlace "$out/bin/ds4-download-model" \
+      --replace-fail 'ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)' 'ROOT=''${DS4_ROOT:-$PWD}'
+    patchShebangs "$out/bin/ds4-download-model"
+    wrapProgram "$out/bin/ds4-download-model" \
+      --prefix PATH : "${
+        lib.makeBinPath [
+          coreutils
+          curl
+          gnused
+        ]
+      }"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "DwarfStar 4 native inference engine for DeepSeek V4 Flash";
+    homepage = "https://github.com/antirez/ds4";
+    license = lib.licenses.mit;
+    mainProgram = "ds4";
+    platforms = lib.platforms.darwin;
+  };
+}


### PR DESCRIPTION
## Summary
- add upstream antirez/ds4 as a flake input
- package DS4 Metal for aarch64-darwin with Xcode SDK override knobs
- expose Darwin DS4 package/apps and add DS4 to Darwin pr-full jobs

## Validation
- nix build --builders '' .#checks.x86_64-linux.format .#checks.x86_64-linux.deadnix .#checks.x86_64-linux.statix
- nix flake check --no-build --builders '' --all-systems
- nix build .#packages.aarch64-darwin.ds4
- nix build .#hydraJobs.aarch64-darwin.pr-full.ds4
- ssh grw@mbp '/nix/store/nkfh8bhdz0s3m38wd58krxw1y4xl3611-ds4-unstable-ec6a82a/bin/ds4 --help'
- ssh grw@mbp '/nix/store/nkfh8bhdz0s3m38wd58krxw1y4xl3611-ds4-unstable-ec6a82a/bin/ds4-bench --help'