### PR TITLE
benchmark-runner: grant nixbld via group ACL, preserve device groups

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1251,7 +1251,6 @@
                 self.nixosModules.benchmark-runner
                 (_: {
                   boot.kernelParams = [ "iommu=off" ];
-                  benchmark.extraUsers = [ "ciuser" ];
                   benchmark.runners.ci = {
                     gpus = [
                       {
@@ -1274,15 +1273,8 @@
             sandboxPaths = benchmarkRunnerProfileConfig.nix.settings.extra-sandbox-paths;
             tmpfilesRules = benchmarkRunnerProfileConfig.systemd.tmpfiles.rules;
             udevRules = benchmarkRunnerProfileConfig.services.udev.extraRules;
-            devicePermissionService = {
-              wantedBy =
-                benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.wantedBy;
-              wants = benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.wants;
-              after = benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.after;
-              script = benchmarkRunnerProfileConfig.systemd.services.benchmark-runner-device-permissions.script;
-            };
-            devicePermissionActivation =
-              benchmarkRunnerProfileConfig.system.activationScripts.benchmark-runner-device-permissions.text;
+            deviceAclActivation =
+              benchmarkRunnerProfileConfig.system.activationScripts.benchmark-runner-device-acls.text;
           };
 
           benchmarkExecutorConfig =
@@ -1490,31 +1482,23 @@
                     and (.sandboxPaths | index("/dev/accel?") == null)
                     and (.sandboxPaths | index("/caller/device") != null)
                     and (.tmpfilesRules | index("d /models 0755 root root -") != null)
-                    and (.tmpfilesRules | index("z /dev/kfd 0660 root nixbld -") != null)
-                    and (.tmpfilesRules | index("z /dev/dri/card* 0660 root nixbld -") != null)
-                    and (.tmpfilesRules | index("z /dev/dri/renderD* 0660 root nixbld -") != null)
-                    and (.tmpfilesRules | index("z /dev/infiniband/* 0660 root nixbld -") != null)
-                    and (.udevRules | contains("KERNEL==\"kfd\", GROUP:=\"nixbld\", MODE:=\"0660\""))
-                    and (.udevRules | contains("SUBSYSTEM==\"drm\", KERNEL==\"renderD*\", GROUP:=\"nixbld\", MODE:=\"0660\""))
-                    and (.udevRules | contains("SUBSYSTEM==\"infiniband_verbs\", GROUP:=\"nixbld\", MODE:=\"0660\""))
-                    and (.udevRules | contains("setfacl -m u:ciuser:rw /dev/$kernel"))
-                    and (.udevRules | contains("setfacl -m u:ciuser:rw /dev/dri/$kernel"))
-                    and (.udevRules | contains("setfacl -m u:ciuser:rw /dev/infiniband/$kernel"))
-                    and (.devicePermissionService.wantedBy | index("multi-user.target") != null)
-                    and (.devicePermissionService.wants | index("systemd-udev-trigger.service") != null)
-                    and (.devicePermissionService.wants | index("systemd-udev-settle.service") != null)
-                    and (.devicePermissionService.after | index("systemd-tmpfiles-setup-dev.service") != null)
-                    and (.devicePermissionService.after | index("systemd-udev-settle.service") != null)
-                    and (.devicePermissionService.script | contains("/dev/kfd"))
-                    and (.devicePermissionService.script | contains("/dev/dri/renderD*"))
-                    and (.devicePermissionService.script | contains("/dev/infiniband/*"))
-                    and (.devicePermissionService.script | contains("chgrp nixbld"))
-                    and (.devicePermissionService.script | contains("chmod 0660"))
-                    and (.devicePermissionService.script | contains("setfacl -m u:ciuser:rw"))
-                    and (.devicePermissionActivation | contains("/dev/kfd"))
-                    and (.devicePermissionActivation | contains("/dev/dri/renderD*"))
-                    and (.devicePermissionActivation | contains("/dev/infiniband/*"))
-                    and (.devicePermissionActivation | contains("setfacl -m u:ciuser:rw"))
+                    and (.tmpfilesRules | map(test("^z /dev/")) | any | not)
+                    and (.udevRules | contains("GROUP:=\"nixbld\"") | not)
+                    and (.udevRules | contains("MODE:=\"0660\"") | not)
+                    and (.udevRules | contains("KERNEL==\"kfd\", RUN+="))
+                    and (.udevRules | contains("setfacl -m g:nixbld:rw /dev/$kernel"))
+                    and (.udevRules | contains("SUBSYSTEM==\"drm\", KERNEL==\"card*\", RUN+="))
+                    and (.udevRules | contains("setfacl -m g:nixbld:rw /dev/dri/$kernel"))
+                    and (.udevRules | contains("SUBSYSTEM==\"drm\", KERNEL==\"renderD*\", RUN+="))
+                    and (.udevRules | contains("SUBSYSTEM==\"infiniband_verbs\", RUN+="))
+                    and (.udevRules | contains("setfacl -m g:nixbld:rw /dev/infiniband/$kernel"))
+                    and (.deviceAclActivation | contains("/dev/kfd"))
+                    and (.deviceAclActivation | contains("/dev/dri/card*"))
+                    and (.deviceAclActivation | contains("/dev/dri/renderD*"))
+                    and (.deviceAclActivation | contains("/dev/infiniband/*"))
+                    and (.deviceAclActivation | contains("setfacl -m g:nixbld:rw"))
+                    and (.deviceAclActivation | contains("chgrp") | not)
+                    and (.deviceAclActivation | contains("chmod") | not)
                   ' profile.json
 
                   touch "$out"

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -13,7 +13,6 @@ let
   inherit (lib)
     any
     concatMap
-    concatMapStringsSep
     concatStringsSep
     filter
     getBin
@@ -22,7 +21,6 @@ let
     mkIf
     mkOption
     optionals
-    optionalString
     stringAfter
     types
     unique
@@ -33,24 +31,13 @@ let
 
   setfacl = "${getBin pkgs.acl}/bin/setfacl";
 
-  # ACL rw entries for cfg.extraUsers. Devices keep group=nixbld so Nix
-  # build sandboxes (whose user namespace only maps the primary nixbld
-  # group) retain access; ACLs grant interactive users a separate rw
-  # entry without competing for the device's group ownership.
-  mkUdevAclSuffix =
-    devicePath:
-    optionalString (cfg.extraUsers != [ ]) (
-      ", "
-      + concatMapStringsSep ", " (
-        user: ''RUN+="${setfacl} -m u:${user}:rw ${devicePath}"''
-      ) cfg.extraUsers
-    );
-
-  mkShellAclLines =
-    pathVar:
-    concatMapStringsSep "\n        " (
-      user: ''${setfacl} -m u:${user}:rw -- "${pathVar}" 2>/dev/null || true''
-    ) cfg.extraUsers;
+  # Grant rw to the Nix build sandbox via a `g:nixbld:rw` POSIX ACL.
+  # The build user's primary gid is `nixbld`, which survives the user
+  # namespace, so this ACL match works without touching the device's
+  # default ownership/mode — upstream `video`/`render` groups and
+  # seat-ACL flows for interactive sessions remain intact.
+  mkUdevAcl = devicePath: ''RUN+="${setfacl} -m g:nixbld:rw ${devicePath}"'';
+  mkShellAcl = pathVar: ''${setfacl} -m g:nixbld:rw -- "${pathVar}" 2>/dev/null || true'';
   enabledRunnerEntries = filter (entry: entry.value.enable) (
     mapAttrsToList (name: value: { inherit name value; }) cfg.runners
   );
@@ -134,7 +121,7 @@ let
   );
 
   relaxSandbox = any (runner: runner.relaxSandbox) enabledRunners;
-  devicePermissionGlobs =
+  deviceAclGlobs =
     optionals hasAmdGpu [
       "/dev/kfd"
     ]
@@ -154,15 +141,13 @@ let
       "/dev/nvidia-uvm"
       "/dev/nvidia-uvm-tools"
     ];
-  applyDevicePermissions = concatStringsSep "\n" (
+  applyDeviceAcls = concatStringsSep "\n" (
     map (glob: ''
       for path in ${glob}; do
         [ -e "$path" ] || continue
-        ${pkgs.coreutils}/bin/chgrp nixbld -- "$path" 2>/dev/null || true
-        ${pkgs.coreutils}/bin/chmod 0660 -- "$path" 2>/dev/null || true
-        ${mkShellAclLines "$path"}
+        ${mkShellAcl "$path"}
       done
-    '') devicePermissionGlobs
+    '') deviceAclGlobs
   );
 
   isIommuParam =
@@ -282,27 +267,6 @@ in
       '';
     };
 
-    extraUsers = mkOption {
-      type = types.listOf types.str;
-      default = [ ];
-      example = [ "grw" ];
-      description = ''
-        Users granted rw access to benchmark accelerator devices via POSIX
-        ACLs, in addition to the `nixbld` group. Lets a host's interactive
-        users share `/dev/kfd`, `/dev/dri/*`, `/dev/accel/*`,
-        `/dev/infiniband/*`, and `/dev/nvidia*` with Nix build sandboxes
-        on the same host without changing the devices' group ownership.
-
-        Sandbox builds must use group=nixbld because Nix runs each build
-        in a user namespace where only the primary group is mapped;
-        supplementary group memberships set on nixbld users on the host
-        are dropped inside the sandbox. ACLs work because the kernel
-        evaluates them against the real host UID regardless of the
-        namespace, so an entry like `u:grw:rw` reaches grw directly
-        without touching the device group.
-      '';
-    };
-
     runners = mkOption {
       type = types.attrsOf runnerModule;
       default = { };
@@ -335,73 +299,38 @@ in
 
     systemd.tmpfiles.rules = [
       "d ${modelsPath} 0755 root root -"
-    ]
-    ++ optionals hasAmdGpu [
-      "z /dev/kfd 0660 root nixbld -"
-    ]
-    ++ optionals hasGpu [
-      "z /dev/dri/card* 0660 root nixbld -"
-      "z /dev/dri/renderD* 0660 root nixbld -"
-    ]
-    ++ optionals hasAmdNpu [
-      "z /dev/accel/accel* 0660 root nixbld -"
-    ]
-    ++ optionals hasRdma [
-      "z /dev/infiniband/* 0660 root nixbld -"
-    ]
-    ++ optionals hasNvidiaGpu [
-      "z /dev/nvidia[0-9]* 0660 root nixbld -"
-      "z /dev/nvidiactl 0660 root nixbld -"
-      "z /dev/nvidia-uvm 0660 root nixbld -"
-      "z /dev/nvidia-uvm-tools 0660 root nixbld -"
     ];
 
-    system.activationScripts.benchmark-runner-device-permissions = mkIf (devicePermissionGlobs != [ ]) (
-      stringAfter [ "users" ] applyDevicePermissions
+    # At boot, the udev rules below fire `RUN+= setfacl` when each device
+    # appears. On `nixos-rebuild switch` (no reboot), existing device nodes
+    # were created under the previous udev rules; this activation script
+    # re-applies the ACL to those. `users` is the dependency because
+    # setfacl resolves `nixbld` against /etc/group.
+    system.activationScripts.benchmark-runner-device-acls = mkIf (deviceAclGlobs != [ ]) (
+      stringAfter [ "users" ] applyDeviceAcls
     );
-
-    systemd.services = mkIf (devicePermissionGlobs != [ ]) {
-      benchmark-runner-device-permissions = {
-        description = "Apply benchmark runner device permissions";
-        wantedBy = [ "multi-user.target" ];
-        wants = [
-          "systemd-udev-trigger.service"
-          "systemd-udev-settle.service"
-        ];
-        after = [
-          "systemd-udev-trigger.service"
-          "systemd-udev-settle.service"
-          "systemd-tmpfiles-setup-dev.service"
-        ];
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-        };
-        script = applyDevicePermissions;
-      };
-    };
 
     services.udev.extraRules = concatStringsSep "\n" (
       optionals hasAmdGpu [
-        ''KERNEL=="kfd", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
+        ''KERNEL=="kfd", ${mkUdevAcl "/dev/$kernel"}''
       ]
       ++ optionals hasAmdNpu [
-        ''SUBSYSTEM=="accel", KERNEL=="accel*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/accel/$kernel"}''
+        ''SUBSYSTEM=="accel", KERNEL=="accel*", ${mkUdevAcl "/dev/accel/$kernel"}''
       ]
       ++ optionals hasGpu [
-        ''SUBSYSTEM=="drm", KERNEL=="card*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/dri/$kernel"}''
-        ''SUBSYSTEM=="drm", KERNEL=="renderD*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/dri/$kernel"}''
+        ''SUBSYSTEM=="drm", KERNEL=="card*", ${mkUdevAcl "/dev/dri/$kernel"}''
+        ''SUBSYSTEM=="drm", KERNEL=="renderD*", ${mkUdevAcl "/dev/dri/$kernel"}''
       ]
       ++ optionals hasRdma [
-        ''SUBSYSTEM=="infiniband", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/infiniband/$kernel"}''
-        ''SUBSYSTEM=="infiniband_verbs", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/infiniband/$kernel"}''
-        ''SUBSYSTEM=="infiniband_cm", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/infiniband/$kernel"}''
+        ''SUBSYSTEM=="infiniband", ${mkUdevAcl "/dev/infiniband/$kernel"}''
+        ''SUBSYSTEM=="infiniband_verbs", ${mkUdevAcl "/dev/infiniband/$kernel"}''
+        ''SUBSYSTEM=="infiniband_cm", ${mkUdevAcl "/dev/infiniband/$kernel"}''
       ]
       ++ optionals hasNvidiaGpu [
-        ''KERNEL=="nvidia[0-9]*", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
-        ''KERNEL=="nvidiactl", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
-        ''KERNEL=="nvidia-uvm", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
-        ''KERNEL=="nvidia-uvm-tools", GROUP:="nixbld", MODE:="0660"${mkUdevAclSuffix "/dev/$kernel"}''
+        ''KERNEL=="nvidia[0-9]*", ${mkUdevAcl "/dev/$kernel"}''
+        ''KERNEL=="nvidiactl", ${mkUdevAcl "/dev/$kernel"}''
+        ''KERNEL=="nvidia-uvm", ${mkUdevAcl "/dev/$kernel"}''
+        ''KERNEL=="nvidia-uvm-tools", ${mkUdevAcl "/dev/$kernel"}''
       ]
     );
   };


