### PR TITLE
packages: add cross-platform JACCL and MLX

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,22 @@ Main package outputs:
 
 - `packages.aarch64-darwin.default`
 - `packages.aarch64-darwin.ds4`
+- `packages.aarch64-darwin.jaccl`
 - `packages.aarch64-darwin.llama-cpp`
+- `packages.aarch64-darwin.mlx`
+- `packages.aarch64-darwin.mlx-metal`
 - `packages.x86_64-linux.default`
 - `packages.x86_64-linux.ds4-rocm`
 - `packages.x86_64-linux.ds4-rocm-gfx1151`
 - `packages.x86_64-linux.fastflowlm`
+- `packages.x86_64-linux.jaccl`
 - `packages.x86_64-linux.llama-cpp`
 - `packages.x86_64-linux.llama-cpp-rocm`
 - `packages.x86_64-linux.llama-cpp-rocm-gfx1151`
 - `packages.x86_64-linux.llama-cpp-vulkan`
+- `packages.x86_64-linux.mlx`
+- `packages.x86_64-linux.mlx-rocm`
+- `packages.x86_64-linux.mlx-rocm-gfx1151`
 - `packages.x86_64-linux.ec-su-axb35-monitor`
 - `packages.x86_64-linux.fevm-faex9-live-iso`
 - `packages.x86_64-linux.strix-halo-mes-firmware`
@@ -91,11 +98,21 @@ Example configuration helpers:
 }
 ```
 
-On macOS, the overlay intentionally exposes only generic non-ROCm outputs such as `llama-cpp`, CPU `llama-cli`/`llama-server` apps, DS4 Metal outputs, and CPU benchmark derivations. ROCm, TheRock, EC, and firmware outputs are Linux-only.
+On macOS, the overlay intentionally exposes only generic non-ROCm outputs such as `llama-cpp`, CPU `llama-cli`/`llama-server` apps, DS4 Metal outputs, MLX/JACCL library outputs, and CPU benchmark derivations. ROCm, TheRock, EC, and firmware outputs are Linux-only.
 
 The DS4 Metal package builds against nixpkgs' `apple-sdk_26` by default because
 it uses newer Metal APIs than the default Darwin SDK. Override `darwinSdk`,
 `darwinSdkRoot`, or `darwinDeploymentTarget` for a different SDK policy.
+
+## MLX And JACCL Libraries
+
+The flake exposes library packages for shared MLX/JACCL development across Linux and macOS:
+
+- `packages.x86_64-linux.jaccl`: standalone JACCL library from the pinned MLX source, built against `rdma-core`
+- `packages.x86_64-linux.mlx` / `mlx-rocm`: compatibility aliases for the default MLX ROCm target
+- `packages.x86_64-linux.mlx-rocm-gfx1151`: MLX with the ROCm backend and portable JACCL support, narrowed for Strix Halo
+- `packages.aarch64-darwin.jaccl`: standalone JACCL library from the same pinned MLX source, built against Apple's RDMA library
+- `packages.aarch64-darwin.mlx` / `mlx-metal`: MLX and its Metal backend built from the pinned upstream MLX source
 
 ## TheRock ROCm Targets
 
@@ -284,6 +301,17 @@ nix build .#benchmarks.aarch64-darwin.bench-deepseek-v4-flash-ds4-metal-smoke
 cat result/results.csv
 ```
 
+MLX GPU smoke benchmarks run a small float32 GEMM and verify the result on
+the GPU backend. They do not require model files:
+
+```bash
+nix build .#benchmarks.x86_64-linux.bench-mlx-rocm-gfx1151-gemm-smoke
+cat result/stdout.txt
+
+nix build .#benchmarks.aarch64-darwin.bench-mlx-metal-gemm-smoke
+cat result/stdout.txt
+```
+
 vLLM benchmarks use the upstream offline benchmark CLI in throughput and
 latency modes. They expect the Hugging Face model cache under
 `/models/.cache/huggingface` and run offline against `Qwen/Qwen3-0.6B`:
@@ -397,4 +425,4 @@ nix flake check --no-build
 
 CI is driven by the flake's `checks` output. The buildbot should build `.#checks.<system>.*` for the systems it owns.
 
-The checks include source formatting/linting, representative package builds, benchmark metadata validation, executor builder translation, and Linux benchmark-runner module composition. Hardware/model-dependent benchmark derivations remain under `benchmarks` because they require local models and host-specific device access.
+The checks include source formatting/linting, representative package builds, benchmark metadata validation, executor builder translation, Linux benchmark-runner module composition, and model-free GPU smoke benchmarks for MLX. Model-dependent benchmark derivations remain under `benchmarks` because they require local models and host-specific device access.

--- a/bench/suites/mlx.nix
+++ b/bench/suites/mlx.nix
@@ -1,0 +1,192 @@
+{
+  pkgs,
+  package,
+  target ? null,
+  accelerator ? if pkgs.stdenv.isDarwin then "metal" else "rocm",
+  hostProfile ? if accelerator == "metal" then "darwin-metal" else "linux-amd-kfd",
+  matrixMetadata ? { },
+  extraSystemFeatures ? [ ],
+  extraSandboxPaths ? [ ],
+  n ? 256,
+  warmup ? 2,
+  iterations ? 5,
+}:
+
+assert pkgs.lib.assertMsg (
+  accelerator == "metal" || accelerator == "rocm"
+) "unsupported MLX benchmark accelerator: ${accelerator}";
+assert pkgs.lib.assertMsg (
+  accelerator == "metal" || target != null
+) "MLX ROCm benchmarks require a target record";
+
+let
+  inherit (pkgs) lib;
+  benchLib = import ../lib.nix { inherit lib; };
+
+  isMetal = accelerator == "metal";
+  backend = accelerator;
+  packageRole = if isMetal then "mlx" else "mlx-rocm-${target.packageSuffix}";
+  python = pkgs.python3.withPackages (_: [ package ]);
+  caseName = if isMetal then "metal-gemm-smoke" else "rocm-${target.packageSuffix}-gemm-smoke";
+  derivationName = "mlx-${caseName}";
+  metaPlatforms = if isMetal then [ "aarch64-darwin" ] else [ "x86_64-linux" ];
+  systemFeatures =
+    (
+      if isMetal then
+        [
+          "metal"
+          "benchmark"
+        ]
+      else
+        [ target.systemFeature ]
+    )
+    ++ extraSystemFeatures;
+  sandboxPaths =
+    (
+      if isMetal then
+        [ ]
+      else
+        [
+          "/dev/dri"
+          "/dev/kfd"
+          "/sys/class/drm"
+          "/sys/class/kfd"
+        ]
+    )
+    ++ extraSandboxPaths;
+  targetMetadata =
+    if isMetal then
+      {
+        packageSuffix = "metal";
+        runtimeArch = "metal";
+        systemFeature = "metal";
+      }
+    else
+      {
+        inherit (target)
+          packageSuffix
+          runtimeArch
+          systemFeature
+          ;
+      };
+
+  runner = pkgs.writeShellScript "${derivationName}-runner" ''
+    set -euo pipefail
+
+    export HOME="$TMPDIR"
+    export XDG_CACHE_HOME="$TMPDIR/cache"
+    export PYTHONNOUSERSITE=1
+
+    ${python}/bin/python - <<'PY'
+    import json
+    import math
+    import os
+    import time
+
+    import mlx.core as mx
+
+    if not mx.is_available(mx.gpu):
+        raise SystemExit("MLX GPU device is not available")
+
+    mx.set_default_device(mx.gpu)
+
+    n = ${toString n}
+    warmup = ${toString warmup}
+    iterations = ${toString iterations}
+    expected = float(2 * n)
+
+    a = mx.ones((n, n), dtype=mx.float32)
+    b = mx.full((n, n), 2.0, dtype=mx.float32)
+
+    for _ in range(warmup):
+        mx.eval(a @ b)
+
+    start = time.perf_counter()
+    c = None
+    for _ in range(iterations):
+        c = a @ b
+        mx.eval(c)
+    elapsed = time.perf_counter() - start
+
+    value = float(c[0, 0].item())
+    if not math.isclose(value, expected, rel_tol=0.0, abs_tol=1e-3):
+        raise SystemExit(f"bad GEMM result: {value} != {expected}")
+
+    try:
+        device_info = mx.device_info(mx.gpu)
+    except Exception as exc:
+        device_info = {"error": str(exc)}
+
+    print(json.dumps({
+        "device": str(mx.default_device()),
+        "device_info": device_info,
+        "dtype": "float32",
+        "elapsed_seconds": elapsed,
+        "expected": expected,
+        "iterations": iterations,
+        "n": n,
+        "op": "matmul",
+        "seconds_per_iteration": elapsed / iterations,
+        "shape": list(c.shape),
+        "value": value,
+        "verified": True,
+    }, default=str, sort_keys=True), flush=True)
+
+    # ROCm can leave non-daemon runtime threads alive after the work is done.
+    # The smoke has already synchronized and verified the result, so exit
+    # without waiting for backend teardown.
+    os._exit(0)
+    PY
+  '';
+in
+{
+  benchmarks = {
+    mlx = {
+      ${caseName} = benchLib.mkBenchmark {
+        inherit
+          pkgs
+          package
+          ;
+        name = derivationName;
+        command = [ runner ];
+        requirements = {
+          inherit
+            systemFeatures
+            sandboxPaths
+            ;
+          hostProfiles = [ hostProfile ];
+        };
+        metadata = lib.recursiveUpdate {
+          kind = "mlx-gpu-smoke";
+          smokeRevision = 2;
+          suite = "mlx";
+          inherit
+            accelerator
+            backend
+            ;
+          scenario = "gemm-smoke";
+          params = {
+            inherit
+              iterations
+              n
+              warmup
+              ;
+            dtype = "float32";
+            expected = 2 * n;
+            op = "matmul";
+          };
+          target = targetMetadata;
+          tool = {
+            inherit
+              backend
+              packageRole
+              ;
+            executable = "python";
+          };
+        } matrixMetadata;
+        meta.platforms = metaPlatforms;
+        description = "Run MLX ${accelerator} GEMM smoke benchmark";
+      };
+    };
+  };
+}

