### PR TITLE
fevm-faex9-live: add USB-bootable live image

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Main package outputs:
 - `packages.x86_64-linux.llama-cpp-rocm-gfx1151`
 - `packages.x86_64-linux.llama-cpp-vulkan`
 - `packages.x86_64-linux.ec-su-axb35-monitor`
+- `packages.x86_64-linux.fevm-faex9-live-iso`
 - `packages.x86_64-linux.strix-halo-mes-firmware`
 - `packages.x86_64-linux.vllm-rocm-therock-gfx1151`
 - `packages.x86_64-linux.xrt-amdxdna`
@@ -61,9 +62,10 @@ Main app outputs:
 - `apps.x86_64-linux.llama-server-gfx1151`
 - `apps.x86_64-linux.flm`
 
-Example configuration helper:
+Example configuration helpers:
 
 - `lib.mkFevmFaex9Configuration`
+- `lib.mkFevmFaex9LiveConfiguration`
 
 ## Use The Overlay
 
@@ -220,6 +222,27 @@ nix build --impure --file ./examples/fevm-faex9 \
   --arg diskoModule '(builtins.getFlake "github:nix-community/disko").nixosModules.disko' \
   config.system.build.toplevel
 ```
+
+## Live USB
+
+`fevm-faex9-live` wraps the same modules in a USB-flashable ISO built from
+`installer/cd-dvd/installation-cd-base.nix`. It boots into a NixOS live system
+with the Strix Halo tuning, MES firmware, AXB35 EC driver, and the
+`llama-cpp-rocm-gfx1151`, `llama-cpp-vulkan`, `fastflowlm`, and
+`ec-su-axb35-monitor` packages already installed.
+
+```bash
+nix build .#fevm-faex9-live-iso
+sudo dd if=$(readlink -f result)/iso/*.iso of=/dev/sdX bs=4M conv=fsync status=progress
+```
+
+The installer profile creates a passwordless `nixos` user (sudo via `wheel`)
+and enables `sshd` and NetworkManager. Same as upstream NixOS installer
+images: set a password with `passwd` or drop a key in
+`~nixos/.ssh/authorized_keys` before exposing the box.
+
+`lib.mkFevmFaex9LiveConfiguration` is the reusable helper if you want to add
+extra modules or override defaults from a downstream flake.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ images: set a password with `passwd` or drop a key in
 `lib.mkFevmFaex9LiveConfiguration` is the reusable helper if you want to add
 extra modules or override defaults from a downstream flake.
 
+To smoke-test the image without writing to a USB stick, boot it in QEMU. The
+wrapper enables KVM when `/dev/kvm` is writable and accepts pass-through
+`qemu-system-x86_64` arguments:
+
+```bash
+nix run .#fevm-faex9-live-iso-vm
+# headless / VNC for remote hosts:
+nix run .#fevm-faex9-live-iso-vm -- -display none -vnc :0
+# tune resources:
+FEVM_LIVE_VM_MEM=8G FEVM_LIVE_VM_CPUS=8 nix run .#fevm-faex9-live-iso-vm
+```
+
 ## Benchmarks
 
 Benchmark derivations are generated from structured tool/model/scenario records and exposed under `benchmarks.<system>`. The default cross-platform matrix runs CPU `llama-bench` against local GGUF files under the platform model root. Linux uses `/models`; Darwin uses `/Users/Shared/models`. Linux also exposes this flake's ROCm and Vulkan llama.cpp tool variants.

--- a/examples/fevm-faex9-live/configuration.nix
+++ b/examples/fevm-faex9-live/configuration.nix
@@ -1,0 +1,51 @@
+# Live USB / installation image variant of the fevm-faex9 example.
+# Builds a USB-flashable ISO with the strix-halo overlay and tooling
+# pre-installed. Unlike `examples/fevm-faex9`, this configuration does not
+# include a host-specific disk layout or system bootloader; the installer
+# image module provides those for the live system itself.
+{
+  lib,
+  modulesPath,
+  pkgs,
+  inputs,
+  ...
+}:
+{
+  imports = [
+    "${modulesPath}/installer/cd-dvd/installation-cd-base.nix"
+
+    inputs.self.nixosModules.default
+    inputs.self.nixosModules.tuning
+    inputs.self.nixosModules.ec-su-axb35
+    inputs.self.nixosModules.rpc-server
+    inputs.self.nixosModules.fastflowlm-server
+  ];
+
+  # Strix Halo gfx1151 needs a recent kernel; the installer base defaults
+  # to the LTS line which lags behind.
+  boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
+
+  # Build the AXB35 EC kernel module into the image and load it at boot.
+  # The driver no-ops on non-AXB35 boards, so the live image stays bootable
+  # elsewhere while exposing fans/power controls on the target hardware.
+  services.ec-su-axb35.enable = lib.mkDefault true;
+
+  networking.hostName = lib.mkForce "fevm-faex9-live";
+
+  time.timeZone = lib.mkDefault "UTC";
+  i18n.defaultLocale = lib.mkDefault "en_US.UTF-8";
+
+  environment.systemPackages = with pkgs; [
+    llama-cpp-rocm-gfx1151
+    llama-cpp-vulkan
+    fastflowlm
+    ec-su-axb35-monitor
+    pciutils
+    usbutils
+    htop
+    tmux
+    vim
+  ];
+
+  isoImage.edition = lib.mkForce "fevm-faex9";
+}

--- a/examples/fevm-faex9-live/configuration.nix
+++ b/examples/fevm-faex9-live/configuration.nix
@@ -25,6 +25,13 @@
   # to the LTS line which lags behind.
   boot.kernelPackages = lib.mkDefault pkgs.linuxPackages_latest;
 
+  # Serial console for headless boots and the QEMU-based boot smoke test.
+  # `tty1` stays the primary console for users plugged into a monitor.
+  boot.kernelParams = [
+    "console=tty1"
+    "console=ttyS0,115200"
+  ];
+
   # Build the AXB35 EC kernel module into the image and load it at boot.
   # The driver no-ops on non-AXB35 boards, so the live image stays bootable
   # elsewhere while exposing fans/power controls on the target hardware.

--- a/examples/fevm-faex9-live/default.nix
+++ b/examples/fevm-faex9-live/default.nix
@@ -1,0 +1,13 @@
+{
+  nix-strix-halo ? builtins.getFlake (toString ../..),
+  system ? "x86_64-linux",
+  extraModules ? [ ],
+  specialArgs ? { },
+}:
+nix-strix-halo.lib.mkFevmFaex9LiveConfiguration {
+  inherit
+    extraModules
+    specialArgs
+    system
+    ;
+}

--- a/flake.nix
+++ b/flake.nix
@@ -572,12 +572,31 @@
           ]
           ++ extraModules;
         };
+
+      mkFevmFaex9LiveConfiguration =
+        {
+          system ? "x86_64-linux",
+          extraModules ? [ ],
+          specialArgs ? { },
+        }:
+        nixpkgs.lib.nixosSystem {
+          inherit system;
+          specialArgs = {
+            inherit inputs self;
+          }
+          // specialArgs;
+          modules = [
+            ./examples/fevm-faex9-live/configuration.nix
+          ]
+          ++ extraModules;
+        };
     in
     {
       lib = {
         inherit
           defaultTherockSources
           mkFevmFaex9Configuration
+          mkFevmFaex9LiveConfiguration
           mkTherockOverlays
           mkTherockPythonOverlay
           mkTherockRocmOverlay
@@ -748,6 +767,7 @@
 
       nixosConfigurations = {
         fevm-faex9 = mkFevmFaex9Configuration { };
+        fevm-faex9-live = mkFevmFaex9LiveConfiguration { };
       };
 
       darwinModules = {
@@ -833,6 +853,7 @@
                 xrt-amdxdna
                 ;
               inherit (cudaPkgs) llama-cpp-cuda llama-cpp-master-cuda;
+              fevm-faex9-live-iso = self.nixosConfigurations.fevm-faex9-live.config.system.build.isoImage;
             }
             // ds4RocmPackages
             // llamaCppTargetPackages
@@ -1457,6 +1478,9 @@
           }
           // lib.optionalAttrs (system == "x86_64-linux") {
             system = afterPrQuick "system" self.nixosConfigurations.fevm-faex9.config.system.build.toplevel;
+            fevm-faex9-live-iso =
+              afterPrQuick "fevm-faex9-live-iso"
+                self.packages.${system}.fevm-faex9-live-iso;
             vllm =
               afterPrQuick "vllm"
                 self.packages.${system}."vllm-rocm-therock-${defaultRocmTarget.packageSuffix}";

--- a/flake.nix
+++ b/flake.nix
@@ -974,6 +974,36 @@
               binary = "flm";
               description = "Run the FastFlowLM CLI on AMD Ryzen AI NPUs";
             };
+
+            fevm-faex9-live-iso-vm =
+              let
+                iso = self.packages.${system}.fevm-faex9-live-iso;
+              in
+              {
+                type = "app";
+                program = toString (
+                  pkgs.writeShellScript "fevm-faex9-live-iso-vm" ''
+                    set -euo pipefail
+                    iso_file=$(echo ${iso}/iso/*.iso)
+                    if [ ! -f "$iso_file" ]; then
+                      echo "fevm-faex9-live ISO not found under ${iso}/iso" >&2
+                      exit 1
+                    fi
+                    kvm_args=()
+                    if [ -w /dev/kvm ]; then
+                      kvm_args+=(-enable-kvm -cpu host)
+                    fi
+                    exec ${pkgs.qemu}/bin/qemu-system-x86_64 \
+                      "''${kvm_args[@]}" \
+                      -m ''${FEVM_LIVE_VM_MEM:-4G} \
+                      -smp ''${FEVM_LIVE_VM_CPUS:-4} \
+                      -cdrom "$iso_file" \
+                      -boot d \
+                      "$@"
+                  ''
+                );
+                meta.description = "Boot the fevm-faex9 live ISO in QEMU (override FEVM_LIVE_VM_MEM, FEVM_LIVE_VM_CPUS)";
+              };
           }
           // (lib.foldl' lib.recursiveUpdate { } (map mkTargetLlamaApps rocmTargets))
           // lib.optionalAttrs (builtins.hasAttr "therock-rocm-${s}-env" pkgs) {

--- a/flake.nix
+++ b/flake.nix
@@ -1422,6 +1422,66 @@
             package-fastflowlm = pkgs.fastflowlm;
             package-strix-halo-mes-firmware = pkgs.strix-halo-mes-firmware;
             "therock-pytorch-${s}" = pkgs.${therockPytorchPackage};
+
+            fevm-faex9-live-iso-boot =
+              let
+                iso = self.packages.${system}.fevm-faex9-live-iso;
+              in
+              pkgs.runCommand "ci-fevm-faex9-live-iso-boot"
+                {
+                  nativeBuildInputs = [
+                    pkgs.qemu_test
+                    pkgs.expect
+                  ];
+                  requiredSystemFeatures = [
+                    "kvm"
+                    "nixos-test"
+                  ];
+                  meta.timeout = 900;
+                }
+                ''
+                  set -euo pipefail
+                  iso_file=$(echo ${iso}/iso/*.iso)
+                  if [ ! -f "$iso_file" ]; then
+                    echo "ISO not found at $iso_file" >&2
+                    exit 1
+                  fi
+
+                  echo "Booting $iso_file in QEMU..."
+
+                  ISO_FILE=$iso_file expect <<'EXPECT'
+                    set timeout 300
+                    spawn qemu-system-x86_64 \
+                      -enable-kvm \
+                      -cpu host \
+                      -m 2G \
+                      -smp 2 \
+                      -cdrom $env(ISO_FILE) \
+                      -boot d \
+                      -nographic \
+                      -no-reboot
+                    expect {
+                      "fevm-faex9-live login: nixos (automatic login)" {
+                        send_user "\n>>> auto-login OK\n"
+                      }
+                      timeout { send_user "\n!!! TIMEOUT waiting for login prompt\n"; exit 1 }
+                      eof { send_user "\n!!! VM exited before login prompt\n"; exit 1 }
+                    }
+                    expect {
+                      "fevm-faex9-live:" {
+                        send_user "\n>>> shell prompt OK\n"
+                      }
+                      timeout { send_user "\n!!! TIMEOUT waiting for shell prompt\n"; exit 1 }
+                    }
+                    send "command -v llama-cli && command -v flm && grep -F amd_iommu=pt /proc/cmdline && echo BOOTOK\r"
+                    expect {
+                      "BOOTOK" { send_user "\n>>> sanity checks OK\n"; exit 0 }
+                      timeout { send_user "\n!!! TIMEOUT during sanity checks\n"; exit 1 }
+                    }
+                  EXPECT
+
+                  touch "$out"
+                '';
           }
         )
         // lib.optionalAttrs pkgs.stdenv.isDarwin (


### PR DESCRIPTION
## Summary
- Add `examples/fevm-faex9-live` configuration that layers the strix-halo overlay, MES firmware/IOMMU tuning, and AXB35 EC driver on top of `installer/cd-dvd/installation-cd-base.nix`, producing a USB-flashable ISO with `llama-cpp-rocm-gfx1151`, `llama-cpp-vulkan`, `fastflowlm`, and `ec-su-axb35-monitor` pre-installed.
- Expose `packages.x86_64-linux.fevm-faex9-live-iso`, `nixosConfigurations.fevm-faex9-live`, `lib.mkFevmFaex9LiveConfiguration`, and a `pr-full.fevm-faex9-live-iso` Hydra job alongside the existing `system` job.
- Use `pkgs.linuxPackages_latest` (kernel 7.0.10) so the live image meets the gfx1151 minimum kernel requirement that the installer base's LTS line misses.

## Test plan
- [x] `nix flake show` — new outputs visible under packages/nixosConfigurations/hydraJobs.
- [x] `nix fmt -- --tree-root . --walk filesystem` — no formatting drift.
- [x] `nix run nixpkgs#deadnix -- --fail` and `nix run nixpkgs#statix -- check .` — clean on the new files.
- [x] `nix build .#fevm-faex9-live-iso --cores 32` — produces a 3.5G `nixos-fevm-faex9-26.05-x86_64.iso` reported by `file` as bootable ISO 9660 with DOS/MBR boot sector.
- [x] Eval check confirms: kernel 7.0.10, hostname `fevm-faex9-live`, `boot.kernelParams` includes `amd_iommu=pt` and `ttm.pages_limit=20971520` from `nixosModules.tuning`, ISO edition `fevm-faex9`, `services.ec-su-axb35.enable=true`, `services.tuned.enable=true`, `services.openssh.enable=true`, `users.users.nixos.initialHashedPassword=""`.
- [ ] Flash to USB and boot on actual fevm-faex9 hardware (left to follow-up; build artifact ready at `result/iso/*.iso`).