### PR TITLE
meta: set local derivation maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # nix-strix-halo
 
 [![Hydra full][hydra-full-badge]][hydra-full]
+[hydra-full]: https://hydra.hellas.ai/job/hellas/nix-strix-halo/x86_64-linux.pr-full.all
 [hydra-full-badge]: https://img.shields.io/endpoint?label=hydra%20full&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fnix-strix-halo%2Fx86_64-linux.pr-full.all%2Fshield
 
 *NO SUPPORT / WARRANTY*

--- a/hydra.nix
+++ b/hydra.nix
@@ -229,9 +229,26 @@ let
     flattenBenchmarks genericBenchmarks // linuxBenchmarks // darwinBenchmarks // cudaRtx4090Benchmarks;
 
   # Hydra aggregates
+  maintainerMeta = {
+    maintainers = with lib.maintainers; [ georgewhewell ];
+  };
+
+  mkLinkFarm =
+    name: entries:
+    pkgs.runCommandLocal name
+      {
+        meta = maintainerMeta;
+      }
+      ''
+        mkdir -p "$out"
+        ${lib.concatMapStringsSep "\n" (entry: ''
+          ln -s ${entry.path} "$out"/${lib.escapeShellArg entry.name}
+        '') entries}
+      '';
+
   mkAggregate =
     aggregateName: jobs:
-    pkgs.linkFarm "nix-strix-halo-${aggregateName}" (
+    mkLinkFarm "nix-strix-halo-${aggregateName}" (
       lib.mapAttrsToList (name: path: {
         inherit name path;
       }) jobs
@@ -246,7 +263,7 @@ let
 
   afterPrQuick =
     name: path:
-    pkgs.linkFarm "nix-strix-halo-pr-full-${name}" (
+    mkLinkFarm "nix-strix-halo-pr-full-${name}" (
       lib.optionals isSourceCheckSystem [
         {
           name = "pr-quick";

--- a/lib/bench.nix
+++ b/lib/bench.nix
@@ -226,7 +226,10 @@ rec {
         meta = {
           inherit description;
         }
-        // meta;
+        // meta
+        // {
+          maintainers = with pkgs.lib.maintainers; [ georgewhewell ];
+        };
       }
       ''
         set -euo pipefail

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -39,6 +39,14 @@ lib.optionalAttrs prev.stdenv.isLinux (
       rpcSupport = true;
     };
 
+    georgewhewellMaintained =
+      drv:
+      drv.overrideAttrs (old: {
+        meta = (old.meta or { }) // {
+          maintainers = with lib.maintainers; [ georgewhewell ];
+        };
+      });
+
     masterRev = inputs.llama-cpp-master.shortRev or inputs.llama-cpp-master.rev or "unknown";
     # llama-cpp-master is the upstream HEAD variant. Override is via
     # `.overrideAttrs` (the package doesn't expose `src` through .override),
@@ -61,6 +69,9 @@ lib.optionalAttrs prev.stdenv.isLinux (
         (lib.cmakeBool "LLAMA_BUILD_UI" false)
         (lib.cmakeFeature "LLAMA_BUILD_NUMBER" "0")
       ];
+      meta = (old.meta or { }) // {
+        maintainers = with lib.maintainers; [ georgewhewell ];
+      };
     });
 
     # ROCm packages compile hundreds-to-thousands of HIP kernels via amdclang;
@@ -90,13 +101,15 @@ lib.optionalAttrs prev.stdenv.isLinux (
       src = inputs.fastflowlm;
     };
 
-    llama-cpp-rocm = bigParallel (prev.llama-cpp.override rocmOverride);
-    llama-cpp-vulkan = prev.llama-cpp.override vulkanOverride;
-    llama-cpp-cuda = prev.llama-cpp.override cudaOverride;
+    llama-cpp-rocm = bigParallel (georgewhewellMaintained (prev.llama-cpp.override rocmOverride));
+    llama-cpp-vulkan = georgewhewellMaintained (prev.llama-cpp.override vulkanOverride);
+    llama-cpp-cuda = georgewhewellMaintained (prev.llama-cpp.override cudaOverride);
     llama-cpp-master = llamaCppMaster;
-    llama-cpp-master-rocm = bigParallel (llamaCppMaster.override rocmOverride);
-    llama-cpp-master-vulkan = llamaCppMaster.override vulkanOverride;
-    llama-cpp-master-cuda = llamaCppMaster.override cudaOverride;
+    llama-cpp-master-rocm = bigParallel (
+      georgewhewellMaintained (llamaCppMaster.override rocmOverride)
+    );
+    llama-cpp-master-vulkan = georgewhewellMaintained (llamaCppMaster.override vulkanOverride);
+    llama-cpp-master-cuda = georgewhewellMaintained (llamaCppMaster.override cudaOverride);
 
     ds4-rocm = bigParallel (
       prev.callPackage ../pkgs/ds4-rocm {

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -303,6 +303,9 @@ let
           vllmFeatureOptions = featureFlags;
           vllmUnsupportedFeatures = unsupportedFeatureReasons;
         };
+        meta = (old.meta or { }) // {
+          maintainers = with lib.maintainers; [ georgewhewell ];
+        };
       });
 
   vllmTherock = lib.makeOverridable mkVllmTherock { };