### PR DESCRIPTION
## Summary

The benchmark-runner module's udev rules used to force `GROUP:=nixbld, MODE:=0660` on all benchmark accelerator devices (`/dev/dri/card*`, `/dev/dri/renderD*`, `/dev/nvidia*`, `/dev/kfd`, `/dev/accel/*`, `/dev/infiniband/*`). On hosts that double as interactive desktops, this clobbered the upstream nixpkgs defaults (`video`/`render` group ownership, seat-ACLs) — the desktop user could no longer open `/dev/dri/card*` or `/dev/nvidia*`, and Plasma silently fell back to software rendering.

Flip the model: device ownership/mode are left at upstream defaults, and a `g:nixbld:rw` POSIX ACL is added via `RUN+= setfacl`. The Nix build sandbox's primary gid is `nixbld`, which is preserved across the user namespace, so the ACL group entry matches without competing for the device's group ownership. Interactive sessions keep their default `video`/`render` access; the systemd-logind seat-ACL flow is unaffected.

## Cleanup

- Drop the `benchmark.extraUsers` option. With upstream defaults preserved, interactive users only need to be in `video`/`render` — the same as everywhere else in NixOS.
- Drop the `benchmark-runner-device-permissions` systemd service. It used to fix up devices at boot after the `tmpfiles z` rules clobbered ownership; both are gone now. udev `RUN+=` covers new-device events at boot; the activation script (renamed `benchmark-runner-device-acls`) covers `nixos-rebuild switch` against existing nodes.
- Drop the `tmpfiles z` rules — they only existed to keep the forced group ownership across reboots.
- Update the `benchmark-runner-profiles` check to assert the new contract (no `GROUP:=` overrides, no `z /dev/...` tmpfiles, `g:nixbld:rw` ACLs present).

## Test plan

- [x] `nix flake check --no-build` passes
- [x] `nix build .#checks.x86_64-linux.benchmark-runner-profiles` passes
- [x] Deployed on a host with an RTX 4090 + Granite Ridge iGPU; `/dev/dri/card*` returns to `root:video 0660` with `g:nixbld:rw` ACL; `/dev/nvidia*` returns to `root:root 0666` with `g:nixbld:rw` ACL; Plasma/desktop is no longer software-rendered
- [x] Deployed on a Strix Halo host; `sudo -u nixbld1 test -r /dev/kfd /dev/dri/card0 /dev/dri/renderD128` all succeed
- [x] Sandboxed `bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke` builds and runs against the GPU