### PR TITLE
ci: filter unsupported benchmark jobs

### DIFF
--- a/hydra/benchmark/flake.nix
+++ b/hydra/benchmark/flake.nix
@@ -14,14 +14,30 @@
         "aarch64-darwin"
       ];
 
+      supportedFeatures = {
+        x86_64-linux = [
+          "benchmark"
+          "gfx1151"
+        ];
+        aarch64-darwin = [ "benchmark" ];
+      };
+
       addBenchmarkFeature =
         drv:
         drv.overrideAttrs (old: {
           requiredSystemFeatures = lib.unique ((old.requiredSystemFeatures or [ ]) ++ [ "benchmark" ]);
         });
+
+      supportedOn =
+        system: drv:
+        lib.all
+          (feature: lib.elem feature supportedFeatures.${system})
+          (drv.requiredSystemFeatures or [ ]);
     in
     {
       hydraJobs = lib.genAttrs benchmarkSystems (system:
-        lib.mapAttrs (_: addBenchmarkFeature) src.benchmarks.${system});
+        lib.filterAttrs (_: supportedOn system) (
+          lib.mapAttrs (_: addBenchmarkFeature) src.benchmarks.${system}
+        ));
     };
 }


### PR DESCRIPTION
Filters the benchmark Hydra wrapper to the feature sets currently backed by benchmark machines. This keeps xdna2 jobs out until we have an NPU-capable benchmark host advertised to Hydra.