--- a/pkgs/ds4-rocm/default.nix
+++ b/pkgs/ds4-rocm/default.nix
@@ -181,6 +181,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/ejpir/ds4-hip/tree/rocm-upstream-shape-cyberneurova";
     license = lib.licenses.mit;
     mainProgram = "ds4";
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/ds4/default.nix
+++ b/pkgs/ds4/default.nix
@@ -145,6 +145,7 @@ stdenv.mkDerivation {
     homepage = "https://github.com/antirez/ds4";
     license = lib.licenses.mit;
     mainProgram = "ds4";
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = lib.platforms.darwin;
   };
 }

--- a/pkgs/fastflowlm/default.nix
+++ b/pkgs/fastflowlm/default.nix
@@ -124,7 +124,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "High-performance LLM inference engine for AMD Ryzen AI NPUs";
     homepage = "https://github.com/FastFlowLM/FastFlowLM";
     license = lib.licenses.mit;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
     mainProgram = "flm";
   };

--- a/pkgs/jaccl/default.nix
+++ b/pkgs/jaccl/default.nix
@@ -328,6 +328,7 @@ stdenv.mkDerivation {
     description = "JACCL RDMA-over-Thunderbolt collective communication library from MLX";
     homepage = "https://github.com/ml-explore/mlx";
     license = licenses.mit;
+    maintainers = with maintainers; [ georgewhewell ];
     platforms = platforms.linux ++ [ "aarch64-darwin" ];
   };
 }

--- a/pkgs/mlx/metal.nix
+++ b/pkgs/mlx/metal.nix
@@ -187,6 +187,7 @@ mlx.overrideAttrs (old: {
         "Apple MLX with Metal backend built from source";
     homepage = "https://github.com/ml-explore/mlx";
     license = licenses.mit;
+    maintainers = with maintainers; [ georgewhewell ];
     platforms = [ "aarch64-darwin" ];
   };
 })

--- a/pkgs/mlx/rocm.nix
+++ b/pkgs/mlx/rocm.nix
@@ -399,6 +399,7 @@ mlx.overrideAttrs (old: {
   meta = old.meta // {
     description = "MLX with ROCm backend and portable JACCL support";
     changelog = "https://github.com/NripeshN/mlx/commit/39fac95d901c72175fce4baf973e375d4a054ba7";
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
     broken = false;
   };

--- a/pkgs/opentelemetry-semantic-conventions-ai/default.nix
+++ b/pkgs/opentelemetry-semantic-conventions-ai/default.nix
@@ -24,6 +24,6 @@ buildPythonPackage rec {
     description = "OpenTelemetry semantic conventions extension for generative AI";
     homepage = "https://github.com/traceloop/openllmetry/tree/main/packages/opentelemetry-semantic-conventions-ai";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ georgewhewell ];
   };
 }

--- a/pkgs/strix-halo-mes-firmware.nix
+++ b/pkgs/strix-halo-mes-firmware.nix
@@ -19,6 +19,7 @@ runCommand "strix-halo-mes-firmware-0x80"
       description = "Strix Halo MES 0x80 firmware blobs";
       homepage = "https://git.kernel.org/pub/scm/linux/kernel/git/firmware/linux-firmware.git";
       license = lib.licenses.unfreeRedistributableFirmware;
+      maintainers = with lib.maintainers; [ georgewhewell ];
       platforms = lib.platforms.linux;
     };
   }

--- a/pkgs/therock/amdsmi/default.nix
+++ b/pkgs/therock/amdsmi/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   buildPythonPackage,
   python,
   wheels,
