### PR TITLE
Expose benchmark Hydra jobs

### DIFF
--- a/hydra/benchmark/flake.nix
+++ b/hydra/benchmark/flake.nix
@@ -1,0 +1,9 @@
+{
+  description = "Hydra benchmark job wrapper";
+
+  inputs.src.url = "path:../..";
+
+  outputs = { src, ... }: {
+    hydraJobs = src.benchmarks;
+  };
+}


### PR DESCRIPTION
Adds a tiny Hydra benchmark wrapper flake under hydra/benchmark so the separate infra benchmark project can evaluate the repository's benchmarks output through Hydra's normal flake jobset path.