--- a/bench/suites/mlx.nix
+++ b/bench/suites/mlx.nix
@@ -158,7 +158,7 @@ in
         };
         metadata = lib.recursiveUpdate {
           kind = "mlx-gpu-smoke";
-          smokeRevision = 2;
+          smokeRevision = 3;
           suite = "mlx";
           inherit
             accelerator

--- a/flake.lock
+++ b/flake.lock
@@ -81,6 +81,23 @@
         "type": "github"
       }
     },
+    "mlx-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777394396,
+        "narHash": "sha256-3OOYc2MlBAMVZGwulp25X0VOVKS/vYTIWQjSz16DmFg=",
+        "owner": "ml-explore",
+        "repo": "mlx",
+        "rev": "e8ebdebeeb655feaa85a51f6b24ece5b6d5518d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ml-explore",
+        "repo": "mlx",
+        "rev": "e8ebdebeeb655feaa85a51f6b24ece5b6d5518d1",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779560665,
@@ -104,6 +121,7 @@
         "ec-su-axb35": "ec-su-axb35",
         "fastflowlm": "fastflowlm",
         "llama-cpp-master": "llama-cpp-master",
+        "mlx-src": "mlx-src",
         "nixpkgs": "nixpkgs",
         "therock-src-7-13-gfx1151-base-half-011b45bd": "therock-src-7-13-gfx1151-base-half-011b45bd",
         "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84": "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84",

--- a/flake.nix
+++ b/flake.nix
@@ -1178,6 +1178,15 @@
             sandboxPaths = benchmarkRunnerProfileConfig.nix.settings.extra-sandbox-paths;
             tmpfilesRules = benchmarkRunnerProfileConfig.systemd.tmpfiles.rules;
             udevRules = benchmarkRunnerProfileConfig.services.udev.extraRules;
+            devicePermissionService = {
+              wantedBy =
+                benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.wantedBy;
+              wants = benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.wants;
+              after = benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.after;
+              script = benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.script;
+            };
+            devicePermissionActivation =
+              benchmarkRunnerProfileConfig.system.activationScripts.benchmark-runner-device-permissions.text;
           };
 
           benchmarkExecutorConfig =
@@ -1382,6 +1391,17 @@
                     and (.tmpfilesRules | index("z /dev/dri/renderD* 0660 root nixbld -") != null)
                     and (.udevRules | contains("KERNEL==\"kfd\", GROUP:=\"nixbld\", MODE:=\"0660\""))
                     and (.udevRules | contains("SUBSYSTEM==\"drm\", KERNEL==\"renderD*\", GROUP:=\"nixbld\", MODE:=\"0660\""))
+                    and (.devicePermissionService.wantedBy | index("multi-user.target") != null)
+                    and (.devicePermissionService.wants | index("systemd-udev-trigger.service") != null)
+                    and (.devicePermissionService.wants | index("systemd-udev-settle.service") != null)
+                    and (.devicePermissionService.after | index("systemd-tmpfiles-setup-dev.service") != null)
+                    and (.devicePermissionService.after | index("systemd-udev-settle.service") != null)
+                    and (.devicePermissionService.script | contains("/dev/kfd"))
+                    and (.devicePermissionService.script | contains("/dev/dri/renderD*"))
+                    and (.devicePermissionService.script | contains("chgrp nixbld"))
+                    and (.devicePermissionService.script | contains("chmod 0660"))
+                    and (.devicePermissionActivation | contains("/dev/kfd"))
+                    and (.devicePermissionActivation | contains("/dev/dri/renderD*"))
                   ' profile.json
 
                   touch "$out"

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,11 @@
       flake = false;
     };
 
+    mlx-src = {
+      url = "github:ml-explore/mlx/e8ebdebeeb655feaa85a51f6b24ece5b6d5518d1";
+      flake = false;
+    };
+
     xrt-src = {
       url = "git+https://github.com/Xilinx/XRT?ref=XRT-2.21&submodules=1";
       flake = false;
@@ -534,11 +539,18 @@
                   package = pkgs.${"vllm-rocm-therock-${defaultRocmTarget.packageSuffix}"};
                   target = defaultTargetMetadata;
                 }).benchmarks;
+              mlxRocmBenchmarks =
+                (import ./bench/suites/mlx.nix {
+                  inherit pkgs;
+                  package = self.packages.${system}."mlx-rocm-${defaultRocmTarget.packageSuffix}";
+                  target = defaultTargetMetadata;
+                }).benchmarks;
             in
             flattenBenchmarks acceleratedBenchmarks
             // flattenBenchmarks fastflowlmBenchmarks
             // flattenBenchmarks ds4Benchmarks
             // flattenBenchmarks vllmBenchmarks
+            // flattenBenchmarks mlxRocmBenchmarks
           );
 
           darwinBenchmarks = lib.optionalAttrs pkgs.stdenv.isDarwin (
@@ -549,8 +561,14 @@
                   package = self.packages.${system}.ds4;
                   accelerator = "metal";
                 }).benchmarks;
+              mlxMetalBenchmarks =
+                (import ./bench/suites/mlx.nix {
+                  inherit pkgs;
+                  package = self.packages.${system}.mlx;
+                  accelerator = "metal";
+                }).benchmarks;
             in
-            flattenBenchmarks ds4MetalBenchmarks
+            flattenBenchmarks ds4MetalBenchmarks // flattenBenchmarks mlxMetalBenchmarks
           );
         in
         flattenBenchmarks genericBenchmarks // linuxBenchmarks // darwinBenchmarks;
@@ -780,9 +798,14 @@
       packages = perSystem (
         pkgs:
         let
+          s = defaultRocmTarget.packageSuffix;
+          jacclPackage = pkgs.callPackage ./pkgs/jaccl {
+            inherit (inputs) mlx-src;
+          };
           genericPackages = {
             default = pkgs.llama-cpp;
             inherit (pkgs) llama-cpp;
+            jaccl = jacclPackage;
           };
 
           linuxPackages =
@@ -829,6 +852,26 @@
                 name: builtins.hasAttr name pkgs
               ) ds4RocmPackageNames) (name: pkgs.${name});
               cudaPkgs = cudaPackagesFor pkgs.stdenv.hostPlatform.system;
+              mkMlxRocm =
+                rocmTarget:
+                let
+                  buildTarget = builtins.head rocmTarget.buildTargets;
+                in
+                pkgs.python3Packages.callPackage ./pkgs/mlx/rocm.nix {
+                  pname = "mlx-rocm-${rocmTarget.packageSuffix}";
+                  rocmPackages = pkgs.therockRocmPackages.${buildTarget};
+                  gfx = buildTarget;
+                };
+              mlxRocmTargets = builtins.filter (
+                rocmTarget: builtins.hasAttr (builtins.head rocmTarget.buildTargets) pkgs.therockRocmPackages
+              ) rocmTargets;
+              mlxRocmTargetPackages = lib.listToAttrs (
+                map (rocmTarget: {
+                  name = "mlx-rocm-${rocmTarget.packageSuffix}";
+                  value = mkMlxRocm rocmTarget;
+                }) mlxRocmTargets
+              );
+              mlxRocm = mlxRocmTargetPackages."mlx-rocm-${s}";
 
               therockPackages =
                 assert lib.assertMsg (missingRequiredTherockPackages == [ ])
@@ -854,16 +897,35 @@
                 ;
               inherit (cudaPkgs) llama-cpp-cuda llama-cpp-master-cuda;
               fevm-faex9-live-iso = self.nixosConfigurations.fevm-faex9-live.config.system.build.isoImage;
+              mlx = mlxRocm;
+              mlx-rocm = mlxRocm;
             }
             // ds4RocmPackages
+            // mlxRocmTargetPackages
             // llamaCppTargetPackages
             // therockPackages;
-          darwinPackages = {
-            ds4 = pkgs.callPackage ./pkgs/ds4 {
-              src = inputs.ds4;
-              version = unstableInputVersion inputs.ds4;
+          darwinPackages =
+            let
+              mlxMetalBackend = pkgs.python3Packages.callPackage ./pkgs/mlx/metal.nix {
+                inherit (inputs) mlx-src;
+                pname = "mlx-metal";
+                buildStage = 2;
+              };
+              mlxMetal = pkgs.python3Packages.callPackage ./pkgs/mlx/metal.nix {
+                inherit (inputs) mlx-src;
+                pname = "mlx";
+                buildStage = 1;
+                backendPackage = mlxMetalBackend;
+              };
+            in
+            {
+              ds4 = pkgs.callPackage ./pkgs/ds4 {
+                src = inputs.ds4;
+                version = unstableInputVersion inputs.ds4;
+              };
+              mlx = mlxMetal;
+              mlx-metal = mlxMetalBackend;
             };
-          };
         in
         genericPackages
         // lib.optionalAttrs pkgs.stdenv.isLinux linuxPackages
@@ -1272,6 +1334,7 @@
               '';
 
           package-llama-cpp = pkgs.llama-cpp;
+          package-jaccl = self.packages.${system}.jaccl;
         }
         // lib.optionalAttrs pkgs.stdenv.isLinux (
           let
@@ -1279,6 +1342,8 @@
             fastflowlmBenchmarkMetadata = builtins.toJSON fastflowlmBenchmark.passthru.benchmark;
             ds4Benchmark = benchmarkSet.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke;
             ds4BenchmarkMetadata = builtins.toJSON ds4Benchmark.passthru.benchmark;
