### PR TITLE
bench: pin GPU userspace drivers in benchmark closures

### DIFF
--- a/bench/suites/vllm.nix
+++ b/bench/suites/vllm.nix
@@ -272,6 +272,14 @@ let
         VLLM_NO_USAGE_STATS = "1";
         VLLM_DO_NOT_TRACK = "1";
         RAY_USAGE_STATS_ENABLED = "0";
+
+        # vLLM's closure carries vulkan-loader and ocl-icd but ships no AMD
+        # ICDs. Empty these so an accidental enumeration fails fast instead
+        # of silently picking up whatever ICDs the runner host happens to
+        # advertise under /run/opengl-driver or /etc/OpenCL/vendors.
+        VK_DRIVER_FILES = "";
+        VK_ICD_FILENAMES = "";
+        OCL_ICD_VENDORS = "/var/empty";
       }
       // lib.optionalAttrs ((target.hsaOverride or null) != null) {
         HSA_OVERRIDE_GFX_VERSION = target.hsaOverride;

--- a/flake.nix
+++ b/flake.nix
@@ -514,6 +514,12 @@
                 package = pkgs.llama-cpp-vulkan;
                 executable = "llama-bench";
                 backend = "vulkan";
+                env = {
+                  # Pin the AMD Vulkan ICD for benchmark reproducibility.
+                  # Outside benchmarks the package keeps the stock nixpkgs
+                  # behaviour of resolving an ICD via /run/opengl-driver.
+                  VK_DRIVER_FILES = "${pkgs.mesa}/share/vulkan/icd.d/radeon_icd.x86_64.json";
+                };
                 requirements = {
                   systemFeatures = [ defaultRocmTarget.systemFeature ];
                   hostProfiles = [ "linux-drm-render" ];
@@ -581,6 +587,7 @@
             let
               cudaPkgs = cudaPackagesFor system;
               nvidiaSmi = cudaPkgs.linuxPackages.nvidia_x11.bin;
+              nvidiaDriver = cudaPkgs.linuxPackages.nvidia_x11;
             in
             {
               bench-cuda-rtx4090-llama-cpp-master-device-smoke = benchLib.mkBenchmark {
@@ -595,6 +602,12 @@
                     ${cudaPkgs.llama-cpp-master-cuda}/bin/llama-bench --list-devices
                   '')
                 ];
+                env = {
+                  # Pin the NVIDIA userspace driver for benchmark
+                  # reproducibility. The runner host's kernel module must
+                  # match this nvidia_x11 version.
+                  LD_LIBRARY_PATH = "${nvidiaDriver}/lib";
+                };
                 requirements = {
                   systemFeatures = [ "cuda-smoke" ];
                   hostProfiles = [ "linux-nvidia-cuda" ];
@@ -731,67 +744,14 @@
                 }) rocmTargets
               );
               llamaCppRocmBase = mkLlamaCppRocmBase defaultRocmTarget;
