### PR TITLE
ci: lock benchmark hydra wrapper

### DIFF
--- a/hydra/benchmark/flake.lock
+++ b/hydra/benchmark/flake.lock
@@ -1,0 +1,1158 @@
+{
+  "nodes": {
+    "ds4-hip": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779749771,
+        "narHash": "sha256-fpND5xv3ceafMg26JDeGatm5yNDpM8CBcZlAQ1iG+f8=",
+        "owner": "ejpir",
+        "repo": "ds4-hip",
+        "rev": "aa09fdca6cef1b73d2664f6c114260c4c3c31643",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ejpir",
+        "ref": "rocm-upstream-shape-cyberneurova",
+        "repo": "ds4-hip",
+        "type": "github"
+      }
+    },
+    "ec-su-axb35": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779413431,
+        "narHash": "sha256-VuKP1wYqjkxsMGZo6W+MPiie/5slQrB08DKfF+kXgJo=",
+        "owner": "cmetz",
+        "repo": "ec-su_axb35-linux",
+        "rev": "b8cab5a4ad6b6fc0489520742d4e510f72407558",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cmetz",
+        "repo": "ec-su_axb35-linux",
+        "type": "github"
+      }
+    },
+    "fastflowlm": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778687531,
+        "narHash": "sha256-hJNZntx0GjHHmKNRCmJ3VLz7C68Y+XjrnLPHplnJJJM=",
+        "owner": "FastFlowLM",
+        "repo": "FastFlowLM",
+        "rev": "c99e5ae21b1e72d3e32fca1eb379b49d50d33756",
+        "type": "github"
+      },
+      "original": {
+        "owner": "FastFlowLM",
+        "repo": "FastFlowLM",
+        "type": "github"
+      }
+    },
+    "llama-cpp-master": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779732316,
+        "narHash": "sha256-rcgUHahUGf7GBM5Bv/+HBsyFWoYYo0Ohuk11n37KThU=",
+        "owner": "ggml-org",
+        "repo": "llama.cpp",
+        "rev": "35c9b1f39ebe5a7bb83986d64415a079218be78d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ggml-org",
+        "repo": "llama.cpp",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "src": "src"
+      }
+    },
+    "src": {
+      "inputs": {
+        "ds4-hip": "ds4-hip",
+        "ec-su-axb35": "ec-su-axb35",
+        "fastflowlm": "fastflowlm",
+        "llama-cpp-master": "llama-cpp-master",
+        "nixpkgs": "nixpkgs",
+        "therock-src-7-13-gfx1151-base-half-011b45bd": "therock-src-7-13-gfx1151-base-half-011b45bd",
+        "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84": "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84",
+        "therock-src-7-13-gfx1151-compiler-amd-llvm-1e702164": "therock-src-7-13-gfx1151-compiler-amd-llvm-1e702164",
+        "therock-src-7-13-gfx1151-compiler-hipify-ea979a85": "therock-src-7-13-gfx1151-compiler-hipify-ea979a85",
+        "therock-src-7-13-gfx1151-compiler-spirv-llvm-translator-b9250448": "therock-src-7-13-gfx1151-compiler-spirv-llvm-translator-b9250448",
+        "therock-src-7-13-gfx1151-debug-tools-rocgdb-source-e3322990": "therock-src-7-13-gfx1151-debug-tools-rocgdb-source-e3322990",
+        "therock-src-7-13-gfx1151-iree-libs-fusilli-e6b3e4e6": "therock-src-7-13-gfx1151-iree-libs-fusilli-e6b3e4e6",
+        "therock-src-7-13-gfx1151-iree-libs-iree-89b77fa6": "therock-src-7-13-gfx1151-iree-libs-iree-89b77fa6",
+        "therock-src-7-13-gfx1151-iree-libs-iree-third-party-benchmark-0f3f8fcb": "therock-src-7-13-gfx1151-iree-libs-iree-third-party-benchmark-0f3f8fcb",
+        "therock-src-7-13-gfx1151-iree-libs-iree-third-party-flatcc-6e795d0f": "therock-src-7-13-gfx1151-iree-libs-iree-third-party-flatcc-6e795d0f",
+        "therock-src-7-13-gfx1151-iree-libs-iree-third-party-llvm-project-053021c5": "therock-src-7-13-gfx1151-iree-libs-iree-third-party-llvm-project-053021c5",
+        "therock-src-7-13-gfx1151-iree-libs-iree-third-party-torch-mlir-decfc1a0": "therock-src-7-13-gfx1151-iree-libs-iree-third-party-torch-mlir-decfc1a0",
+        "therock-src-7-13-gfx1151-math-libs-libhipcxx-10b48ff4": "therock-src-7-13-gfx1151-math-libs-libhipcxx-10b48ff4",
+        "therock-src-7-13-gfx1151-rocm-libraries-36c771f3": "therock-src-7-13-gfx1151-rocm-libraries-36c771f3",
+        "therock-src-7-13-gfx1151-rocm-libraries-projects-miopen-fin-2766eaa9": "therock-src-7-13-gfx1151-rocm-libraries-projects-miopen-fin-2766eaa9",
+        "therock-src-7-13-gfx1151-rocm-libraries-shared-tensile-hostlibrarytests-googletest-dd647abc": "therock-src-7-13-gfx1151-rocm-libraries-shared-tensile-hostlibrarytests-googletest-dd647abc",
+        "therock-src-7-13-gfx1151-rocm-systems-9c0ec3e9": "therock-src-7-13-gfx1151-rocm-systems-9c0ec3e9",
+        "therock-src-7-13-gfx1151-rocm-systems-experimental-python-perfxpert-opencode-2fa84e1d": "therock-src-7-13-gfx1151-rocm-systems-experimental-python-perfxpert-opencode-2fa84e1d",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-compute-src-vendored-pyyaml-b64e5974": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-compute-src-vendored-pyyaml-b64e5974",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-plugin-perfetto-perfetto-4d7082cd": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-plugin-perfetto-perfetto-4d7082cd",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-register-external-fmt-93ca61ec": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-register-external-fmt-93ca61ec",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-register-external-glog-da9d9e82": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-register-external-glog-da9d9e82",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-abseil-cpp-471579c4": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-abseil-cpp-471579c4",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-cereal-7f708e93": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-cereal-7f708e93",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-doxygen-awesome-c-15f99d59": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-doxygen-awesome-c-15f99d59",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-elfio-cf38c296": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-elfio-cf38c296",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-filesystem-807165f4": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-filesystem-807165f4",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-fmt-90ac0bf5": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-fmt-90ac0bf5",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-googletest-0a626aae": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-googletest-0a626aae",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-gotcha-10fa2c98": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-gotcha-10fa2c98",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-json-a3f85fd2": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-json-a3f85fd2",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-perfetto-9d309359": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-perfetto-9d309359",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-ptl-db721fa0": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-ptl-db721fa0",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-pybind11-6da66437": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-pybind11-6da66437",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-sqlite-373e906e": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-sqlite-373e906e",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-yaml-cpp-1bef3305": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-yaml-cpp-1bef3305",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-examples-lulesh-extern-cd755d3c": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-examples-lulesh-extern-cd755d3c",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-examples-openmp-extern-2e954ae7": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-examples-openmp-extern-2e954ae7",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-dyninst-5f477976": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-dyninst-5f477976",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-elfio-5047d340": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-elfio-5047d340",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-filesystem-ded63cc0": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-filesystem-ded63cc0",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-googletest-88801747": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-googletest-88801747",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-json-ef3d2b7e": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-json-ef3d2b7e",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-onetbb-9159eae3": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-onetbb-9159eae3",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-papi-ae8ec169": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-papi-ae8ec169",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-perfetto-c27c4344": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-perfetto-c27c4344",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-pybind11-92d9411d": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-pybind11-92d9411d",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-spdlog-1f6adb92": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-spdlog-1f6adb92",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-sqlite-1519e496": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-sqlite-1519e496",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-1cc6846c": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-1cc6846c",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-742cff1f": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-742cff1f",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-811a2531": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-811a2531",
+        "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf": "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf",
+        "therock-src-7-13-gfx1151-root": "therock-src-7-13-gfx1151-root",
+        "therock-src-7-13-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c": "therock-src-7-13-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c",
+        "vllm-src": "vllm-src",
+        "xdna-driver-src": "xdna-driver-src",
+        "xrt-src": "xrt-src"
+      },
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "therock-src-7-13-gfx1151-base-half-011b45bd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750971477,
+        "narHash": "sha256-If9O5BEeymsLN+C0drZsPSxEWXpJTxeDBGNHNXSumm4=",
+        "owner": "ROCm",
+        "repo": "half",
+        "rev": "207ee58595a64b5c4a70df221f1e6e704b807811",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "half",
+        "rev": "207ee58595a64b5c4a70df221f1e6e704b807811",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755709169,
+        "narHash": "sha256-im6UO0crO0Jc27zkTsdvJYPHit8IGlw/vDPGrmP1XqY=",
+        "owner": "ROCm",
+        "repo": "rocm-cmake",
+        "rev": "10155d7272ea1bf79f6b5a9dbc339657af1aa372",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocm-cmake",
+        "rev": "10155d7272ea1bf79f6b5a9dbc339657af1aa372",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-compiler-amd-llvm-1e702164": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775758359,
+        "narHash": "sha256-HT90H9iYf1gAnVFnxIVA+umB3WAlJ4MrszFcq3m8evA=",
+        "owner": "ROCm",
+        "repo": "llvm-project",
+        "rev": "43215c73116c407735c85a180d174f718798c328",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "llvm-project",
+        "rev": "43215c73116c407735c85a180d174f718798c328",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-compiler-hipify-ea979a85": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775160183,
+        "narHash": "sha256-P6xoQfXuCdLZMe1msIrjBF4LsrBihRQNwHczQ/KIxwM=",
+        "owner": "ROCm",
+        "repo": "HIPIFY",
+        "rev": "0f3db9c13669d702e12023ae2bfe0882daab63d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "HIPIFY",
+        "rev": "0f3db9c13669d702e12023ae2bfe0882daab63d5",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-compiler-spirv-llvm-translator-b9250448": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773242135,
+        "narHash": "sha256-z8rLRexprM5NCR0qWUQfO3PYEodeDt+n68llJfWWA4U=",
+        "owner": "ROCm",
+        "repo": "SPIRV-LLVM-Translator",
+        "rev": "aa7c842d4ec5b7015022ae6c6b91a4365bb6b91d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "SPIRV-LLVM-Translator",
+        "rev": "aa7c842d4ec5b7015022ae6c6b91a4365bb6b91d",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-debug-tools-rocgdb-source-e3322990": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777444625,
+        "narHash": "sha256-Ixg6Y/STxokPL1b2N/FGoF3Z1pyPihFTKgxkl5huWA0=",
+        "owner": "ROCm",
+        "repo": "rocgdb",
+        "rev": "c0a785c918a76c63328b774f244aca8f3d9a9dc7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocgdb",
+        "rev": "c0a785c918a76c63328b774f244aca8f3d9a9dc7",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-iree-libs-fusilli-e6b3e4e6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776705074,
+        "narHash": "sha256-1datmhDhyv7CO/ewzvrv7GQhOdXceST4Oq6PYjIyNGE=",
+        "owner": "iree-org",
+        "repo": "fusilli",
+        "rev": "aeed46fe35604c9f055f35005b95dc7e8f56633e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iree-org",
+        "repo": "fusilli",
+        "rev": "aeed46fe35604c9f055f35005b95dc7e8f56633e",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-iree-libs-iree-89b77fa6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776290642,
+        "narHash": "sha256-G+xVMfdmMC2xxdC4PHQl3Gfnpl2v8+Az8EZDWuYrV+w=",
+        "owner": "iree-org",
+        "repo": "iree",
+        "rev": "192602f8a7680467e608480debdb2ed6062d0f4d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iree-org",
+        "repo": "iree",
+        "rev": "192602f8a7680467e608480debdb2ed6062d0f4d",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-iree-libs-iree-third-party-benchmark-0f3f8fcb": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769001408,
+        "narHash": "sha256-Mm4pG7zMB00iof32CxreoNBFnduPZTMp3reHMCIAFPQ=",
+        "owner": "google",
+        "repo": "benchmark",
+        "rev": "192ef10025eb2c4cdd392bc502f0c852196baa48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "benchmark",
+        "rev": "192ef10025eb2c4cdd392bc502f0c852196baa48",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-iree-libs-iree-third-party-flatcc-6e795d0f": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715669061,
+        "narHash": "sha256-umZ9TvNYDZtF/mNwQUGuhAGve0kPw7uXkaaQX0EzkBY=",
+        "owner": "dvidelabs",
+        "repo": "flatcc",
+        "rev": "9362cd00f0007d8cbee7bff86e90fb4b6b227ff3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dvidelabs",
+        "repo": "flatcc",
+        "rev": "9362cd00f0007d8cbee7bff86e90fb4b6b227ff3",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-iree-libs-iree-third-party-llvm-project-053021c5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776242053,
+        "narHash": "sha256-7nW0K12+amR4/SRx0imYJ13fLSS+V0jt/G9slIhrNDY=",
+        "owner": "iree-org",
+        "repo": "llvm-project",
+        "rev": "738ead2c739a6b1999db63a187185d00e534c747",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iree-org",
+        "repo": "llvm-project",
+        "rev": "738ead2c739a6b1999db63a187185d00e534c747",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-iree-libs-iree-third-party-torch-mlir-decfc1a0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775762358,
+        "narHash": "sha256-ZrX7dmRLr6JRRG1SR+mOnbPACAckCv/72kJNRaAMdwQ=",
+        "owner": "iree-org",
+        "repo": "torch-mlir",
+        "rev": "172a8b4d5caddbb3af9045f7329dd4121b590cbf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "iree-org",
+        "repo": "torch-mlir",
+        "rev": "172a8b4d5caddbb3af9045f7329dd4121b590cbf",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-math-libs-libhipcxx-10b48ff4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1775727117,
+        "narHash": "sha256-inGIa8ay3s/WHLywSWrhkRFyab2uasujZkWSzIDH31w=",
+        "owner": "ROCm",
+        "repo": "libhipcxx",
+        "rev": "bc2b452b8c86ab65ba53e79e292b6c121e21a573",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "libhipcxx",
+        "rev": "bc2b452b8c86ab65ba53e79e292b6c121e21a573",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-libraries-36c771f3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778106828,
+        "narHash": "sha256-KHSqf8c/6pOEWs6ncXO20Q56OghOgjYYtvbnWMveQfs=",
+        "owner": "ROCm",
+        "repo": "rocm-libraries",
+        "rev": "f664f44c90ae22e860738f8c9793a019eb1975e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocm-libraries",
+        "rev": "f664f44c90ae22e860738f8c9793a019eb1975e1",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-libraries-projects-miopen-fin-2766eaa9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1772807229,
+        "narHash": "sha256-nsZWdztj/ade2jLL1/NMRDDzR1NZBGn48hj9oJte+R0=",
+        "owner": "ROCm",
+        "repo": "MIFin",
+        "rev": "06650bddfe40c47294b0414e4262691333b788dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "MIFin",
+        "rev": "06650bddfe40c47294b0414e4262691333b788dd",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-libraries-shared-tensile-hostlibrarytests-googletest-dd647abc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1623433346,
+        "narHash": "sha256-SjlJxushfry13RGA7BCjYC9oZqV4z6x8dOiHfl/wpF0=",
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "e2239ee6043f73722e7aa812a459f54a28552929",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "e2239ee6043f73722e7aa812a459f54a28552929",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-9c0ec3e9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777684081,
+        "narHash": "sha256-29KFvZHujDv5LrM2Ye+VV3xf6zIiuLKsbR2Cx+yK3lc=",
+        "owner": "ROCm",
+        "repo": "rocm-systems",
+        "rev": "79e85e1468f96a867108043c953e9547c13b4c5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "rocm-systems",
+        "rev": "79e85e1468f96a867108043c953e9547c13b4c5e",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-experimental-python-perfxpert-opencode-2fa84e1d": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776472156,
+        "narHash": "sha256-jlxR2BODV8wk0sP4Kkyza7Zr5I+Q003gldCfp2eYOt8=",
+        "owner": "sst",
+        "repo": "opencode",
+        "rev": "a35b8a95c27d28e979a3826e1289d7ee87f40251",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sst",
+        "repo": "opencode",
+        "rev": "a35b8a95c27d28e979a3826e1289d7ee87f40251",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-compute-src-vendored-pyyaml-b64e5974": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758834645,
+        "narHash": "sha256-jUooIBp80cLxvdU/zLF0X8Yjrf0Yp9peYeiFjuV8AHA=",
+        "owner": "yaml",
+        "repo": "pyyaml",
+        "rev": "49790e73684bebad1df05ef8d828fa12f685bffb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yaml",
+        "repo": "pyyaml",
+        "rev": "49790e73684bebad1df05ef8d828fa12f685bffb",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-plugin-perfetto-perfetto-4d7082cd": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712741208,
+        "narHash": "sha256-9v4kUKpOLosGayu+GhhPOW/+NXSjX5Lngbt8YJ3KxFM=",
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "eb5ef24c58d13cec289d733d03f0f3f0ed321b12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "eb5ef24c58d13cec289d733d03f0f3f0ed321b12",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-register-external-fmt-93ca61ec": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740593668,
+        "narHash": "sha256-sUbxlYi/Aupaox3JjWFqXIjcaQa0LFjclQAOleT+FRA=",
+        "owner": "fmtlib",
+        "repo": "fmt",
+        "rev": "123913715afeb8a437e6388b4473fcc4753e1c9a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fmtlib",
+        "repo": "fmt",
+        "rev": "123913715afeb8a437e6388b4473fcc4753e1c9a",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-register-external-glog-da9d9e82": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717859254,
+        "narHash": "sha256-+nwWP6VBmhgU7GCPSEGUzvUSCc48wXME181WpJ5ABP4=",
+        "owner": "google",
+        "repo": "glog",
+        "rev": "7b134a5c82c0c0b5698bb6bf7a835b230c5638e4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "glog",
+        "rev": "7b134a5c82c0c0b5698bb6bf7a835b230c5638e4",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-abseil-cpp-471579c4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1770824088,
+        "narHash": "sha256-TJT2Kzc64zI42FAbbGWP3Sshh1dU/D/AtEpgZrrhebg=",
+        "owner": "abseil",
+        "repo": "abseil-cpp",
+        "rev": "255c84dadd029fd8ad25c5efb5933e47beaa00c7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "abseil",
+        "repo": "abseil-cpp",
+        "rev": "255c84dadd029fd8ad25c5efb5933e47beaa00c7",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-cereal-7f708e93": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1760484697,
+        "narHash": "sha256-iNg1U0g4Opj3VcZ2cv1q6hxXHio601KubCchNyfbih4=",
+        "owner": "jrmadsen",
+        "repo": "cereal",
+        "rev": "40a30defcb8874270a04836d316502b08904b2bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "cereal",
+        "rev": "40a30defcb8874270a04836d316502b08904b2bc",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-doxygen-awesome-c-15f99d59": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1685630484,
+        "narHash": "sha256-WlLf0cHskFNC0M5CqFNfmEIzOzTocesqOqgawz4fpNY=",
+        "owner": "jothepro",
+        "repo": "doxygen-awesome-css",
+        "rev": "df83fbf22cfff76b875c13d324baf584c74e96d0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jothepro",
+        "repo": "doxygen-awesome-css",
+        "rev": "df83fbf22cfff76b875c13d324baf584c74e96d0",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-elfio-cf38c296": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755240366,
+        "narHash": "sha256-XvSK/OfH/krsiH3Tm/LdeuW9DePWGN8qHk8DDfzcP/Y=",
+        "owner": "serge1",
+        "repo": "ELFIO",
+        "rev": "575bfdb12cd90fa8913660295103549f151d116a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serge1",
+        "repo": "ELFIO",
+        "rev": "575bfdb12cd90fa8913660295103549f151d116a",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-filesystem-807165f4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678018010,
+        "narHash": "sha256-XZ0IxyNIAs2tegktOGQevkLPbWHam/AOFT+M6wAWPFg=",
+        "owner": "gulrak",
+        "repo": "filesystem",
+        "rev": "8a2edd6d92ed820521d42c94d179462bf06b5ed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gulrak",
+        "repo": "filesystem",
+        "rev": "8a2edd6d92ed820521d42c94d179462bf06b5ed3",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-fmt-90ac0bf5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761748827,
+        "narHash": "sha256-ZmI1Dv0ZabPlxa02OpERI47jp7zFfjpeWCy1WyuPYZ0=",
+        "owner": "fmtlib",
+        "repo": "fmt",
+        "rev": "407c905e45ad75fc29bf0f9bb7c5c2fd3475976f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "fmtlib",
+        "repo": "fmt",
+        "rev": "407c905e45ad75fc29bf0f9bb7c5c2fd3475976f",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-googletest-0a626aae": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1691440787,
+        "narHash": "sha256-IINzCiAegOdxR0MZ3R2feHcUXk8+eRUcqVfjQ3a1qNE=",
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "46db91ef6ffcc128b2d5f31118ae1108109e3400",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "46db91ef6ffcc128b2d5f31118ae1108109e3400",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-gotcha-10fa2c98": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755016804,
+        "narHash": "sha256-FxCCtJnWFod5VXqfb+r0XlfcCAtcjNwfIsVhjUPlRQU=",
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "b944da10ff9b3364ef2e4b12e02cb2464e05dd48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "b944da10ff9b3364ef2e4b12e02cb2464e05dd48",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-json-a3f85fd2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1732727001,
+        "narHash": "sha256-jqk9TS8qvucsZaK6HS5NNyFYnkyxQLNloF6pFtSrzMQ=",
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "e41905fcb0938a7502d25ea5242c6b41396e21b0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "e41905fcb0938a7502d25ea5242c6b41396e21b0",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-perfetto-9d309359": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1712741208,
+        "narHash": "sha256-9v4kUKpOLosGayu+GhhPOW/+NXSjX5Lngbt8YJ3KxFM=",
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "eb5ef24c58d13cec289d733d03f0f3f0ed321b12",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "eb5ef24c58d13cec289d733d03f0f3f0ed321b12",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-ptl-db721fa0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1709321309,
+        "narHash": "sha256-DZQUjg8l1n6iPx9OCn3W3tt2vcwnQfgijCoIKjywF8I=",
+        "owner": "jrmadsen",
+        "repo": "PTL",
+        "rev": "48df41625430d27ce43cf197fd467a8dda87cb45",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "PTL",
+        "rev": "48df41625430d27ce43cf197fd467a8dda87cb45",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-pybind11-6da66437": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1648696333,
+        "narHash": "sha256-O3bkexUBa+gfiJEM6KSR8y/iVqHqlCFmz/9EghxdIpw=",
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "914c06fb252b6cc3727d0eedab6736e88a3fcb01",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pybind",
+        "repo": "pybind11",
+        "rev": "914c06fb252b6cc3727d0eedab6736e88a3fcb01",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-sqlite-373e906e": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729528222,
+        "narHash": "sha256-35xrRPgoj92rji9EAyCHvhMP/NEz9hffOMJyhSKCCZ8=",
+        "owner": "sqlite",
+        "repo": "sqlite",
+        "rev": "f5fb820c0f4781337faf02ed871be68d13a83d94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sqlite",
+        "repo": "sqlite",
+        "rev": "f5fb820c0f4781337faf02ed871be68d13a83d94",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-sdk-external-yaml-cpp-1bef3305": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1724012355,
+        "narHash": "sha256-3uYp9n6dKr07YdYZVjRSZCWm6ZV+sx9pVWoEg9gFuE4=",
+        "owner": "jbeder",
+        "repo": "yaml-cpp",
+        "rev": "7b469b4220f96fb3d036cf68cd7bd30bd39e61d2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jbeder",
+        "repo": "yaml-cpp",
+        "rev": "7b469b4220f96fb3d036cf68cd7bd30bd39e61d2",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-examples-lulesh-extern-cd755d3c": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1684776431,
+        "narHash": "sha256-AlvXepz6utnZzutXmBBa6sgSYQuctgaruZ7wlTuhh5w=",
+        "owner": "kokkos",
+        "repo": "kokkos",
+        "rev": "1a0c2ff6daf1068c65529ec04c2c046177847869",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kokkos",
+        "repo": "kokkos",
+        "rev": "1a0c2ff6daf1068c65529ec04c2c046177847869",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-examples-openmp-extern-2e954ae7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756400461,
+        "narHash": "sha256-zhC40CfNSuvF4YgAVRI4yMz+clbXNf+f94eVmbNIME0=",
+        "owner": "OpenMP-Validation-and-Verification",
+        "repo": "OpenMP_VV",
+        "rev": "2d06fc22ac62f418cb02c435f08b7e46bb8f3c5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "OpenMP-Validation-and-Verification",
+        "repo": "OpenMP_VV",
+        "rev": "2d06fc22ac62f418cb02c435f08b7e46bb8f3c5b",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-dyninst-5f477976": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776723314,
+        "narHash": "sha256-CqzcTdNu8UwMtlnEBdtfXTgFacZdm8YkH51XRGVqUBk=",
+        "owner": "ROCm",
+        "repo": "dyninst",
+        "rev": "da38f411d88540da46fbda1e811bcae47c1c8038",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "dyninst",
+        "rev": "da38f411d88540da46fbda1e811bcae47c1c8038",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-elfio-5047d340": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1671124066,
+        "narHash": "sha256-RjnOxOijzVRXnMkMlQpUZ9Mtr+ZT+T4RHel5SRZAIxQ=",
+        "owner": "jrmadsen",
+        "repo": "ELFIO",
+        "rev": "d00cc32f8b1ed85d22309fac10576a1baf8a4736",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "ELFIO",
+        "rev": "d00cc32f8b1ed85d22309fac10576a1baf8a4736",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-filesystem-ded63cc0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1678018010,
+        "narHash": "sha256-XZ0IxyNIAs2tegktOGQevkLPbWHam/AOFT+M6wAWPFg=",
+        "owner": "gulrak",
+        "repo": "filesystem",
+        "rev": "8a2edd6d92ed820521d42c94d179462bf06b5ed3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gulrak",
+        "repo": "filesystem",
+        "rev": "8a2edd6d92ed820521d42c94d179462bf06b5ed3",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-googletest-88801747": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761944160,
+        "narHash": "sha256-T8tE6bM+sNKVcLoQSZzRH1b8nGrdNdnPDpaDRFF+wwE=",
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "6ec14dfd8c409d05fba94e18e3a02df35b874353",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "googletest",
+        "rev": "6ec14dfd8c409d05fba94e18e3a02df35b874353",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-json-ef3d2b7e": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1744360948,
+        "narHash": "sha256-cECvDOLxgX7Q9R3IE86Hj9JJUxraDQvhoyPDF03B2CY=",
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "55f93686c01528224f448c19128836e7df245f72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nlohmann",
+        "repo": "json",
+        "rev": "55f93686c01528224f448c19128836e7df245f72",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-onetbb-9159eae3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761737496,
+        "narHash": "sha256-HIHF6KHlEI4rgQ9Epe0+DmNe1y95K9iYa4V/wFnJfEU=",
+        "owner": "uxlfoundation",
+        "repo": "oneTBB",
+        "rev": "f1862f38f83568d96e814e469ab61f88336cc595",
+        "type": "github"
+      },
+      "original": {
+        "owner": "uxlfoundation",
+        "repo": "oneTBB",
+        "rev": "f1862f38f83568d96e814e469ab61f88336cc595",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-papi-ae8ec169": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773687226,
+        "narHash": "sha256-iII6W6HZXsHRgqniO5IH2GDjhl1JcwhYdhWuIE8Lymk=",
+        "owner": "icl-utk-edu",
+        "repo": "papi",
+        "rev": "c27003e1642f1c151c9b18ef9e7610072b3c852d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "icl-utk-edu",
+        "repo": "papi",
+        "rev": "c27003e1642f1c151c9b18ef9e7610072b3c852d",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-perfetto-c27c4344": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1718298493,
+        "narHash": "sha256-L7RnOQmD74JFpa10mNwXcLV8YyyjaQ7qYx9eXJpizpw=",
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "35b3d9845c2f4017865c4dc93fafcf6d202f1651",
+        "type": "github"
+      },
+      "original": {
+        "owner": "google",
+        "repo": "perfetto",
+        "rev": "35b3d9845c2f4017865c4dc93fafcf6d202f1651",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-pybind11-92d9411d": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689348038,
+        "narHash": "sha256-r0b1Wr/PtTk4kHOVhgSy3gi/GLED774Ys49J1E7B7WQ=",
+        "owner": "jrmadsen",
+        "repo": "pybind11",
+        "rev": "1a917f1852eb7819b671fc3fa862840f4c491a07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "pybind11",
+        "rev": "1a917f1852eb7819b671fc3fa862840f4c491a07",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-spdlog-1f6adb92": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1760187185,
+        "narHash": "sha256-VB82cNfpJlamUjrQFYElcy0CXAbkPqZkD5zhuLeHLzs=",
+        "owner": "gabime",
+        "repo": "spdlog",
+        "rev": "486b55554f11c9cccc913e11a87085b2a91f706f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gabime",
+        "repo": "spdlog",
+        "rev": "486b55554f11c9cccc913e11a87085b2a91f706f",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-sqlite-1519e496": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773398289,
+        "narHash": "sha256-Fa4Sk67URTSRYRTRdrpElGi/5aX2pEmCg7LdcjounjE=",
+        "owner": "sqlite",
+        "repo": "sqlite",
+        "rev": "a5333afb9ad1aa473f8963b92caeaa955f47dc74",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sqlite",
+        "repo": "sqlite",
+        "rev": "a5333afb9ad1aa473f8963b92caeaa955f47dc74",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-1cc6846c": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664927513,
+        "narHash": "sha256-MWdkZY255bVYLzUhV1BxMPb+LbM3dtDkg1M4AhrB2rQ=",
+        "owner": "jrmadsen",
+        "repo": "yaml-cpp",
+        "rev": "1b50109f7bea60bd382d8ea7befce3d2bd67da5f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jrmadsen",
+        "repo": "yaml-cpp",
+        "rev": "1b50109f7bea60bd382d8ea7befce3d2bd67da5f",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-742cff1f": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690716675,
+        "narHash": "sha256-z5YCue0zadQnMEbGFniFvDjXNy6dSHQDQnXRXS6Uh/Y=",
+        "owner": "libunwind",
+        "repo": "libunwind",
+        "rev": "24947191d61dda869e039e0414fe97e9f594acd5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libunwind",
+        "repo": "libunwind",
+        "rev": "24947191d61dda869e039e0414fe97e9f594acd5",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-exte-811a2531": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752612818,
+        "narHash": "sha256-KHTPiNCzYtIsGcSwjVwFSIgO+GZgdBkruMfv1HNxzYk=",
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "6ef1232a0acc99f3340c2ca4c5d23890e9b8a459",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "GOTCHA",
+        "rev": "6ef1232a0acc99f3340c2ca4c5d23890e9b8a459",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-rocm-systems-projects-rocprofiler-systems-external-timemory-fb6426bf": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777543823,
+        "narHash": "sha256-/5H5kGwC+/EIULnI5l17HI8lMZz/g8Q+euqcXYQt0t4=",
+        "owner": "ROCm",
+        "repo": "timemory",
+        "rev": "6b967ed717a3263a91663a1662616acddade023f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "timemory",
+        "rev": "6b967ed717a3263a91663a1662616acddade023f",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-root": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778536557,
+        "narHash": "sha256-ZNzvu1sOnIfVz/qLwO0iXM7crNWkvQ47S1QKa4ASzig=",
+        "owner": "ROCm",
+        "repo": "TheRock",
+        "rev": "6d2136cd12be28c6251eb38c700e980c8c2f8cf6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "TheRock",
+        "rev": "6d2136cd12be28c6251eb38c700e980c8c2f8cf6",
+        "type": "github"
+      }
+    },
+    "therock-src-7-13-gfx1151-third-party-sysdeps-linux-amd-mesa-mesa-fork-a692c85c": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1773933946,
+        "narHash": "sha256-l2rUVDON9CMnFgoorSohb40+sBTjR7apkO6G4PSsajg=",
+        "owner": "ROCm",
+        "repo": "mesa-fork",
+        "rev": "9a0d5b03fd540cb2448c64bbda17dbf17ccb12bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ROCm",
+        "repo": "mesa-fork",
+        "rev": "9a0d5b03fd540cb2448c64bbda17dbf17ccb12bf",
+        "type": "github"
+      }
+    },
+    "vllm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778819314,
+        "narHash": "sha256-lVgzo6R+l86IH5yxCtfJckVCP86jlgN7ufF5i0Pn2/A=",
+        "owner": "vllm-project",
+        "repo": "vllm",
+        "rev": "ad7125a431e176d4161099480a66f0169609a690",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vllm-project",
+        "ref": "v0.21.0",
+        "repo": "vllm",
+        "type": "github"
+      }
+    },
+    "xdna-driver-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779227778,
+        "narHash": "sha256-srpsvE7Np9gev0K/vXtlc8WownzX+oZVwLMLxU89qQ0=",
+        "ref": "1.7",
+        "rev": "944ca35a395b7dfa37ac3f437f1da48feca7bffc",
+        "revCount": 871,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/amd/xdna-driver"
+      },
+      "original": {
+        "ref": "1.7",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/amd/xdna-driver"
+      }
+    },
+    "xrt-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1779224521,
+        "narHash": "sha256-xErKqZFOFiY+k0o1L8bki6kPwahba66hOxvuj4czXh4=",
+        "ref": "XRT-2.21",
+        "rev": "c14df528b9e98ef1ecaf05f5720ef05d9158dc22",
+        "revCount": 8683,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Xilinx/XRT"
+      },
+      "original": {
+        "ref": "XRT-2.21",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/Xilinx/XRT"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
Adds the lock file for the Hydra benchmark wrapper so Hydra can evaluate the remote flake without trying to write a lock into the fetched source.