+            mlxRocmSmokeBenchmark = benchmarkSet.bench-mlx-rocm-gfx1151-gemm-smoke;
+            mlxRocmSmokeBenchmarkMetadata = builtins.toJSON mlxRocmSmokeBenchmark.passthru.benchmark;
             vllmThroughputBenchmark = benchmarkSet.bench-qwen3-0-6b-vllm-rocm-gfx1151-throughput-smoke;
             vllmThroughputBenchmarkMetadata = builtins.toJSON (
               removeAttrs vllmThroughputBenchmark.passthru.benchmark [ "command" ]
@@ -1312,7 +1377,11 @@
                     and (.sandboxPaths | index("/dev/accel") == null)
                     and (.sandboxPaths | index("/caller/device") != null)
                     and (.tmpfilesRules | index("d /models 0755 root root -") != null)
-                    and (.udevRules | contains("KERNEL==\"kfd\""))
+                    and (.tmpfilesRules | index("z /dev/kfd 0660 root nixbld -") != null)
+                    and (.tmpfilesRules | index("z /dev/dri/card* 0660 root nixbld -") != null)
+                    and (.tmpfilesRules | index("z /dev/dri/renderD* 0660 root nixbld -") != null)
+                    and (.udevRules | contains("KERNEL==\"kfd\", GROUP:=\"nixbld\", MODE:=\"0660\""))
+                    and (.udevRules | contains("SUBSYSTEM==\"drm\", KERNEL==\"renderD*\", GROUP:=\"nixbld\", MODE:=\"0660\""))
                   ' profile.json
 
                   touch "$out"
@@ -1366,6 +1435,37 @@
                     and .params.ctxStart == 128
                     and .params.ctxMax == 256
                     and .params.genTokens == 8
+                  ' metadata.json
+
+                  touch "$out"
+                '';
+
+            mlx-rocm-gemm-smoke-metadata =
+              pkgs.runCommandLocal "ci-mlx-rocm-gemm-smoke-metadata"
+                {
+                  nativeBuildInputs = [ pkgs.jq ];
+                }
+                ''
+                  cat > metadata.json <<'JSON'
+                  ${mlxRocmSmokeBenchmarkMetadata}
+                  JSON
+
+                  jq -e '
+                    .kind == "mlx-gpu-smoke"
+                    and .suite == "mlx"
+                    and .accelerator == "rocm"
+                    and .backend == "rocm"
+                    and .scenario == "gemm-smoke"
+                    and .requirements.systemFeatures == [ "gfx1151" ]
+                    and .requirements.hostProfiles == [ "linux-amd-kfd" ]
+                    and (.requirements.sandboxPaths | index("/dev/kfd") != null)
+                    and (.requirements.sandboxPaths | index("/dev/dri") != null)
+                    and .packages == [ "mlx-rocm-gfx1151" ]
+                    and .params.op == "matmul"
+                    and .params.n == 256
+                    and .target.packageSuffix == "gfx1151"
+                    and .tool.packageRole == "mlx-rocm-gfx1151"
+                    and .tool.executable == "python"
                   ' metadata.json
 
                   touch "$out"
@@ -1426,6 +1526,8 @@
 
             "package-llama-cpp-rocm-${s}" = pkgs."llama-cpp-rocm-${s}";
             "package-ds4-rocm-${s}" = pkgs."ds4-rocm-${s}";
+            package-mlx-rocm = self.packages.${system}.mlx-rocm;
+            package-mlx-rocm-gfx1151 = self.packages.${system}.mlx-rocm-gfx1151;
             "package-vllm-rocm-therock-${s}" = pkgs."vllm-rocm-therock-${s}";
             package-fastflowlm = pkgs.fastflowlm;
             package-strix-halo-mes-firmware = pkgs.strix-halo-mes-firmware;
@@ -1496,8 +1598,12 @@
           let
             ds4MetalBenchmark = benchmarkSet.bench-deepseek-v4-flash-ds4-metal-smoke;
             ds4MetalBenchmarkMetadata = builtins.toJSON ds4MetalBenchmark.passthru.benchmark;
+            mlxMetalSmokeBenchmark = benchmarkSet.bench-mlx-metal-gemm-smoke;
+            mlxMetalSmokeBenchmarkMetadata = builtins.toJSON mlxMetalSmokeBenchmark.passthru.benchmark;
           in
           {
+            package-mlx = self.packages.${system}.mlx;
+            package-mlx-metal = self.packages.${system}.mlx-metal;
             ds4-metal-benchmark-metadata =
               pkgs.runCommandLocal "ci-ds4-metal-benchmark-metadata"
                 {
@@ -1524,6 +1630,36 @@
                     and .params.ctxStart == 128
                     and .params.ctxMax == 256
                     and .params.genTokens == 8
+                  ' metadata.json
+
+                  touch "$out"
+                '';
+
+            mlx-metal-gemm-smoke-metadata =
+              pkgs.runCommandLocal "ci-mlx-metal-gemm-smoke-metadata"
+                {
+                  nativeBuildInputs = [ pkgs.jq ];
+                }
+                ''
+                  cat > metadata.json <<'JSON'
+                  ${mlxMetalSmokeBenchmarkMetadata}
+                  JSON
+
+                  jq -e '
+                    .kind == "mlx-gpu-smoke"
+                    and .suite == "mlx"
+                    and .accelerator == "metal"
+                    and .backend == "metal"
+                    and .scenario == "gemm-smoke"
+                    and .requirements.systemFeatures == [ "metal", "benchmark" ]
+                    and .requirements.hostProfiles == [ "darwin-metal" ]
+                    and .requirements.sandboxPaths == []
+                    and .packages == [ "mlx" ]
+                    and .params.op == "matmul"
+                    and .params.n == 256
+                    and .target.packageSuffix == "metal"
+                    and .tool.packageRole == "mlx"
+                    and .tool.executable == "python"
                   ' metadata.json
 
                   touch "$out"
@@ -1567,14 +1703,22 @@
 
           prFullJobs = {
             default = afterPrQuick "default" self.packages.${system}.default;
+            jaccl = afterPrQuick "jaccl" self.packages.${system}.jaccl;
           }
           // lib.optionalAttrs (system == "aarch64-darwin") {
             ds4 = afterPrQuick "ds4" self.packages.${system}.ds4;
-            ds4-metal-smoke =
-              afterPrQuick "ds4-metal-smoke"
-                self.benchmarks.${system}.bench-deepseek-v4-flash-ds4-metal-smoke;
+            mlx = afterPrQuick "mlx" self.packages.${system}.mlx;
+            mlx-metal = afterPrQuick "mlx-metal" self.packages.${system}.mlx-metal;
+            mlx-metal-gemm-smoke =
+              afterPrQuick "mlx-metal-gemm-smoke"
+                self.benchmarks.${system}.bench-mlx-metal-gemm-smoke;
           }
           // lib.optionalAttrs (system == "x86_64-linux") {
+            mlx-rocm = afterPrQuick "mlx-rocm" self.packages.${system}.mlx-rocm;
+            mlx-rocm-gfx1151 = afterPrQuick "mlx-rocm-gfx1151" self.packages.${system}.mlx-rocm-gfx1151;
+            mlx-rocm-gemm-smoke =
+              afterPrQuick "mlx-rocm-gemm-smoke"
+                self.benchmarks.${system}.bench-mlx-rocm-gfx1151-gemm-smoke;
             system = afterPrQuick "system" self.nixosConfigurations.fevm-faex9.config.system.build.toplevel;
             fevm-faex9-live-iso =
               afterPrQuick "fevm-faex9-live-iso"
@@ -1582,9 +1726,6 @@
             vllm =
               afterPrQuick "vllm"
                 self.packages.${system}."vllm-rocm-therock-${defaultRocmTarget.packageSuffix}";
-            vllm-throughput-smoke =
-              afterPrQuick "vllm-throughput-smoke"
-                self.benchmarks.${system}.bench-qwen3-0-6b-vllm-rocm-gfx1151-throughput-smoke;
           };
         in
         lib.optionalAttrs isSourceCheckSystem {

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -222,24 +222,40 @@ in
 
     systemd.tmpfiles.rules = [
       "d ${modelsPath} 0755 root root -"
+    ]
+    ++ optionals hasAmdGpu [
+      "z /dev/kfd 0660 root nixbld -"
+    ]
+    ++ optionals hasGpu [
+      "z /dev/dri/card* 0660 root nixbld -"
+      "z /dev/dri/renderD* 0660 root nixbld -"
+    ]
+    ++ optionals hasAmdNpu [
+      "z /dev/accel/accel* 0660 root nixbld -"
+    ]
+    ++ optionals hasNvidiaGpu [
+      "z /dev/nvidia[0-9]* 0660 root nixbld -"
+      "z /dev/nvidiactl 0660 root nixbld -"
+      "z /dev/nvidia-uvm 0660 root nixbld -"
+      "z /dev/nvidia-uvm-tools 0660 root nixbld -"
     ];
 
     services.udev.extraRules = concatStringsSep "\n" (
       optionals hasAmdGpu [
-        ''KERNEL=="kfd", GROUP="nixbld", MODE="0660"''
+        ''KERNEL=="kfd", GROUP:="nixbld", MODE:="0660"''
       ]
       ++ optionals hasAmdNpu [
-        ''SUBSYSTEM=="accel", KERNEL=="accel*", GROUP="nixbld", MODE="0660"''
+        ''SUBSYSTEM=="accel", KERNEL=="accel*", GROUP:="nixbld", MODE:="0660"''
       ]
       ++ optionals hasGpu [
-        ''SUBSYSTEM=="drm", KERNEL=="card*", GROUP="nixbld", MODE="0660"''
-        ''SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP="nixbld", MODE="0660"''
+        ''SUBSYSTEM=="drm", KERNEL=="card*", GROUP:="nixbld", MODE:="0660"''
+        ''SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP:="nixbld", MODE:="0660"''
       ]
       ++ optionals hasNvidiaGpu [
-        ''KERNEL=="nvidia[0-9]*", GROUP="nixbld", MODE="0660"''
-        ''KERNEL=="nvidiactl", GROUP="nixbld", MODE="0660"''
-        ''KERNEL=="nvidia-uvm", GROUP="nixbld", MODE="0660"''
-        ''KERNEL=="nvidia-uvm-tools", GROUP="nixbld", MODE="0660"''
+        ''KERNEL=="nvidia[0-9]*", GROUP:="nixbld", MODE:="0660"''
+        ''KERNEL=="nvidiactl", GROUP:="nixbld", MODE:="0660"''
+        ''KERNEL=="nvidia-uvm", GROUP:="nixbld", MODE:="0660"''
+        ''KERNEL=="nvidia-uvm-tools", GROUP:="nixbld", MODE:="0660"''
       ]
     );
   };

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -20,6 +20,7 @@ let
     mkIf
     mkOption
     optionals
+    stringAfter
     types
     unique
     ;
@@ -89,6 +90,32 @@ let
   );
 
   relaxSandbox = any (runner: runner.relaxSandbox) enabledRunners;