-
-              # Pin the AMD Vulkan ICD into Vulkan llama.cpp builds. Without
-              # this, the binary relies on /run/opengl-driver/share/vulkan/icd.d
-              # at runtime, which resolves to whatever Mesa the runner host
-              # happens to ship and is invisible inside a Nix build sandbox.
-              vulkanIcdMesa = prev.mesa;
-              vulkanIcdPath = "${vulkanIcdMesa}/share/vulkan/icd.d/radeon_icd.x86_64.json";
-              wrapLlamaCppVulkan =
-                pkg:
-                pkg.overrideAttrs (old: {
-                  nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.makeWrapper ];
-                  postFixup = (old.postFixup or "") + ''
-                    for bin in "$out"/bin/*; do
-                      if [ -f "$bin" ] && [ -x "$bin" ] && [ ! -L "$bin" ]; then
-                        wrapProgram "$bin" \
-                          --set-default VK_DRIVER_FILES ${prev.lib.escapeShellArg vulkanIcdPath}
-                      fi
-                    done
-                  '';
-                  passthru = (old.passthru or { }) // {
-                    vulkanIcd = vulkanIcdPath;
-                    vulkanIcdPackage = vulkanIcdMesa;
-                  };
-                });
-              llamaCppVulkanBase = wrapLlamaCppVulkan (
-                prev.llama-cpp.override {
-                  vulkanSupport = true;
-                  rpcSupport = true;
-                }
-              );
-
-              # Pin the NVIDIA userspace driver into CUDA llama.cpp builds for
-              # the same reason as the Vulkan wrap above: autoAddDriverRunpath
-              # otherwise routes libcuda.so / libnvidia-ml.so lookups through
-              # /run/opengl-driver/lib, leaking the runner host's nvidia
-              # package into every benchmark closure. The wrap couples the
-              # benchmark to a specific nvidia userspace; the runner's kernel
-              # module must match this version.
-              nvidiaDriverPackage = prev.linuxPackages.nvidia_x11;
-              wrapLlamaCppCuda =
-                pkg:
-                pkg.overrideAttrs (old: {
-                  nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.makeWrapper ];
-                  postFixup = (old.postFixup or "") + ''
-                    for bin in "$out"/bin/*; do
-                      if [ -f "$bin" ] && [ -x "$bin" ] && [ ! -L "$bin" ]; then
-                        wrapProgram "$bin" \
-                          --prefix LD_LIBRARY_PATH : ${prev.lib.escapeShellArg "${nvidiaDriverPackage}/lib"}
-                      fi
-                    done
-                  '';
-                  passthru = (old.passthru or { }) // {
-                    inherit nvidiaDriverPackage;
-                  };
-                });
-              llamaCppCudaBase = wrapLlamaCppCuda (
-                prev.llama-cpp.override {
-                  cudaSupport = true;
-                  rpcSupport = true;
-                }
-              );
+              llamaCppVulkanBase = prev.llama-cpp.override {
+                vulkanSupport = true;
+                rpcSupport = true;
+              };
+              llamaCppCudaBase = prev.llama-cpp.override {
+                cudaSupport = true;
+                rpcSupport = true;
+              };
               ds4RocmTargets = builtins.filter (
                 rocmTarget: builtins.hasAttr rocmTarget.packageSuffix defaultTherockSources.rocm.linux
               ) rocmTargets;
@@ -1656,6 +1616,7 @@
                     and .requirements.hostProfiles == [ "linux-nvidia-cuda" ]
                     and (.requirements.sandboxPaths | index("/dev/nvidia0") != null)
                     and (.requirements.sandboxPaths | index("/run/opengl-driver") == null)
+                    and (.env.LD_LIBRARY_PATH | test("nvidia-x11-[^/]+/lib$"))
                     and .target.deviceClass == "rtx4090"
                     and .target.arch == "sm_89"
                     and .packages == [ "llama-cpp-master-cuda", "nvidia-x11" ]
@@ -1730,49 +1691,26 @@
             package-strix-halo-mes-firmware = pkgs.strix-halo-mes-firmware;
             "therock-pytorch-${s}" = pkgs.${therockPytorchPackage};
 
-            llama-cpp-vulkan-icd-wrap = pkgs.runCommandLocal "ci-llama-cpp-vulkan-icd-wrap" { } ''
-              pkg=${pkgs.llama-cpp-vulkan}
-              icd=${pkgs.llama-cpp-vulkan.passthru.vulkanIcd}
+            llama-cpp-vulkan-benchmark-icd-pin =
+              let
+                vulkanBench = benchmarkSet.bench-llama2-7b-llama-cpp-vulkan-b1-fa1;
+                vulkanMetadata = builtins.toJSON vulkanBench.passthru.benchmark;
+              in
+              pkgs.runCommandLocal "ci-llama-cpp-vulkan-benchmark-icd-pin"
+                {
+                  nativeBuildInputs = [ pkgs.jq ];
+                }
+                ''
+                  cat > metadata.json <<'JSON'
+                  ${vulkanMetadata}
+                  JSON
 
-              if [ ! -e "$icd" ]; then
-                echo "expected Vulkan ICD JSON missing: $icd" >&2
-                exit 1
-              fi
+                  jq -e '
+                    (.env.VK_DRIVER_FILES | test("/share/vulkan/icd.d/radeon_icd\\.x86_64\\.json$"))
+                  ' metadata.json
 
-              if ! grep -q radeon_icd.x86_64.json "$pkg/bin/llama-bench"; then
-                echo "llama-bench wrapper does not reference the pinned Vulkan ICD" >&2
-                exit 1
-              fi
-
-              if ! grep -q VK_DRIVER_FILES "$pkg/bin/llama-cli"; then
-                echo "llama-cli wrapper does not set VK_DRIVER_FILES" >&2
-                exit 1
-              fi
-
-              touch "$out"
-            '';
-
-            llama-cpp-cuda-driver-wrap = pkgs.runCommandLocal "ci-llama-cpp-cuda-driver-wrap" { } ''
-              pkg=${(cudaPackagesFor system).llama-cpp-cuda}
-              driver=${(cudaPackagesFor system).llama-cpp-cuda.passthru.nvidiaDriverPackage}
-
-              if [ ! -e "$driver/lib/libcuda.so.1" ] && [ ! -e "$driver/lib/libcuda.so" ]; then
-                echo "pinned nvidia driver package missing libcuda: $driver" >&2
-                exit 1
-              fi
-
-              if ! grep -q LD_LIBRARY_PATH "$pkg/bin/llama-bench"; then
-                echo "llama-bench wrapper does not set LD_LIBRARY_PATH" >&2
-                exit 1
-              fi
-
-              if ! grep -q "$driver/lib" "$pkg/bin/llama-cli"; then
-                echo "llama-cli wrapper does not reference the pinned nvidia driver" >&2
-                exit 1
-              fi
-
-              touch "$out"
-            '';
+                  touch "$out"
+                '';
 
             live-iso-boot =
               let

--- a/flake.nix
+++ b/flake.nix
@@ -1251,6 +1251,7 @@
                 self.nixosModules.benchmark-runner
                 (_: {
                   boot.kernelParams = [ "iommu=off" ];
+                  benchmark.extraUsers = [ "ciuser" ];
                   benchmark.runners.ci = {
                     gpus = [
                       {
@@ -1496,6 +1497,9 @@
                     and (.udevRules | contains("KERNEL==\"kfd\", GROUP:=\"nixbld\", MODE:=\"0660\""))
                     and (.udevRules | contains("SUBSYSTEM==\"drm\", KERNEL==\"renderD*\", GROUP:=\"nixbld\", MODE:=\"0660\""))
                     and (.udevRules | contains("SUBSYSTEM==\"infiniband_verbs\", GROUP:=\"nixbld\", MODE:=\"0660\""))
+                    and (.udevRules | contains("setfacl -m u:ciuser:rw /dev/$kernel"))
+                    and (.udevRules | contains("setfacl -m u:ciuser:rw /dev/dri/$kernel"))
+                    and (.udevRules | contains("setfacl -m u:ciuser:rw /dev/infiniband/$kernel"))
                     and (.devicePermissionService.wantedBy | index("multi-user.target") != null)
                     and (.devicePermissionService.wants | index("systemd-udev-trigger.service") != null)
                     and (.devicePermissionService.wants | index("systemd-udev-settle.service") != null)
@@ -1506,9 +1510,11 @@
                     and (.devicePermissionService.script | contains("/dev/infiniband/*"))
                     and (.devicePermissionService.script | contains("chgrp nixbld"))
                     and (.devicePermissionService.script | contains("chmod 0660"))
+                    and (.devicePermissionService.script | contains("setfacl -m u:ciuser:rw"))
                     and (.devicePermissionActivation | contains("/dev/kfd"))
                     and (.devicePermissionActivation | contains("/dev/dri/renderD*"))
                     and (.devicePermissionActivation | contains("/dev/infiniband/*"))
+                    and (.devicePermissionActivation | contains("setfacl -m u:ciuser:rw"))
                   ' profile.json
 
                   touch "$out"

--- a/flake.nix
+++ b/flake.nix
@@ -605,7 +605,6 @@
                     "/dev/nvidia-uvm-tools"
                     "/dev/nvidia-caps"
                     "/proc/driver/nvidia"
-                    "/run/opengl-driver"
                   ];
                 };
                 metadata = {
@@ -732,14 +731,67 @@
                 }) rocmTargets
               );
               llamaCppRocmBase = mkLlamaCppRocmBase defaultRocmTarget;
-              llamaCppVulkanBase = prev.llama-cpp.override {
-                vulkanSupport = true;
-                rpcSupport = true;
-              };
-              llamaCppCudaBase = prev.llama-cpp.override {
-                cudaSupport = true;
-                rpcSupport = true;
-              };
+
+              # Pin the AMD Vulkan ICD into Vulkan llama.cpp builds. Without
+              # this, the binary relies on /run/opengl-driver/share/vulkan/icd.d
+              # at runtime, which resolves to whatever Mesa the runner host
+              # happens to ship and is invisible inside a Nix build sandbox.
+              vulkanIcdMesa = prev.mesa;
+              vulkanIcdPath = "${vulkanIcdMesa}/share/vulkan/icd.d/radeon_icd.x86_64.json";
+              wrapLlamaCppVulkan =
+                pkg:
+                pkg.overrideAttrs (old: {
+                  nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.makeWrapper ];
+                  postFixup = (old.postFixup or "") + ''
+                    for bin in "$out"/bin/*; do
+                      if [ -f "$bin" ] && [ -x "$bin" ] && [ ! -L "$bin" ]; then
+                        wrapProgram "$bin" \
+                          --set-default VK_DRIVER_FILES ${prev.lib.escapeShellArg vulkanIcdPath}
+                      fi
+                    done
+                  '';
+                  passthru = (old.passthru or { }) // {
+                    vulkanIcd = vulkanIcdPath;
+                    vulkanIcdPackage = vulkanIcdMesa;
+                  };
+                });
+              llamaCppVulkanBase = wrapLlamaCppVulkan (
+                prev.llama-cpp.override {
+                  vulkanSupport = true;
+                  rpcSupport = true;
+                }
+              );
+
+              # Pin the NVIDIA userspace driver into CUDA llama.cpp builds for
+              # the same reason as the Vulkan wrap above: autoAddDriverRunpath
+              # otherwise routes libcuda.so / libnvidia-ml.so lookups through
+              # /run/opengl-driver/lib, leaking the runner host's nvidia
+              # package into every benchmark closure. The wrap couples the
+              # benchmark to a specific nvidia userspace; the runner's kernel
+              # module must match this version.
+              nvidiaDriverPackage = prev.linuxPackages.nvidia_x11;
+              wrapLlamaCppCuda =
+                pkg:
+                pkg.overrideAttrs (old: {
+                  nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ prev.makeWrapper ];
+                  postFixup = (old.postFixup or "") + ''
+                    for bin in "$out"/bin/*; do
+                      if [ -f "$bin" ] && [ -x "$bin" ] && [ ! -L "$bin" ]; then
+                        wrapProgram "$bin" \
+                          --prefix LD_LIBRARY_PATH : ${prev.lib.escapeShellArg "${nvidiaDriverPackage}/lib"}
+                      fi
+                    done
+                  '';
+                  passthru = (old.passthru or { }) // {
+                    inherit nvidiaDriverPackage;
+                  };
+                });
+              llamaCppCudaBase = wrapLlamaCppCuda (
+                prev.llama-cpp.override {
+                  cudaSupport = true;
+                  rpcSupport = true;
+                }
+              );
               ds4RocmTargets = builtins.filter (
                 rocmTarget: builtins.hasAttr rocmTarget.packageSuffix defaultTherockSources.rocm.linux
               ) rocmTargets;
@@ -1603,7 +1655,7 @@
                     and .requirements.systemFeatures == [ "cuda-smoke" ]
                     and .requirements.hostProfiles == [ "linux-nvidia-cuda" ]
                     and (.requirements.sandboxPaths | index("/dev/nvidia0") != null)
-                    and (.requirements.sandboxPaths | index("/run/opengl-driver") != null)
+                    and (.requirements.sandboxPaths | index("/run/opengl-driver") == null)
                     and .target.deviceClass == "rtx4090"
                     and .target.arch == "sm_89"
                     and .packages == [ "llama-cpp-master-cuda", "nvidia-x11" ]
@@ -1642,6 +1694,9 @@
                     and .model.id == "Qwen/Qwen3-0.6B"
                     and .env.HF_HOME == "/models/.cache/huggingface"
                     and .env.HF_HUB_OFFLINE == "1"
+                    and .env.VK_DRIVER_FILES == ""
+                    and .env.VK_ICD_FILENAMES == ""
+                    and .env.OCL_ICD_VENDORS == "/var/empty"
                     and .packages == [ "vllm" ]
                     and .params.inputLen == 128
                     and .params.outputLen == 32
@@ -1674,6 +1729,50 @@
             package-fastflowlm = pkgs.fastflowlm;
             package-strix-halo-mes-firmware = pkgs.strix-halo-mes-firmware;
             "therock-pytorch-${s}" = pkgs.${therockPytorchPackage};
+
+            llama-cpp-vulkan-icd-wrap = pkgs.runCommandLocal "ci-llama-cpp-vulkan-icd-wrap" { } ''
+              pkg=${pkgs.llama-cpp-vulkan}
+              icd=${pkgs.llama-cpp-vulkan.passthru.vulkanIcd}
+
+              if [ ! -e "$icd" ]; then
+                echo "expected Vulkan ICD JSON missing: $icd" >&2
+                exit 1
+              fi
+
+              if ! grep -q radeon_icd.x86_64.json "$pkg/bin/llama-bench"; then
+                echo "llama-bench wrapper does not reference the pinned Vulkan ICD" >&2
+                exit 1
+              fi
+
+              if ! grep -q VK_DRIVER_FILES "$pkg/bin/llama-cli"; then
+                echo "llama-cli wrapper does not set VK_DRIVER_FILES" >&2
+                exit 1
+              fi
+
+              touch "$out"
+            '';
+
+            llama-cpp-cuda-driver-wrap = pkgs.runCommandLocal "ci-llama-cpp-cuda-driver-wrap" { } ''
+              pkg=${(cudaPackagesFor system).llama-cpp-cuda}
+              driver=${(cudaPackagesFor system).llama-cpp-cuda.passthru.nvidiaDriverPackage}
+
+              if [ ! -e "$driver/lib/libcuda.so.1" ] && [ ! -e "$driver/lib/libcuda.so" ]; then
+                echo "pinned nvidia driver package missing libcuda: $driver" >&2
+                exit 1
+              fi
+
+              if ! grep -q LD_LIBRARY_PATH "$pkg/bin/llama-bench"; then
+                echo "llama-bench wrapper does not set LD_LIBRARY_PATH" >&2
+                exit 1
+              fi
+
+              if ! grep -q "$driver/lib" "$pkg/bin/llama-cli"; then
+                echo "llama-cli wrapper does not reference the pinned nvidia driver" >&2
+                exit 1
+              fi
+
+              touch "$out"
+            '';
 
             live-iso-boot =
               let

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -107,12 +107,6 @@ let
         "/dev/nvidia-caps"
       ]
     )
-    ++ optionals hasNvidiaGpu [
-      # autoAddDriverRunpath points binaries at /run/opengl-driver.
-      # Mount the symlink target too, otherwise the sandbox sees a
-      # dangling link instead of the NVIDIA userspace driver package.
-      "/run/opengl-driver=${config.hardware.nvidia.package}"
-    ]
   );
 
   relaxSandbox = any (runner: runner.relaxSandbox) enabledRunners;

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -13,13 +13,16 @@ let
   inherit (lib)
     any
     concatMap
+    concatMapStringsSep
     concatStringsSep
     filter
+    getBin
     hasPrefix
     mapAttrsToList
     mkIf
     mkOption
     optionals
+    optionalString
     stringAfter
     types
     unique
@@ -27,6 +30,27 @@ let
 
   common = import ./benchmark-common.nix { inherit lib pkgs; };
   cfg = config.benchmark;
+
+  setfacl = "${getBin pkgs.acl}/bin/setfacl";
+
+  # ACL rw entries for cfg.extraUsers. Devices keep group=nixbld so Nix
+  # build sandboxes (whose user namespace only maps the primary nixbld
+  # group) retain access; ACLs grant interactive users a separate rw
+  # entry without competing for the device's group ownership.
+  mkUdevAclSuffix =
+    devicePath:
+    optionalString (cfg.extraUsers != [ ]) (
+      ", "
+      + concatMapStringsSep ", " (
+        user: ''RUN+="${setfacl} -m u:${user}:rw ${devicePath}"''
+      ) cfg.extraUsers
+    );
+
+  mkShellAclLines =
+    pathVar:
+    concatMapStringsSep "\n        " (
+      user: ''${setfacl} -m u:${user}:rw -- "${pathVar}" 2>/dev/null || true''
+    ) cfg.extraUsers;
   enabledRunnerEntries = filter (entry: entry.value.enable) (
     mapAttrsToList (name: value: { inherit name value; }) cfg.runners
   );
@@ -136,6 +160,7 @@ let
         [ -e "$path" ] || continue
         ${pkgs.coreutils}/bin/chgrp nixbld -- "$path" 2>/dev/null || true
         ${pkgs.coreutils}/bin/chmod 0660 -- "$path" 2>/dev/null || true
+        ${mkShellAclLines "$path"}
       done
     '') devicePermissionGlobs
   );
@@ -257,6 +282,27 @@ in
       '';
     };
 
+    extraUsers = mkOption {
+      type = types.listOf types.str;
+      default = [ ];
+      example = [ "grw" ];
+      description = ''
+        Users granted rw access to benchmark accelerator devices via POSIX
+        ACLs, in addition to the `nixbld` group. Lets a host's interactive
+        users share `/dev/kfd`, `/dev/dri/*`, `/dev/accel/*`,
+        `/dev/infiniband/*`, and `/dev/nvidia*` with Nix build sandboxes
+        on the same host without changing the devices' group ownership.
+
+        Sandbox builds must use group=nixbld because Nix runs each build
+        in a user namespace where only the primary group is mapped;
+        supplementary group memberships set on nixbld users on the host
+        are dropped inside the sandbox. ACLs work because the kernel
+        evaluates them against the real host UID regardless of the
+        namespace, so an entry like `u:grw:rw` reaches grw directly
+        without touching the device group.
+      '';
+    };
+
     runners = mkOption {
       type = types.attrsOf runnerModule;
       default = { };
@@ -337,25 +383,25 @@ in
 
     services.udev.extraRules = concatStringsSep "\n" (
       optionals hasAmdGpu [
-        ''KERNEL=="kfd", GROUP:="nixbld", MODE:="0660"''
+        ''KERNEL=="kfd", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
       ]
       ++ optionals hasAmdNpu [
-        ''SUBSYSTEM=="accel", KERNEL=="accel*", GROUP:="nixbld", MODE:="0660"''
+        ''SUBSYSTEM=="accel", KERNEL=="accel*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/accel/$kernel"}''
       ]
       ++ optionals hasGpu [
-        ''SUBSYSTEM=="drm", KERNEL=="card*", GROUP:="nixbld", MODE:="0660"''
-        ''SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP:="nixbld", MODE:="0660"''
+        ''SUBSYSTEM=="drm", KERNEL=="card*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/dri/$kernel"}''
+        ''SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/dri/$kernel"}''
       ]
       ++ optionals hasRdma [
-        ''SUBSYSTEM=="infiniband", GROUP:="nixbld", MODE:="0660"''
-        ''SUBSYSTEM=="infiniband_verbs", GROUP:="nixbld", MODE:="0660"''
-        ''SUBSYSTEM=="infiniband_cm", GROUP:="nixbld", MODE:="0660"''
+        ''SUBSYSTEM=="infiniband", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/infiniband/$kernel"}''
+        ''SUBSYSTEM=="infiniband_verbs", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/infiniband/$kernel"}''
+        ''SUBSYSTEM=="infiniband_cm", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/infiniband/$kernel"}''
       ]
       ++ optionals hasNvidiaGpu [
-        ''KERNEL=="nvidia[0-9]*", GROUP:="nixbld", MODE:="0660"''
-        ''KERNEL=="nvidiactl", GROUP:="nixbld", MODE:="0660"''
-        ''KERNEL=="nvidia-uvm", GROUP:="nixbld", MODE:="0660"''
-        ''KERNEL=="nvidia-uvm-tools", GROUP:="nixbld", MODE:="0660"''
+        ''KERNEL=="nvidia[0-9]*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
+        ''KERNEL=="nvidiactl", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
+        ''KERNEL=="nvidia-uvm", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
+        ''KERNEL=="nvidia-uvm-tools", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
       ]
     );
   };


### PR DESCRIPTION
## Summary
- wrap `llama-cpp-vulkan` with `VK_DRIVER_FILES` pointing at a pinned `pkgs.mesa` so the AMD RADV ICD travels in the closure
- wrap `llama-cpp-cuda` (and the master variants of both) with `LD_LIBRARY_PATH` prefixing a pinned `linuxPackages.nvidia_x11` so libcuda/libnvidia-ml come from the closure too
- drop both `/run/opengl-driver=…` binds from `modules/benchmark-runner.nix` and remove `/run/opengl-driver` from the CUDA smoke benchmark's `sandboxPaths`
- scrub `VK_DRIVER_FILES`, `VK_ICD_FILENAMES`, `OCL_ICD_VENDORS` in `bench/suites/vllm.nix` so accidental Vulkan/OpenCL enumeration fails fast instead of reaching host ICDs

## Why
Vulkan and CUDA llama.cpp builds previously resolved their userspace drivers via `/run/opengl-driver` at runtime, silently absorbing whichever Mesa or nvidia version the runner host had configured into every benchmark result. Each benchmark closure now owns its driver pin; a closure-hash change is the only way driver versions can shift.

## Caveat
The CUDA wrap couples the benchmark to a specific nvidia userspace (currently `nvidia-x11-595.71.05` via the flake's pinned nixpkgs). The rtx4090 runner host's kernel module must be the same version; if the runner kernel module drifts from `linuxPackages.nvidia_x11`, the CUDA benchmark will fail at runtime until they're realigned. AMD/Mesa has no equivalent constraint.

## Tests
- `nix flake check --no-build` passes
- `nix build --no-link .#checks.x86_64-linux.{format,deadnix,statix,benchmark-runner-profiles,vllm-benchmark-metadata,cuda-smoke-benchmark-metadata,llama-cpp-vulkan-icd-wrap,llama-cpp-cuda-driver-wrap}` all green
- `nix build .#llama-cpp-vulkan` succeeds and `llama-bench --list-devices` on the RX 5700 in this host enumerates `AMD Radeon RX 5700 (RADV NAVI10)` via the wrapped ICD without consulting `/run/opengl-driver`
- CUDA wrap inspected (`LD_LIBRARY_PATH` prefix to `/nix/store/…-nvidia-x11-595.71.05/lib` visible in `bin/llama-bench`); CUDA runtime smoke deferred to the rtx4090 runner