### PR TITLE
ci: constrain benchmark Hydra jobs

### DIFF
--- a/hydra/benchmark/flake.lock
+++ b/hydra/benchmark/flake.lock
@@ -83,6 +83,10 @@
     },
     "root": {
       "inputs": {
+        "nixpkgs": [
+          "src",
+          "nixpkgs"
+        ],
         "src": "src"
       }
     },

--- a/hydra/benchmark/flake.nix
+++ b/hydra/benchmark/flake.nix
@@ -2,8 +2,26 @@
   description = "Hydra benchmark job wrapper";
 
   inputs.src.url = "path:../..";
+  inputs.nixpkgs.follows = "src/nixpkgs";
 
-  outputs = { src, ... }: {
-    hydraJobs = src.benchmarks;
-  };
+  outputs =
+    { nixpkgs, src, ... }:
+    let
+      inherit (nixpkgs) lib;
+
+      benchmarkSystems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+
+      addBenchmarkFeature =
+        drv:
+        drv.overrideAttrs (old: {
+          requiredSystemFeatures = lib.unique ((old.requiredSystemFeatures or [ ]) ++ [ "benchmark" ]);
+        });
+    in
+    {
+      hydraJobs = lib.genAttrs benchmarkSystems (system:
+        lib.mapAttrs (_: addBenchmarkFeature) src.benchmarks.${system});
+    };
 }


### PR DESCRIPTION
Limits the benchmark Hydra wrapper to benchmark-capable systems for now and marks exported benchmark derivations with the benchmark feature so they do not run on general builders.