@@ -31,6 +32,7 @@ buildPythonPackage {
   meta = {
     description = "Python AMD SMI bindings from the matching TheRock Python ROCm bundle";
     homepage = "https://github.com/ROCm/TheRock";
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/therock/python-env/default.nix
+++ b/pkgs/therock/python-env/default.nix
@@ -147,6 +147,7 @@ stdenv.mkDerivation {
   meta = {
     description = "TheRock pinned Python ROCm/PyTorch wheel runtime for ${wheelSources.target}";
     homepage = "https://github.com/ROCm/TheRock";
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/therock/python-wheels/default.nix
+++ b/pkgs/therock/python-wheels/default.nix
@@ -151,6 +151,7 @@ python312Packages.buildPythonPackage (finalAttrs: {
   meta = {
     description = "TheRock pinned ROCm/PyTorch/Triton wheels for ${wheelSources.target}";
     homepage = "https://github.com/ROCm/TheRock";
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
   };
 })

--- a/pkgs/therock/rocm-env/default.nix
+++ b/pkgs/therock/rocm-env/default.nix
@@ -76,6 +76,7 @@ writeShellApplication {
 
   meta = with lib; {
     description = "Run a command inside the TheRock ${packageSuffix} ROCm SDK environment";
+    maintainers = with maintainers; [ georgewhewell ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/therock/rocm-from-source/default.nix
+++ b/pkgs/therock/rocm-from-source/default.nix
@@ -1319,6 +1319,7 @@ stdenv.mkDerivation {
     description = "TheRock ROCm ${version} built from source for ${target}";
     homepage = "https://github.com/ROCm/TheRock";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/therock/rocm-rocshmem-env/default.nix
+++ b/pkgs/therock/rocm-rocshmem-env/default.nix
@@ -74,6 +74,7 @@ writeShellApplication {
 
   meta = with lib; {
     description = "Run a command inside TheRock ${packageSuffix} with rocSHMEM + IB verbs sysfs filter";
+    maintainers = with maintainers; [ georgewhewell ];
     platforms = platforms.linux;
   };
 }

--- a/pkgs/therock/rocm-sdk/default.nix
+++ b/pkgs/therock/rocm-sdk/default.nix
@@ -175,6 +175,7 @@ stdenvNoCC.mkDerivation {
     description = "TheRock ROCm SDK binary tarball for ${target}";
     homepage = "https://github.com/ROCm/TheRock";
     license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
   };
 }

--- a/pkgs/tokenizers-cpp/default.nix
+++ b/pkgs/tokenizers-cpp/default.nix
@@ -41,6 +41,7 @@ let
       description = "C FFI bindings for the Hugging Face tokenizers library";
       homepage = "https://github.com/mlc-ai/tokenizers-cpp";
       license = lib.licenses.asl20;
+      maintainers = with lib.maintainers; [ georgewhewell ];
       platforms = lib.platforms.unix;
     };
   };
@@ -85,7 +86,7 @@ stdenv.mkDerivation {
     description = "C++ wrapper for Hugging Face tokenizers with cross-platform support";
     homepage = "https://github.com/mlc-ai/tokenizers-cpp";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = lib.platforms.unix;
   };
 }

--- a/pkgs/xrt/default.nix
+++ b/pkgs/xrt/default.nix
@@ -119,7 +119,7 @@ stdenv.mkDerivation (finalAttrs: {
     description = "Xilinx Runtime for FPGA/ACAP devices (and Ryzen AI NPUs via xrt.xdna)";
     homepage = "https://github.com/Xilinx/XRT";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = lib.platforms.linux;
   };
 })

--- a/pkgs/xrt/xdna.nix
+++ b/pkgs/xrt/xdna.nix
@@ -96,7 +96,7 @@ let
       description = "AMD XDNA driver userspace plugin for XRT";
       homepage = "https://github.com/amd/xdna-driver";
       license = lib.licenses.asl20;
-      maintainers = [ ];
+      maintainers = with lib.maintainers; [ georgewhewell ];
       platforms = lib.platforms.linux;
     };
   };
@@ -118,7 +118,7 @@ symlinkJoin {
     description = "Xilinx Runtime with AMD XDNA NPU support for Ryzen AI";
     homepage = "https://github.com/amd/xdna-driver";
     license = lib.licenses.asl20;
-    maintainers = [ ];
+    maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = lib.platforms.linux;
   };
 }


### PR DESCRIPTION
## Summary
- set project-owned package, benchmark, and Hydra aggregate derivations to `lib.maintainers.georgewhewell`
- restore the missing `[hydra-full]` README badge link target

## Verification
- evaluated representative package, benchmark, nested benchmark, and Hydra aggregate `meta.maintainers` values as `["georgewhewell"]`
- checked Hydra shield and shields.io badge endpoints return HTTP 200
- ran `git diff --check`