### PR TITLE
bench: expose AMDSMI sysfs in runner sandboxes

### DIFF
--- a/bench/suites/vllm.nix
+++ b/bench/suites/vllm.nix
@@ -282,8 +282,12 @@ let
         sandboxPaths = [
           "/dev/dri"
           "/dev/kfd"
+          "/sys/bus/pci/devices"
           "/sys/class/drm"
+          "/sys/class/hwmon"
           "/sys/class/kfd"
+          "/sys/class/net"
+          "/sys/class/scsi_host"
           resolvedModelRoot
         ];
       };

--- a/flake.nix
+++ b/flake.nix
@@ -1305,6 +1305,10 @@
                     and (.sandboxPaths | index("/models") != null)
                     and (.sandboxPaths | index("/dev/dri") != null)
                     and (.sandboxPaths | index("/dev/kfd") != null)
+                    and (.sandboxPaths | index("/sys/class/hwmon") != null)
+                    and (.sandboxPaths | index("/sys/class/net") != null)
+                    and (.sandboxPaths | index("/sys/class/scsi_host") != null)
+                    and (.sandboxPaths | index("/sys/bus/pci/devices") != null)
                     and (.sandboxPaths | index("/dev/accel") == null)
                     and (.sandboxPaths | index("/caller/device") != null)
                     and (.tmpfilesRules | index("d /models 0755 root root -") != null)
@@ -1388,6 +1392,10 @@
                     and .requirements.systemFeatures == [ "gfx1151" ]
                     and .requirements.hostProfiles == [ "linux-amd-kfd" ]
                     and (.requirements.sandboxPaths | index("/dev/kfd") != null)
+                    and (.requirements.sandboxPaths | index("/sys/class/hwmon") != null)
+                    and (.requirements.sandboxPaths | index("/sys/class/net") != null)
+                    and (.requirements.sandboxPaths | index("/sys/class/scsi_host") != null)
+                    and (.requirements.sandboxPaths | index("/sys/bus/pci/devices") != null)
                     and (.requirements.sandboxPaths | index("/models") != null)
                     and .model.id == "Qwen/Qwen3-0.6B"
                     and .env.HF_HOME == "/models/.cache/huggingface"

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -65,7 +65,11 @@ let
     ]
     ++ optionals hasAmdGpu [
       "/dev/kfd"
+      "/sys/bus/pci/devices"
+      "/sys/class/hwmon"
       "/sys/class/kfd"
+      "/sys/class/net"
+      "/sys/class/scsi_host"
     ]
     ++ optionals hasAmdNpu [
       "/dev/accel"


### PR DESCRIPTION
## Summary
- expose AMDSMI/Broadcom discovery sysfs views from AMD GPU benchmark runners
- declare the same sysfs paths in vLLM benchmark requirements
- extend metadata checks so vLLM and runner sandbox requirements stay in sync

## Tests
- nix build --no-link .#checks.x86_64-linux.format .#checks.x86_64-linux.benchmark-runner-profiles .#checks.x86_64-linux.vllm-benchmark-metadata
- nix flake check --no-build --impure