### PR TITLE
ci: enable Dependabot Nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "nix"
+    directories:
+      - "/"
+      - "/hydra/benchmark"
+    schedule:
+      interval: "daily"
+    groups:
+      nix-inputs:
+        patterns:
+          - "*"
+        group-by: "dependency-name"
+    ignore:
+      # TheRock source inputs are generated from pkgs/therock/sources/rocm-source.json
+      # and must be bumped atomically by pkgs/therock/scripts/update-source-tree.py.
+      - dependency-name: "therock-src-*"
+      # GitHub Dependabot's Nix updater does not currently support private inputs.
+      - dependency-name: "thunderbolt-ibverbs"


### PR DESCRIPTION
## Summary
- add Dependabot version updates for the root flake and Hydra benchmark wrapper flake
- group updates by dependency name across both directories so matching lockfile bumps land in one PR
- ignore generated TheRock source inputs and the private thunderbolt-ibverbs input

## Notes
The benchmark wrapper has its own flake.lock and follows the root flake through a path input, so root and hydra/benchmark lock updates need to stay in sync. Dependabot's multi-directory config plus dependency-name grouping keeps those updates in one PR instead of racing two separate PRs.

The benchmark Hydra jobset still follows master via github:hellas-ai/nix-strix-halo/master?dir=hydra/benchmark, so benchmark runs happen from the merged state rather than from a standalone benchmark-update branch.

TheRock source pins are generated from pkgs/therock/sources/rocm-source.json and should be bumped atomically with the existing source-tree updater rather than as independent flake inputs.