+  devicePermissionGlobs =
+    optionals hasAmdGpu [
+      "/dev/kfd"
+    ]
+    ++ optionals hasGpu [
+      "/dev/dri/card*"
+      "/dev/dri/renderD*"
+    ]
+    ++ optionals hasAmdNpu [
+      "/dev/accel/accel*"
+    ]
+    ++ optionals hasNvidiaGpu [
+      "/dev/nvidia[0-9]*"
+      "/dev/nvidiactl"
+      "/dev/nvidia-uvm"
+      "/dev/nvidia-uvm-tools"
+    ];
+  applyDevicePermissions = concatStringsSep "\n" (
+    map (glob: ''
+      for path in ${glob}; do
+        [ -e "$path" ] || continue
+        ${pkgs.coreutils}/bin/chgrp nixbld -- "$path" 2>/dev/null || true
+        ${pkgs.coreutils}/bin/chmod 0660 -- "$path" 2>/dev/null || true
+      done
+    '') devicePermissionGlobs
+  );
 
   isIommuParam =
     param:
@@ -239,6 +266,31 @@ in
       "z /dev/nvidia-uvm 0660 root nixbld -"
       "z /dev/nvidia-uvm-tools 0660 root nixbld -"
     ];
+
+    system.activationScripts.benchmark-runner-device-permissions = mkIf (devicePermissionGlobs != [ ]) (
+      stringAfter [ "users" ] applyDevicePermissions
+    );
+
+    systemd.services = mkIf (devicePermissionGlobs != [ ]) {
+      benchmark-runner-device-permissions = {
+        description = "Apply benchmark runner device permissions";
+        wantedBy = [ "multi-user.target" ];
+        wants = [
+          "systemd-udev-trigger.service"
+          "systemd-udev-settle.service"
+        ];
+        after = [
+          "systemd-udev-trigger.service"
+          "systemd-udev-settle.service"
+          "systemd-tmpfiles-setup-dev.service"
+        ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = applyDevicePermissions;
+      };
+    };
 
     services.udev.extraRules = concatStringsSep "\n" (
       optionals hasAmdGpu [

--- a/pkgs/jaccl/default.nix
+++ b/pkgs/jaccl/default.nix
@@ -1,0 +1,333 @@
+{
+  lib,
+  stdenv,
+  runCommand,
+  fetchzip,
+  cmake,
+  pkg-config,
+  perl,
+  rdma-core ? null,
+  apple-sdk_26 ? null,
+  mlx-src,
+  darwinSdk ? apple-sdk_26,
+  darwinSdkRoot ? if darwinSdk != null then darwinSdk.sdkroot else null,
+  darwinSdkVersion ? "26.5",
+  darwinDeploymentTarget ? "26.0",
+}:
+
+let
+  json-src = fetchzip {
+    url = "https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz";
+    hash = "sha256-cnGfiVhXzqfj5Fay823wntWcTnbh8r2SefDLslb1Dh0=";
+  };
+
+  linuxLibibverbsName =
+    if stdenv.hostPlatform.isLinux then
+      assert rdma-core != null;
+      "${rdma-core}/lib/libibverbs.so.1"
+    else
+      "libibverbs.so.1";
+
+  jaccl-src = runCommand "jaccl-src" { nativeBuildInputs = [ perl ]; } ''
+        cp -r ${mlx-src}/mlx/distributed/jaccl/lib "$out"
+        chmod -R u+w "$out"
+
+        replace_if_present() {
+          local file="$1"
+          local from="$2"
+          local to="$3"
+
+          FROM="$from" TO="$to" perl -0pi -e '
+            BEGIN {
+              $from = $ENV{"FROM"};
+              $to = $ENV{"TO"};
+            }
+            s/\Q$from\E/$to/g;
+          ' "$file"
+        }
+
+        replace_if_present "$out/CMakeLists.txt" \
+          'if(NOT ''${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      message(STATUS "JACCL requires macOS (Darwin). Skipping JACCL build.")
+      return()
+    endif()
+
+    # Try to determine MACOS_SDK_VERSION if not set' \
+          'if(''${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # Try to determine MACOS_SDK_VERSION if not set'
+
+        replace_if_present "$out/CMakeLists.txt" \
+          'if(DEFINED MACOS_SDK_VERSION AND MACOS_SDK_VERSION VERSION_LESS "26.2")
+      message(STATUS "JACCL requires macOS SDK >= 26.2. Skipping JACCL build.")
+      return()
+    endif()
+
+    add_library(' \
+          'if(DEFINED MACOS_SDK_VERSION AND MACOS_SDK_VERSION VERSION_LESS "26.2")
+      message(STATUS "JACCL requires macOS SDK >= 26.2. Skipping JACCL build.")
+      return()
+    endif()
+    endif()
+
+    add_library('
+
+        replace_if_present "$out/jaccl/rdma.cpp" \
+          'librdma_handle_ = dlopen("librdma.dylib", RTLD_NOW | RTLD_GLOBAL);' \
+          '#if defined(__APPLE__)
+      const char* librdma_name = "librdma.dylib";
+    #else
+      const char* librdma_name = "${linuxLibibverbsName}";
+    #endif
+
+      librdma_handle_ = dlopen(librdma_name, RTLD_NOW | RTLD_GLOBAL);'
+        replace_if_present "$out/jaccl/rdma.cpp" \
+          '  const char* librdma_name = "libibverbs.so.1";' \
+          '  const char* librdma_name = "${linuxLibibverbsName}";'
+
+        replace_if_present "$out/jaccl/jaccl.h" '#include <memory>' '#include <memory>
+    #include <optional>'
+        replace_if_present "$out/jaccl/mesh_impl.h" '#include <memory>' '#include <algorithm>
+    #include <cstring>
+    #include <memory>'
+        replace_if_present "$out/jaccl/ring_impl.h" '#include <span>' '#include <algorithm>
+    #include <cstring>
+    #include <span>'
+
+        if ! grep -Fq '#include <algorithm>' "$out/jaccl/rdma.h"; then
+          perl -0pi -e 's@#include <infiniband/verbs.h>\n@#include <infiniband/verbs.h>\n\n#include <algorithm>\n@' "$out/jaccl/rdma.h"
+        fi
+        if ! grep -Fq '#include <cstdlib>' "$out/jaccl/rdma.h"; then
+          perl -0pi -e 's@#include <algorithm>\n@#include <algorithm>\n#include <cstdlib>\n@' "$out/jaccl/rdma.h"
+        fi
+
+        replace_if_present "$out/jaccl/rdma.h" \
+          '  if (__builtin_available(macOS 26.3, iOS 26.3, tvOS 26.3, visionOS 26.3, *)) {' \
+          '#if defined(__APPLE__)
+      if (__builtin_available(macOS 26.3, iOS 26.3, tvOS 26.3, visionOS 26.3, *)) {'
+        replace_if_present "$out/jaccl/rdma.h" \
+          '  }
+      return {0, FRAME_SIZE};
+    }' \
+          '  }
+    #else
+      for (int k = BUFFER_SIZES - 1; k > 0; k--) {
+        if (msg >= FRAME_SIZE * (1 << k)) {
+          return {k, FRAME_SIZE * (1 << k)};
+        }
+      }
+    #endif
+      return {0, FRAME_SIZE};
+    }'
+
+        replace_if_present "$out/jaccl/rdma.h" \
+          'constexpr int BUFFER_SIZES = 8;' \
+          'constexpr int BUFFER_SIZES = 9;'
+        replace_if_present "$out/jaccl/rdma.h" \
+          'inline std::pair<int, int64_t> buffer_size_from_message(int64_t msg) {' \
+          'inline std::pair<int, int64_t> buffer_size_from_message(int64_t msg) {
+      if (const char* forced = std::getenv("JACCL_BUFFER_SIZE")) {
+        char* end = nullptr;
+        long value = std::strtol(forced, &end, 10);
+        if (end != forced && *end == 0 && value > 0) {
+          for (int k = 0; k < BUFFER_SIZES; k++) {
+            if (value == FRAME_SIZE * (1 << k)) {
+              return {k, value};
+            }
+          }
+        }
+      }'
+        replace_if_present "$out/jaccl/rdma.h" \
+          '  int packet_sequence_number;
+      ibv_gid global_identifier;' \
+          '  int packet_sequence_number;
+      int source_gid_index;
+      ibv_gid global_identifier;'
+
+        replace_if_present "$out/jaccl/rdma.cpp" \
+          '  src.local_id = -1;
+    }' \
+          '  src.local_id = -1;
+      src.source_gid_index = 0;
+    }'
+        replace_if_present "$out/jaccl/rdma.cpp" \
+          '  ibv_gid gid;
+      for (int i = 0; i < port_attr.gid_tbl_len; i++) {
+        ibv_gid tmp;
+        if (ibv().query_gid(ctx, 1, i, &tmp) == 0) {
+          if (*(uint64_t*)&tmp.raw[0] == 0 && *(uint16_t*)&tmp.raw[8] == 0 &&
+              *(uint16_t*)&tmp.raw[10] == 0xffff) {
+            gid = tmp;
+            break;
+          }
+        }
+      }
+
+      src.local_id = port_attr.lid;' \
+          '  ibv_gid gid = {};
+      int gid_index = -1;
+      for (int i = 0; i < port_attr.gid_tbl_len; i++) {
+        ibv_gid tmp;
+        if (ibv().query_gid(ctx, 1, i, &tmp) == 0) {
+          if (*(uint64_t*)&tmp.raw[0] == 0 && *(uint16_t*)&tmp.raw[8] == 0 &&
+              *(uint16_t*)&tmp.raw[10] == 0xffff) {
+            gid = tmp;
+            gid_index = i;
+            break;
+          }
+        }
+      }
+      if (gid_index < 0) {
+        throw std::runtime_error("[jaccl] No IPv4-mapped GID found for RDMA device");
+      }
+
+      src.local_id = port_attr.lid;'
+        replace_if_present "$out/jaccl/rdma.cpp" \
+          '  src.packet_sequence_number = 7;
+      src.global_identifier = gid;' \
+          '  src.packet_sequence_number = 7;
+      src.source_gid_index = gid_index;
+      src.global_identifier = gid;'
+        replace_if_present "$out/jaccl/rdma.cpp" \
+          '    attr.ah_attr.grh.sgid_index = 1;' \
+          '    attr.ah_attr.grh.sgid_index = src.source_gid_index;'
+        replace_if_present "$out/jaccl/rdma.cpp" \
+          '    // Search for the name and try to open the device
+        for (int i = 0; i < num_devices; i++) {
+          if (name == ibv().get_device_name(devices[i])) {
+            auto ctx = ibv().open_device(devices[i]);
+            if (ctx == nullptr) {
+              std::ostringstream msg;
+              msg << "[jaccl] Could not open device " << name;
+              throw std::runtime_error(msg.str());
+            }
+            connections.emplace_back(ctx);
+            break;
+          }
+        }' \
+          '    // Search for the name and try to open the device.
+        bool found = false;
+        for (int i = 0; i < num_devices; i++) {
+          if (name == ibv().get_device_name(devices[i])) {
+            auto ctx = ibv().open_device(devices[i]);
+            if (ctx == nullptr) {
+              std::ostringstream msg;
+              msg << "[jaccl] Could not open device " << name;
+              throw std::runtime_error(msg.str());
+            }
+            connections.emplace_back(ctx);
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          std::ostringstream msg;
+          msg << "[jaccl] Could not find RDMA device " << name;
+          throw std::runtime_error(msg.str());
+        }'
+
+        replace_if_present "$out/jaccl/mesh.cpp" \
+          '    mesh_.all_reduce(in_ptr, out_ptr, count, reduce_op);' \
+          '    mesh_.all_reduce(
+            in_ptr, out_ptr, count, reduce_op, [&] { side_channel_.barrier(); });'
+        replace_if_present "$out/jaccl/mesh_impl.h" \
+          '  template <typename T, typename ReduceOp>
+      void all_reduce(const T* in, T* out, int64_t size, ReduceOp reduce_op) {
+        // Fully connected all reduce with deterministic reduction order.' \
+          '  template <typename T, typename ReduceOp>
+      void all_reduce(const T* in, T* out, int64_t size, ReduceOp reduce_op) {
+        all_reduce(in, out, size, reduce_op, [] {});
+      }
+
+      template <typename T, typename ReduceOp, typename RecvReady>
+      void all_reduce(
+          const T* in,
+          T* out,
+          int64_t size,
+          ReduceOp reduce_op,
+          RecvReady recv_ready) {
+        // Fully connected all reduce with deterministic reduction order.'
+    replace_if_present "$out/jaccl/mesh_impl.h" \
+      '    int reduce_rank = 0;
+
+    // Total number of chunks
+    int64_t total_chunks = (total + N - 1) / N;
+
+    // Prefill the pipeline
+    int buff = 0;
+    while (read_offset < total && buff < PIPELINE) {' \
+      '    int reduce_rank = 0;
+
+    // Total number of chunks
+    int64_t total_chunks = (total + N - 1) / N;
+
+    // Prefill the pipeline
+    int buff = 0;
+    int preposted = 0;
+    while (read_offset < total && buff < PIPELINE) {'
+    replace_if_present "$out/jaccl/mesh_impl.h" \
+      '      recv_end[rank_]++;
+      post_send_all(sz, buff);
+
+      buff++;
+      in_flight += 2 * num_peers;
+      read_offset += N;
+    }
+
+    // Main loop' \
+      '      recv_end[rank_]++;
+      buff++;
+      preposted++;
+      in_flight += num_peers;
+      read_offset += N;
+        }
+
+        recv_ready();
+
+        for (int b = 0; b < preposted; b++) {
+          post_send_all(sz, b);
+          in_flight += num_peers;
+        }
+
+        // Main loop'
+  '';
+in
+stdenv.mkDerivation {
+  pname = "jaccl";
+  version = "0.32.0-mlx";
+  src = jaccl-src;
+
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  buildInputs =
+    lib.optionals stdenv.hostPlatform.isLinux [
+      rdma-core
+      rdma-core.dev
+    ]
+    ++ lib.optionals stdenv.hostPlatform.isDarwin [ darwinSdk ];
+
+  cmakeFlags = [
+    "-DFETCHCONTENT_SOURCE_DIR_JSON=${json-src}"
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    "-DMACOS_SDK_VERSION=${darwinSdkVersion}"
+  ];
+
+  preConfigure = lib.optionalString stdenv.hostPlatform.isDarwin ''
+    if [ ! -d "${darwinSdkRoot}" ]; then
+      echo "jaccl: missing macOS SDK: ${darwinSdkRoot}" >&2
+      exit 1
+    fi
+    export SDKROOT=${lib.escapeShellArg darwinSdkRoot}
+    export MACOSX_DEPLOYMENT_TARGET=${lib.escapeShellArg darwinDeploymentTarget}
+  '';
+
+  meta = with lib; {
+    description = "JACCL RDMA-over-Thunderbolt collective communication library from MLX";
+    homepage = "https://github.com/ml-explore/mlx";
+    license = licenses.mit;
+    platforms = platforms.linux ++ [ "aarch64-darwin" ];
+  };
+}

--- a/pkgs/mlx/metal.nix
+++ b/pkgs/mlx/metal.nix
@@ -1,0 +1,177 @@
+{
+  lib,
+  stdenv,
+  mlx,
+  fetchFromGitHub,
+  fetchzip,
+  replaceVars,
+  nanobind,
+  python,
+  zsh,
+  apple-sdk_26,
+  mlx-src,
+  buildStage ? 1,
+  pname ? if buildStage == 2 then "mlx-metal" else "mlx",
+  backendPackage ? null,
+  darwinSdk ? apple-sdk_26,
+  darwinSdkRoot ? darwinSdk.sdkroot,
+  darwinSdkVersion ? darwinSdk.version,
+  darwinDeploymentTarget ? "26.0",
+}:
+
+assert lib.assertMsg stdenv.hostPlatform.isDarwin "MLX Metal is Darwin-only";
+assert lib.assertMsg (
+  buildStage == 1 || buildStage == 2
+) "MLX Metal buildStage must be 1 (frontend) or 2 (backend)";
+assert lib.assertMsg (
+  buildStage != 1 || backendPackage != null
+) "MLX Metal stage 1 requires backendPackage";
+
+let
+  gguf-tools = fetchFromGitHub {
+    owner = "antirez";
+    repo = "gguf-tools";
+    rev = "8fa6eb65236618e28fd7710a0fba565f7faa1848";
+    hash = "sha256-15FvyPOFqTOr5vdWQoPnZz+mYH919++EtghjozDlnSA=";
+  };
+
+  metal-cpp = fetchzip {
+    url = "https://developer.apple.com/metal/cpp/files/metal-cpp_26.zip";
+    hash = "sha256-7n2eI2lw/S+Us6l7YPAATKwcIbRRpaQ8VmES7S8ZjY8=";
+  };
+
+  inherit (python) sitePackages;
+  backendLibDir = "${backendPackage}/${sitePackages}/mlx/lib";
+in
+mlx.overrideAttrs (old: {
+  inherit pname;
+  version = "0.32.0";
+
+  src = mlx-src;
+  patches = [
+    ./patches/use-system-nanobind.patch
+    ./patches/use-system-json.patch
+    (replaceVars ./patches/darwin-sdk-version.patch {
+      sdkVersion = darwinSdkVersion;
+    })
+  ];
+
+  nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ zsh ];
+  buildInputs = (old.buildInputs or [ ]) ++ [ darwinSdk ];
+  __noChroot = true;
+  propagatedBuildInputs =
+    (old.propagatedBuildInputs or [ ]) ++ lib.optionals (buildStage == 1) [ backendPackage ];
+
+  env = {
+    PYPI_RELEASE = "1";
+    MLX_BUILD_STAGE = toString buildStage;
+    CMAKE_ARGS = lib.concatStringsSep " " [
+      (lib.cmakeBool "MLX_BUILD_METAL" true)
+      (lib.cmakeBool "USE_SYSTEM_FMT" true)
+      (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_GGUFLIB" "${gguf-tools}")
+      (lib.cmakeOptionType "filepath" "FETCHCONTENT_SOURCE_DIR_METAL_CPP" "${metal-cpp}")
+      (lib.cmakeFeature "nanobind_DIR" "${nanobind}/${sitePackages}/nanobind/cmake")
+      (lib.cmakeFeature "CMAKE_OSX_SYSROOT" darwinSdkRoot)
+      (lib.cmakeFeature "CMAKE_OSX_DEPLOYMENT_TARGET" darwinDeploymentTarget)
+    ];
+  };
+
+  preBuild = (old.preBuild or "") + ''
+    if [ ! -d "${darwinSdkRoot}" ]; then
+      echo "mlx-metal: missing macOS SDK: ${darwinSdkRoot}" >&2
+      exit 1
+    fi
+    export SDKROOT=${lib.escapeShellArg darwinSdkRoot}
+    export MACOSX_DEPLOYMENT_TARGET=${lib.escapeShellArg darwinDeploymentTarget}
+
+    metal_tool="$(/usr/bin/xcrun -sdk macosx -find metal 2>/dev/null || true)"
+    if [ -z "$metal_tool" ] || ! "$metal_tool" --version >/dev/null 2>&1; then
+      metal_tool="$(find /private/var/run/com.apple.security.cryptexd/mnt \
+        -path '*/Metal.xctoolchain/usr/bin/metal' -type f | head -n 1 || true)"
+    fi
+    if [ -z "$metal_tool" ] || ! "$metal_tool" --version >/dev/null 2>&1; then
+      echo "mlx-metal: missing usable Apple Metal Toolchain" >&2
+      echo "mlx-metal: run xcodebuild -downloadComponent MetalToolchain on the builder" >&2
+      exit 1
+    fi
+
+    metallib_tool="$(dirname "$metal_tool")/metallib"
+    if [ ! -x "$metallib_tool" ]; then
+      echo "mlx-metal: missing metallib next to $metal_tool" >&2
+      exit 1
+    fi
+
+    xcrun_wrapper="$TMPDIR/mlx-xcrun-wrapper"
+    mkdir -p "$xcrun_wrapper"
+    cat > "$xcrun_wrapper/xcrun" <<'SH'
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    args=("$@")
+    tool=""
+    i=0
+    while [ "$i" -lt "''${#args[@]}" ]; do
+      case "''${args[$i]}" in
+        -sdk|--sdk)
+          i=$((i + 2))
+          ;;
+        *)
+          tool="''${args[$i]}"
+          i=$((i + 1))
+          break
+          ;;
+      esac
+    done
+
+    case "$tool" in
+      metal)
+        exec "$MLX_METAL_TOOL" "''${args[@]:$i}"
+        ;;
+      metallib)
+        exec "$MLX_METALLIB_TOOL" "''${args[@]:$i}"
+        ;;
+      *)
+        exec /usr/bin/xcrun "$@"
+        ;;
+    esac
+    SH
+    chmod +x "$xcrun_wrapper/xcrun"
+
+    export MLX_METAL_TOOL="$metal_tool"
+    export MLX_METALLIB_TOOL="$metallib_tool"
+    export PATH="$xcrun_wrapper:$PATH:/usr/bin:/bin"
+  '';
+
+  postInstall =
+    (old.postInstall or "")
+    + lib.optionalString (buildStage == 1) ''
+      mkdir -p "$out/${sitePackages}/mlx/lib"
+      for path in ${backendLibDir}/*; do
+        ln -sf "$path" "$out/${sitePackages}/mlx/lib/$(basename "$path")"
+      done
+    ''
+    + lib.optionalString (buildStage == 2) ''
+      find "$out/${sitePackages}/mlx" -maxdepth 1 -type f \
+        \( -name '*.py' -o -name '*.pyc' -o -name 'py.typed' \) -delete
+      rm -rf "$out/${sitePackages}/mlx/__pycache__"
+    '';
+
+  nativeCheckInputs = [ ];
+  doCheck = false;
+  doInstallCheck = false;
+  dontCheckRuntimeDeps = true;
+  dontUsePytestCheck = true;
+  dontStrip = true;
+  pythonImportsCheck = lib.optionals (buildStage == 1) [ "mlx.core" ];
+
+  meta = with lib; {
+    description =
+      if buildStage == 2 then
+        "Apple MLX Metal backend built from source"
+      else
+        "Apple MLX with Metal backend built from source";
+    homepage = "https://github.com/ml-explore/mlx";
+    license = licenses.mit;
+    platforms = [ "aarch64-darwin" ];
+  };
+})

--- a/pkgs/mlx/metal.nix
+++ b/pkgs/mlx/metal.nix
@@ -59,8 +59,14 @@ mlx.overrideAttrs (old: {
   nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ zsh ];
   buildInputs = (old.buildInputs or [ ]) ++ [ darwinSdk ];
   __noChroot = true;
-  propagatedBuildInputs =
-    (old.propagatedBuildInputs or [ ]) ++ lib.optionals (buildStage == 1) [ backendPackage ];
+  propagatedBuildInputs = lib.optionals (buildStage == 1) (
+    (old.propagatedBuildInputs or [ ]) ++ [ backendPackage ]
+  );
+
+  postPatch = (old.postPatch or "") + ''
+    substituteInPlace mlx/backend/cpu/jit_compiler.cpp \
+      --replace-fail "${stdenv.cc}/bin/c++" "/usr/bin/c++"
+  '';
 
   env = {
     PYPI_RELEASE = "1";
@@ -154,6 +160,15 @@ mlx.overrideAttrs (old: {
       find "$out/${sitePackages}/mlx" -maxdepth 1 -type f \
         \( -name '*.py' -o -name '*.pyc' -o -name 'py.typed' \) -delete
       rm -rf "$out/${sitePackages}/mlx/__pycache__"
+
+      cmake_targets="$out/${sitePackages}/mlx/share/cmake/MLX/MLXTargets.cmake"
+      if [ -f "$cmake_targets" ]; then
+        substituteInPlace "$cmake_targets" \
+          --replace-fail "${darwinSdkRoot}/System/Library/Frameworks/Metal.framework" "-framework;Metal" \
+          --replace-fail "${darwinSdkRoot}/System/Library/Frameworks/Foundation.framework" "-framework;Foundation" \
+          --replace-fail "${darwinSdkRoot}/System/Library/Frameworks/QuartzCore.framework" "-framework;QuartzCore" \
+          --replace-fail "${darwinSdkRoot}/System/Library/Frameworks/Accelerate.framework" "-framework;Accelerate"
+      fi
     '';
 
   nativeCheckInputs = [ ];

--- a/pkgs/mlx/patches/darwin-sdk-version.patch
+++ b/pkgs/mlx/patches/darwin-sdk-version.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 27b772c..a316875 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -178,10 +178,7 @@ if(MLX_BUILD_METAL)
+   endif()
+
+   # Throw an error if xcrun not found
+-  execute_process(
+-    COMMAND zsh "-c" "/usr/bin/xcrun -sdk macosx --show-sdk-version"
+-    OUTPUT_VARIABLE MACOS_SDK_VERSION
+-    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
++  set(MACOS_SDK_VERSION @sdkVersion@)
+
+   if(${MACOS_SDK_VERSION} LESS 14.0)
+     message(

--- a/pkgs/mlx/patches/use-system-json.patch
+++ b/pkgs/mlx/patches/use-system-json.patch
@@ -1,0 +1,82 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 27b772c..805de09 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -315,13 +315,8 @@ else()
+   set(MLX_BUILD_ACCELERATE OFF)
+ endif()
+
+-message(STATUS "Downloading json")
+-FetchContent_Declare(
+-  json
+-  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+-FetchContent_MakeAvailable(json)
+-target_include_directories(
+-  mlx PRIVATE $<BUILD_INTERFACE:${json_SOURCE_DIR}/single_include/nlohmann>)
++find_package(nlohmann_json REQUIRED)
++target_link_libraries(mlx PRIVATE nlohmann_json::nlohmann_json)
+
+ # Add standalone JACCL library (RDMA over Thunderbolt distributed backend)
+ if(MLX_BUILD_CPU
+diff --git a/mlx/distributed/jaccl/lib/CMakeLists.txt b/mlx/distributed/jaccl/lib/CMakeLists.txt
+index aaeed81..0aed1d5 100644
+--- a/mlx/distributed/jaccl/lib/CMakeLists.txt
++++ b/mlx/distributed/jaccl/lib/CMakeLists.txt
+@@ -14,11 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ include(FetchContent)
+
+ # nlohmann/json for device file parsing
+-message(STATUS "Downloading json for JACCL")
+-FetchContent_Declare(
+-  json
+-  URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+-FetchContent_MakeAvailable(json)
++find_package(nlohmann_json REQUIRED)
+
+ # Check platform and SDK version requirements
+ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+@@ -55,8 +50,7 @@ target_include_directories(
+   jaccl PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+                $<INSTALL_INTERFACE:include>)
+
+-target_include_directories(
+-  jaccl PRIVATE $<BUILD_INTERFACE:${json_SOURCE_DIR}/single_include/nlohmann>)
++target_link_libraries(jaccl PRIVATE nlohmann_json::nlohmann_json)
+
+ target_compile_features(jaccl PUBLIC cxx_std_20)
+
+diff --git a/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp b/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp
+index 1e9f2ff..c615e8c 100644
+--- a/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp
++++ b/mlx/distributed/jaccl/lib/jaccl/jaccl.cpp
+@@ -3,6 +3,6 @@
+ #include <fstream>
+ #include <sstream>
+
+-#include <json.hpp>
++#include <nlohmann/json.hpp>
+
+ #include "jaccl/jaccl.h"
+diff --git a/mlx/distributed/ring/ring.cpp b/mlx/distributed/ring/ring.cpp
+index 687d6e6..35d97c5 100644
+--- a/mlx/distributed/ring/ring.cpp
++++ b/mlx/distributed/ring/ring.cpp
+@@ -17,6 +17,6 @@
+ #include <thread>
+ #include <unordered_map>
+
+-#include <json.hpp>
++#include <nlohmann/json.hpp>
+
+ #include "mlx/backend/cpu/encoder.h"
+diff --git a/mlx/io/safetensors.cpp b/mlx/io/safetensors.cpp
+index 8035c3c..f59b13e 100644
+--- a/mlx/io/safetensors.cpp
++++ b/mlx/io/safetensors.cpp
+@@ -1,5 +1,5 @@
+ // Copyright © 2025 Apple Inc.
+
+-#include <json.hpp>
++#include <nlohmann/json.hpp>
+
+ #include <memory>

--- a/pkgs/mlx/patches/use-system-nanobind.patch
+++ b/pkgs/mlx/patches/use-system-nanobind.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 27b772c..0d320fc 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -354,13 +354,7 @@ if(MLX_BUILD_PYTHON_BINDINGS)
+     Python 3.10
+     COMPONENTS Interpreter Development.Module
+     REQUIRED)
+-  FetchContent_Declare(
+-    nanobind
+-    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+-    GIT_TAG v2.12.0
+-    GIT_SHALLOW TRUE
+-    EXCLUDE_FROM_ALL)
+-  FetchContent_MakeAvailable(nanobind)
++  find_package(nanobind CONFIG REQUIRED)
+   add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/python/src)
+ endif()

--- a/pkgs/mlx/rocm-include-rocblas.patch
+++ b/pkgs/mlx/rocm-include-rocblas.patch
@@ -1,0 +1,69 @@
+Add rocblas + hipblaslt + hipblas-common include paths to the HIP compile
+flags and the mlx target's C++ include dirs.
+
+The MLX ROCm backend's gemms/rocblas_gemm.cpp and gemms/hipblaslt_gemm.cpp
+include <rocblas/rocblas.h> and <hipblaslt/hipblaslt.h>, and hipblaslt.h
+in turn includes <hipblas-common/hipblas-common.h>. The ROCm CMakeLists
+plumbs rocthrust/rocprim/hiprand/rocwmma but not rocblas/hipblaslt.
+
+--- a/mlx/backend/rocm/CMakeLists.txt
++++ b/mlx/backend/rocm/CMakeLists.txt
+@@ -7,6 +7,7 @@
+ # Find ROCm packages
+ find_package(hip REQUIRED CONFIG)
+ find_package(rocblas REQUIRED CONFIG)
++find_package(hipblaslt REQUIRED CONFIG)
+ find_package(rocthrust REQUIRED CONFIG)
+ find_package(rocprim REQUIRED CONFIG)
+ find_package(hiprand REQUIRED CONFIG)
+@@ -58,6 +59,12 @@
+   get_target_property(ROCWMMA_INCLUDES roc::rocwmma
+                       INTERFACE_INCLUDE_DIRECTORIES)
+ endif()
++get_target_property(ROCBLAS_INCLUDES roc::rocblas
++                    INTERFACE_INCLUDE_DIRECTORIES)
++get_target_property(HIPBLASLT_INCLUDES roc::hipblaslt
++                    INTERFACE_INCLUDE_DIRECTORIES)
++get_target_property(HIPBLAS_COMMON_INCLUDES roc::hipblas-common
++                    INTERFACE_INCLUDE_DIRECTORIES)
+
+ # Find GCC installation for C++ standard library headers ROCm's clang needs to
+ # know where to find libstdc++ headers
+@@ -120,6 +127,21 @@
+     list(APPEND HIP_INCLUDE_FLAGS "-I${inc}")
+   endif()
+ endforeach()
++foreach(inc ${ROCBLAS_INCLUDES})
++  if(inc)
++    list(APPEND HIP_INCLUDE_FLAGS "-I${inc}")
++  endif()
++endforeach()
++foreach(inc ${HIPBLASLT_INCLUDES})
++  if(inc)
++    list(APPEND HIP_INCLUDE_FLAGS "-I${inc}")
++  endif()
++endforeach()
++foreach(inc ${HIPBLAS_COMMON_INCLUDES})
++  if(inc)
++    list(APPEND HIP_INCLUDE_FLAGS "-I${inc}")
++  endif()
++endforeach()
+ if(MLX_HAS_ROCM_WMMA)
+   foreach(inc ${ROCWMMA_INCLUDES})
+     if(inc)
+@@ -321,6 +343,15 @@
+   target_include_directories(mlx PRIVATE ${HIP_HOST_INCLUDES})
+ endif()
+ target_include_directories(mlx PRIVATE ${HIP_INCLUDE_DIRS})
++if(ROCBLAS_INCLUDES)
++  target_include_directories(mlx PRIVATE ${ROCBLAS_INCLUDES})
++endif()
++if(HIPBLASLT_INCLUDES)
++  target_include_directories(mlx PRIVATE ${HIPBLASLT_INCLUDES})
++endif()
++if(HIPBLAS_COMMON_INCLUDES)
++  target_include_directories(mlx PRIVATE ${HIPBLAS_COMMON_INCLUDES})
++endif()
+
+ # Add HIP platform define for C++ files
+ target_compile_definitions(mlx PRIVATE __HIP_PLATFORM_AMD__=1)

--- a/pkgs/mlx/rocm.nix
+++ b/pkgs/mlx/rocm.nix
@@ -1,0 +1,404 @@
+{
+  lib,
+  mlx,
+  applyPatches,
+  fetchFromGitHub,
+  rdma-core,
+  rocmPackages,
+  gfx ? "gfx1151",
+  pname ? "mlx-rocm",
+}:
+
+let
+  mlx-rocm-src = applyPatches {
+    src = fetchFromGitHub {
+      owner = "NripeshN";
+      repo = "mlx";
+      rev = "39fac95d901c72175fce4baf973e375d4a054ba7";
+      hash = "sha256-LZB1gY0nZO0GGxHfRGaX5uk5BOJJ89g33vPBy3x45YA=";
+    };
+    patches = [ ./rocm-include-rocblas.patch ];
+  };
+in
+mlx.overrideAttrs (old: {
+  inherit pname;
+  src = mlx-rocm-src;
+
+  patches = [ ];
+
+  postPatch = (old.postPatch or "") + ''
+          substituteInPlace CMakeLists.txt \
+            --replace-fail \
+              'FetchContent_Declare(
+        nanobind
+        GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+        GIT_TAG v2.10.2
+        GIT_SHALLOW TRUE
+        EXCLUDE_FROM_ALL)
+      FetchContent_MakeAvailable(nanobind)' \
+              'find_package(nanobind CONFIG REQUIRED)'
+
+          substituteInPlace CMakeLists.txt \
+            --replace-fail \
+              'message(STATUS "Downloading json")
+    FetchContent_Declare(
+      json
+      URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+    FetchContent_MakeAvailable(json)
+    target_include_directories(
+      mlx PRIVATE $<BUILD_INTERFACE:''${json_SOURCE_DIR}/single_include/nlohmann>)' \
+              'find_package(nlohmann_json REQUIRED)
+    target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)'
+
+          substituteInPlace mlx/distributed/jaccl/CMakeLists.txt \
+            --replace-fail \
+              'if(MLX_BUILD_CPU
+       AND ''${CMAKE_SYSTEM_NAME} MATCHES "Darwin"
+       AND MACOS_SDK_VERSION GREATER_EQUAL 26.2)' \
+              'if(MLX_BUILD_CPU AND NOT WIN32)'
+          substituteInPlace mlx/distributed/jaccl/CMakeLists.txt \
+            --replace-fail \
+              'if(MLX_BUILD_CPU AND NOT WIN32)
+      target_sources(' \
+              'if(MLX_BUILD_CPU AND NOT WIN32)
+      target_include_directories(mlx PRIVATE ${rdma-core.dev}/include)
+      target_sources('
+
+          substituteInPlace mlx/distributed/jaccl/utils.cpp \
+            --replace-fail \
+              '#include <dlfcn.h>
+    #include <unistd.h>
+    #include <iostream>
+    #include <sstream>' \
+              '#include <dlfcn.h>
+    #include <unistd.h>
+    #include <cstring>
+    #include <iostream>
+    #include <sstream>' \
+            --replace-fail \
+              '  librdma_handle_ = dlopen("librdma.dylib", RTLD_NOW | RTLD_GLOBAL);' \
+              '  librdma_handle_ = dlopen("${rdma-core}/lib/libibverbs.so.1", RTLD_NOW | RTLD_GLOBAL);'
+
+          substituteInPlace mlx/distributed/jaccl/utils.h \
+            --replace-fail \
+              'constexpr int BUFFER_SIZES = 8;' \
+              'constexpr int BUFFER_SIZES = 9;' \
+            --replace-fail \
+              '#include <infiniband/verbs.h>
+
+    #include <span>' \
+              '#include <infiniband/verbs.h>
+
+    #include <algorithm>
+    #include <cstdlib>
+    #include <cstring>
+    #include <span>'
+
+          substituteInPlace mlx/distributed/jaccl/utils.h \
+            --replace-fail \
+              'inline std::pair<int, int64_t> buffer_size_from_message(int64_t msg) {
+      if (__builtin_available(macOS 26.3, iOS 26.3, tvOS 26.3, visionOS 26.3, *)) {
+        for (int k = BUFFER_SIZES - 1; k > 0; k--) {
+          if (msg >= FRAME_SIZE * (1 << k)) {
+            return {k, FRAME_SIZE * (1 << k)};
+          }
+        }
+      }
+      return {0, FRAME_SIZE};
+    }' \
+              'inline std::pair<int, int64_t> buffer_size_from_message(int64_t msg) {
+      if (const char* forced = std::getenv("JACCL_BUFFER_SIZE")) {
+        char* end = nullptr;
+        long value = std::strtol(forced, &end, 10);
+        if (end != forced && *end == 0 && value > 0) {
+          for (int k = 0; k < BUFFER_SIZES; k++) {
+            if (value == FRAME_SIZE * (1 << k)) {
+              return {k, value};
+            }
+          }
+        }
+      }
+    #if defined(__APPLE__)
+      if (__builtin_available(macOS 26.3, iOS 26.3, tvOS 26.3, visionOS 26.3, *)) {
+    #endif
+        for (int k = BUFFER_SIZES - 1; k > 0; k--) {
+          if (msg >= FRAME_SIZE * (1 << k)) {
+            return {k, FRAME_SIZE * (1 << k)};
+          }
+        }
+    #if defined(__APPLE__)
+      }
+    #endif
+      return {0, FRAME_SIZE};
+    }' \
+            --replace-fail \
+              '  int packet_sequence_number;
+      ibv_gid global_identifier;' \
+              '  int packet_sequence_number;
+      int source_gid_index;
+      ibv_gid global_identifier;'
+
+          substituteInPlace mlx/distributed/jaccl/utils.cpp \
+            --replace-fail \
+              '  src.local_id = -1;
+    }' \
+              '  src.local_id = -1;
+      src.source_gid_index = 0;
+    }' \
+            --replace-fail \
+              '  ibv_gid gid;
+      ibv().query_gid(ctx, 1, 1, &gid);
+
+      src.local_id = port_attr.lid;' \
+              '  ibv_gid gid = {};
+      int gid_index = -1;
+      for (int i = 0; i < port_attr.gid_tbl_len; i++) {
+        ibv_gid tmp;
+        if (ibv().query_gid(ctx, 1, i, &tmp) == 0) {
+          if (*(uint64_t*)&tmp.raw[0] == 0 && *(uint16_t*)&tmp.raw[8] == 0 &&
+              *(uint16_t*)&tmp.raw[10] == 0xffff) {
+            gid = tmp;
+            gid_index = i;
+            break;
+          }
+        }
+      }
+      if (gid_index < 0) {
+        throw std::runtime_error("[jaccl] No IPv4-mapped GID found for RDMA device");
+      }
+
+      src.local_id = port_attr.lid;' \
+            --replace-fail \
+              '  src.packet_sequence_number = 7; // TODO: Change to sth random
+      src.global_identifier = gid;' \
+              '  src.packet_sequence_number = 7; // TODO: Change to sth random
+      src.source_gid_index = gid_index;
+      src.global_identifier = gid;' \
+            --replace-fail \
+              '    attr.ah_attr.grh.sgid_index = 1;' \
+              '    attr.ah_attr.grh.sgid_index = src.source_gid_index;' \
+            --replace-fail \
+              '    // Search for the name and try to open the device
+        for (int i = 0; i < num_devices; i++) {
+          if (name == ibv().get_device_name(devices[i])) {
+            auto ctx = ibv().open_device(devices[i]);
+            if (ctx == nullptr) {
+              std::ostringstream msg;
+              msg << "[jaccl] Could not open device " << name;
+              throw std::runtime_error(msg.str());
+            }
+            connections.emplace_back(ctx);
+            break;
+          }
+        }' \
+              '    // Search for the name and try to open the device.
+        bool found = false;
+        for (int i = 0; i < num_devices; i++) {
+          if (name == ibv().get_device_name(devices[i])) {
+            auto ctx = ibv().open_device(devices[i]);
+            if (ctx == nullptr) {
+              std::ostringstream msg;
+              msg << "[jaccl] Could not open device " << name;
+              throw std::runtime_error(msg.str());
+            }
+            connections.emplace_back(ctx);
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          std::ostringstream msg;
+          msg << "[jaccl] Could not find RDMA device " << name;
+          throw std::runtime_error(msg.str());
+        }'
+
+          substituteInPlace mlx/distributed/jaccl/mesh.h \
+            --replace-fail \
+              '#include "mlx/distributed/distributed_impl.h"' \
+              '#include <functional>
+
+    #include "mlx/distributed/distributed_impl.h"' \
+            --replace-fail \
+              '      Stream stream,
+          ReduceOp reduce_op);' \
+              '      Stream stream,
+          ReduceOp reduce_op,
+          std::function<void()> recv_ready);'
+
+          substituteInPlace mlx/distributed/jaccl/mesh.cpp \
+            --replace-fail \
+              '    all_reduce<T>(input, output, stream, detail::SumOp<T>{});' \
+              '    all_reduce<T>(
+            input, output, stream, detail::SumOp<T>{}, [&] {
+              side_channel_.all_gather<int>(0);
+            });' \
+            --replace-fail \
+              '    all_reduce<T>(input, output, stream, detail::MaxOp<T>{});' \
+              '    all_reduce<T>(
+            input, output, stream, detail::MaxOp<T>{}, [&] {
+              side_channel_.all_gather<int>(0);
+            });' \
+            --replace-fail \
+              '    all_reduce<T>(input, output, stream, detail::MinOp<T>{});' \
+              '    all_reduce<T>(
+            input, output, stream, detail::MinOp<T>{}, [&] {
+              side_channel_.all_gather<int>(0);
+            });' \
+            --replace-fail \
+              '    Stream stream,
+        ReduceOp reduce_op) {' \
+              '    Stream stream,
+        ReduceOp reduce_op,
+        std::function<void()> recv_ready) {' \
+            --replace-fail \
+              '  encoder.dispatch([in_ptr, out_ptr, size, this, reduce_op]() {' \
+              '  encoder.dispatch([in_ptr, out_ptr, size, this, reduce_op, recv_ready]() {' \
+            --replace-fail \
+              '      mesh_.all_reduce(in_ptr, out_ptr, size, reduce_op);' \
+              '      mesh_.all_reduce(in_ptr, out_ptr, size, reduce_op, recv_ready);'
+
+          substituteInPlace mlx/distributed/jaccl/mesh_impl.h \
+            --replace-fail \
+              '#include <span>' \
+              '#include <functional>
+    #include <span>' \
+            --replace-fail \
+              '  all_reduce(const T* in_ptr, T* out_ptr, int64_t size, ReduceOp reduce_op) {' \
+              '  all_reduce(
+          const T* in_ptr,
+          T* out_ptr,
+          int64_t size,
+          ReduceOp reduce_op,
+          std::function<void()> recv_ready) {' \
+            --replace-fail \
+              '    // Prefill the pipeline
+        int buff = 0;
+        while (read_offset < total && buff < PIPELINE) {
+          post_recv_all(sz, buff);
+          std::copy(
+              data + read_offset,
+              data + std::min(read_offset + N, total),
+              send_buffer(sz, buff).begin<T>());
+          post_send_all(sz, buff);
+
+          buff++;
+          in_flight += 2 * num_peers;
+          read_offset += N;
+        }
+
+        // Main loop' \
+              '    // Prefill the pipeline
+        int buff = 0;
+        int preposted = 0;
+        while (read_offset < total && buff < PIPELINE) {
+          post_recv_all(sz, buff);
+          std::copy(
+              data + read_offset,
+              data + std::min(read_offset + N, total),
+              send_buffer(sz, buff).begin<T>());
+
+          buff++;
+          preposted++;
+          in_flight += num_peers;
+          read_offset += N;
+        }
+
+        recv_ready();
+
+        for (int b = 0; b < preposted; b++) {
+          post_send_all(sz, b);
+          in_flight += num_peers;
+        }
+
+        // Main loop'
+
+          for f in mlx/distributed/jaccl/mesh.cpp mlx/distributed/jaccl/ring.cpp; do
+            substituteInPlace "$f" \
+              --replace-fail \
+                '  side_channel_.all_gather<int>(0);' \
+                '  side_channel_.all_gather<int>(0);
+      side_channel_.all_gather<int>(0);'
+          done
+
+          substituteInPlace mlx/backend/rocm/CMakeLists.txt \
+            --replace-fail \
+              'if(arch MATCHES "^gfx1[12]")' \
+              'if(arch MATCHES "^gfx12" OR arch MATCHES "^gfx110[0-2]$" OR arch MATCHES "^gfx115[0-3]$")' \
+            --replace-fail \
+              'message(STATUS "HIP include flags: ''${HIP_INCLUDE_FLAGS}")' \
+              'list(APPEND HIP_INCLUDE_FLAGS "-I${rocmPackages.rocwmma}/include")
+    message(STATUS "HIP include flags: ''${HIP_INCLUDE_FLAGS}")'
+          substituteInPlace mlx/backend/rocm/quantized/qmm.hip \
+            --replace-fail \
+              'defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1103__) || \
+        defined(__gfx1150__)' \
+              'defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
+        defined(__gfx1150__)' \
+            --replace-fail \
+              '      } else if (std::strstr(arch_name, "gfx11") != nullptr) {
+            hw.tier = RocmQmvArchTier::Rdna3;
+            hw.simds_per_cu = 2;
+            hw.has_wmma = true;
+          } else if (std::strstr(arch_name, "gfx10") != nullptr) {' \
+              '      } else if (std::strstr(arch_name, "gfx1103") != nullptr) {
+            hw.tier = RocmQmvArchTier::Rdna3;
+            hw.simds_per_cu = 2;
+            hw.has_wmma = false;
+          } else if (std::strstr(arch_name, "gfx11") != nullptr) {
+            hw.tier = RocmQmvArchTier::Rdna3;
+            hw.simds_per_cu = 2;
+            hw.has_wmma = true;
+          } else if (std::strstr(arch_name, "gfx10") != nullptr) {'
+  '';
+
+  buildInputs =
+    (old.buildInputs or [ ])
+    ++ [
+      rdma-core
+      rdma-core.dev
+    ]
+    ++ (with rocmPackages; [
+      clr
+      rocblas
+      hipblas
+      hipblas-common
+      hipblaslt
+      composable_kernel
+      rocthrust
+      rocprim
+      hiprand
+      rocrand
+      rocwmma
+    ]);
+
+  nativeBuildInputs =
+    (old.nativeBuildInputs or [ ])
+    ++ (with rocmPackages; [
+      hipcc
+      clang
+    ]);
+
+  env = (old.env or { }) // {
+    CMAKE_ARGS = lib.concatStringsSep " " [
+      ((old.env or { }).CMAKE_ARGS or "")
+      "-DMLX_BUILD_METAL=OFF"
+      "-DMLX_BUILD_ROCM=ON"
+      "-DCMAKE_HIP_ARCHITECTURES=${gfx}"
+      "-DCMAKE_C_COMPILER=${rocmPackages.clang}/bin/clang"
+      "-DCMAKE_CXX_COMPILER=${rocmPackages.clang}/bin/clang++"
+      "-DMLX_BUILD_TESTS=OFF"
+    ];
+    NIX_CFLAGS_COMPILE = ((old.env or { }).NIX_CFLAGS_COMPILE or "") + " -I${rdma-core.dev}/include";
+  };
+
+  doCheck = false;
+  doInstallCheck = false;
+  pythonImportsCheck = [ ];
+  nativeCheckInputs = [ ];
+
+  meta = old.meta // {
+    description = "MLX with ROCm backend and portable JACCL support";
+    platforms = [ "x86_64-linux" ];
+    broken = false;
+  };
+})


### PR DESCRIPTION
## Summary
- add standalone JACCL library packaging from a pinned MLX source for Linux and macOS
- add Linux MLX ROCm packaging with portable JACCL/RDMA fixes
- add macOS MLX Metal wheel packaging and required Metal kernel wheel dependency
- expose package-level checks and Hydra jobs for the JACCL/MLX library outputs

This intentionally does not add probes, benchmark runners, or application harnesses.

## Verification
- `nix flake check --no-build --all-systems`
- `nix build --no-link .#checks.x86_64-linux.format .#checks.x86_64-linux.deadnix .#checks.x86_64-linux.statix .#packages.x86_64-linux.jaccl .#packages.x86_64-linux.mlx-rocm`
