### PR TITLE
Harden provider follow-up surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,21 @@ The package set is parameterised over three axes:
 
 | axis | tag/value source | default |
 |---|---|---|
-| rocm provider | `lib.rocmProviders` (`therock-bin`, `therock-source`) | `therock-bin` |
-| python provider | `lib.pythonProviders` (`therock-wheels`) | `therock-wheels` |
+| rocm provider | `lib.rocmProviders` (`therock-bin`, `therock-source`, `nixpkgs`) | `therock-bin` |
+| python provider | `lib.pythonProviders` (`therock-wheels`; future stubs in `lib.pythonProviderStubs`) | `therock-wheels` |
 | GPU target | `pkgs/therock/targets.nix` | `gfx1151` |
 
 Per-target packages (default providers) are available under
 `legacyPackages`:
 
 ```bash
-nix build .#legacyPackages.x86_64-linux.gfx1100.llama-cpp-rocm
+nix build .#legacyPackages.x86_64-linux.gfx1103.llama-cpp-rocm
 ```
+
+Only targets with matching TheRock binary/Python source pins expose
+TheRock-shaped packages such as `therock-rocm`, `ds4-rocm`, `mlx-rocm`, and
+`vllm-rocm`. At the moment those pins exist for `gfx1151`; `llama-cpp-rocm`
+is available for every target listed in `pkgs/therock/targets.nix`.
 
 For non-default providers compose your own overlays with `lib.mkRocmOverlay`,
 `lib.mkPythonOverlay`, and `lib.mkPkgsOverlay`. Add a new target by
@@ -97,13 +102,15 @@ the tag in `lib/providers.nix`.
 ## Hydra / CI
 
 `hydra.nix` (project root, not a flake output) composes the build matrix
-Hydra reads. Each default-target package gets a job, plus `-from-source`
-variants of `vllm-rocm`, `therock-rocm`, and `llama-cpp-rocm` that
-exercise the parameterised abstraction end-to-end.
+Hydra reads. It imports the flake to reuse its packages, checks, overlays,
+and helper libraries. Each default-target package gets a job, plus
+`-from-source` variants of `vllm-rocm`, `therock-rocm`, and
+`llama-cpp-rocm` that exercise the parameterised abstraction end-to-end.
 
 ```bash
 nix-build hydra.nix --argstr system x86_64-linux -A pr-full.all
 nix-build hydra.nix --argstr system x86_64-linux -A pr-full.vllm-rocm-from-source
+nix-build hydra.nix --argstr system x86_64-linux --argstr jobset benchmarks -A bench-mlx-rocm-gfx1151-gemm-smoke
 ```
 
 ## Development

--- a/flake.nix
+++ b/flake.nix
@@ -418,6 +418,24 @@
           pythonProvider ? "therock-wheels",
           cpu ? null,
         }:
+        let
+          suffix = rocmTarget.packageSuffix;
+          hasTherockRocmSource = lib.hasAttrByPath [
+            "rocm"
+            "linux"
+            suffix
+          ] defaultTherockSources;
+          hasTherockPythonSource = lib.hasAttrByPath [
+            "pythonWheels"
+            "targets"
+            suffix
+          ] defaultTherockSources;
+          enableTherockVllm =
+            rocmProvider != "nixpkgs"
+            && pythonProvider == "therock-wheels"
+            && hasTherockRocmSource
+            && hasTherockPythonSource;
+        in
         [
           thunderboltIbverbsOverlay
           thunderboltRenamesOverlay
@@ -437,6 +455,7 @@
             target = rocmTarget;
             vllmSrc = inputs.vllm-src;
             vllmVersion = "0.21.0";
+            enabled = enableTherockVllm;
           })
           (import ./overlays/pkgs.nix {
             inherit
@@ -444,7 +463,10 @@
               lib
               inputVersion
               rocmTarget
+              rocmProvider
+              pythonProvider
               ;
+            sources = defaultTherockSources;
           })
         ]
         ++ lib.optional (cpu != null) (import ./overlays/mtune.nix { inherit lib cpu; });
@@ -516,7 +538,7 @@
           mkLiveIsoConfiguration
           ;
         inherit (rocmTargetLib) mkRocmTarget;
-        inherit (providers) rocmProviders pythonProviders;
+        inherit (providers) rocmProviders pythonProviders pythonProviderStubs;
         therockTargets = therockTargetConfig;
         bench = benchLib;
 
@@ -539,6 +561,7 @@
           import ./overlays/pkgs.nix (
             {
               inherit lib inputs inputVersion;
+              sources = defaultTherockSources;
             }
             // args
           );
@@ -581,7 +604,7 @@
     }
     // {
       # Per-target pkgs sets. Use to escape-hatch to a non-default rocm
-      # target: `nix build .#legacyPackages.x86_64-linux.gfx1100.llama-cpp-rocm`.
+      # target: `nix build .#legacyPackages.x86_64-linux.gfx1103.llama-cpp-rocm`.
       legacyPackages = forAllSystems (
         system:
         lib.listToAttrs (
@@ -613,6 +636,7 @@
                 inherit inputs lib;
                 inputVersion = _: _: "version";
                 rocmTarget = defaultRocmTarget;
+                sources = defaultTherockSources;
               };
               allKeys = builtins.attrNames (overlay { } { stdenv.isLinux = true; });
             in
@@ -776,6 +800,68 @@
         // lib.optionalAttrs pkgs.stdenv.isDarwin darwinApps
       );
 
+      checks = perSystem (
+        pkgs:
+        lib.optionalAttrs (pkgs.stdenv.hostPlatform.system == "x86_64-linux") (
+          let
+            system = pkgs.stdenv.hostPlatform.system;
+            src = self;
+            runSourceCheck =
+              name: nativeBuildInputs: command:
+              pkgs.runCommandLocal "ci-${name}"
+                {
+                  inherit nativeBuildInputs;
+                  meta.maintainers = with lib.maintainers; [ georgewhewell ];
+                }
+                ''
+                  export HOME="$TMPDIR/home"
+                  export XDG_CACHE_HOME="$TMPDIR/cache"
+                  mkdir -p "$HOME" "$XDG_CACHE_HOME"
+                  cp -R --no-preserve=mode,ownership ${src} "$TMPDIR/src"
+                  chmod -R u+rwX "$TMPDIR/src"
+                  cd "$TMPDIR/src"
+                  ${command}
+                  touch "$out"
+                '';
+
+            packageSurface =
+              let
+                plain = builtins.unsafeDiscardStringContext;
+              in
+              assert
+                self.packages.${system}.llama-cpp-rocm.drvPath
+                == self.legacyPackages.${system}.gfx1151.llama-cpp-rocm.drvPath;
+              assert
+                self.packages.${system}.vllm-rocm.drvPath
+                == self.legacyPackages.${system}.gfx1151.vllm-rocm.drvPath;
+              assert !(self.packages.${system} ? llama-cpp-rocm-gfx1151);
+              assert !(self.packages.${system} ? vllm-rocm-therock-gfx1151);
+              assert !(self.legacyPackages.${system}.gfx1103 ? ds4-rocm);
+              assert !(self.legacyPackages.${system}.gfx1103 ? vllm-rocm);
+              pkgs.runCommandLocal "ci-package-surface"
+                {
+                  meta.maintainers = with lib.maintainers; [ georgewhewell ];
+                }
+                ''
+                  cat > "$out" <<'EOF'
+                  default llama-cpp-rocm: ${plain self.packages.${system}.llama-cpp-rocm.drvPath}
+                  legacy gfx1151 llama-cpp-rocm: ${plain self.legacyPackages.${system}.gfx1151.llama-cpp-rocm.drvPath}
+                  legacy gfx1103 llama-cpp-rocm: ${plain self.legacyPackages.${system}.gfx1103.llama-cpp-rocm.drvPath}
+                  default vllm-rocm: ${plain self.packages.${system}.vllm-rocm.drvPath}
+                  EOF
+                '';
+          in
+          {
+            deadnix = runSourceCheck "deadnix" [ pkgs.deadnix ] "deadnix --fail .";
+            statix = runSourceCheck "statix" [ pkgs.statix ] "statix check .";
+            nixfmt = runSourceCheck "nixfmt" [
+              pkgs.nixfmt-tree
+            ] "treefmt --tree-root . --walk filesystem --fail-on-change .";
+            package-surface = packageSurface;
+          }
+        )
+      );
+
       devShells = perSystem (pkgs: {
         default = pkgs.mkShell {
           packages =
@@ -798,12 +884,6 @@
       });
 
       formatter = perSystem (pkgs: pkgs.nixfmt-tree);
-
-      # Hydra reads its jobset from `flake.hydraJobs`. The build matrix
-      # itself lives in ./hydra.nix (so curious humans can `nix-build
-      # hydra.nix -A pr-full.all` without a flake roundtrip); expose it
-      # here too so Hydra's flake-aware evaluator finds something.
-      hydraJobs = forAllSystems (system: import ./hydra.nix { inherit self system; });
 
     };
 }

--- a/hydra.nix
+++ b/hydra.nix
@@ -16,6 +16,8 @@
 {
   self ? builtins.getFlake (toString ./.),
   system ? builtins.currentSystem,
+  jobset ? "default",
+  ...
 }:
 
 let
@@ -228,6 +230,32 @@ let
   benchmarks =
     flattenBenchmarks genericBenchmarks // linuxBenchmarks // darwinBenchmarks // cudaRtx4090Benchmarks;
 
+  supportedBenchmarkFeatures = {
+    x86_64-linux = [
+      "benchmark"
+      "gfx1151"
+      "xdna2"
+      "rtx4090"
+    ];
+    aarch64-darwin = [ "benchmark" ];
+  };
+
+  addBenchmarkFeature =
+    drv:
+    drv.overrideAttrs (old: {
+      requiredSystemFeatures = lib.unique ((old.requiredSystemFeatures or [ ]) ++ [ "benchmark" ]);
+    });
+
+  supportedOnBenchmarkHost =
+    _name: drv:
+    lib.all (feature: lib.elem feature (supportedBenchmarkFeatures.${system} or [ ])) (
+      drv.requiredSystemFeatures or [ ]
+    );
+
+  benchmarkJobs = lib.filterAttrs supportedOnBenchmarkHost (
+    lib.mapAttrs (_: addBenchmarkFeature) benchmarks
+  );
+
   # Hydra aggregates
   maintainerMeta = {
     maintainers = with lib.maintainers; [ georgewhewell ];
@@ -256,9 +284,9 @@ let
 
   isSourceCheckSystem = system == "x86_64-linux";
 
-  # pr-quick currently has no jobs — flake.checks lost its metadata
-  # assertions in the cleanup. Bring them back here later if needed.
-  prQuickJobs = { };
+  # Keep the fast source/evaluation checks ahead of every pr-full link-farm
+  # entry so Hydra catches regressions before scheduling the heavier jobs.
+  prQuickJobs = lib.optionalAttrs isSourceCheckSystem self.checks.${system};
   prQuick = mkAggregate "pr-quick" prQuickJobs;
 
   afterPrQuick =
@@ -286,6 +314,23 @@ let
       rocmProvider,
       pythonProvider ? "therock-wheels",
     }:
+    let
+      suffix = defaultRocmTarget.packageSuffix;
+      sources = flakeLib.defaultTherockSources;
+      enableTherockVllm =
+        rocmProvider != "nixpkgs"
+        && pythonProvider == "therock-wheels"
+        && lib.hasAttrByPath [
+          "rocm"
+          "linux"
+          suffix
+        ] sources
+        && lib.hasAttrByPath [
+          "pythonWheels"
+          "targets"
+          suffix
+        ] sources;
+    in
     import nixpkgs {
       inherit system;
       config = {
@@ -327,8 +372,12 @@ let
           target = defaultRocmTarget;
           vllmSrc = self.inputs.vllm-src;
           vllmVersion = "0.21.0";
+          enabled = enableTherockVllm;
         })
-        (flakeLib.mkPkgsOverlay { rocmTarget = defaultRocmTarget; })
+        (flakeLib.mkPkgsOverlay {
+          inherit rocmProvider pythonProvider;
+          rocmTarget = defaultRocmTarget;
+        })
       ];
     };
 
@@ -336,9 +385,9 @@ let
     rocmProvider = "therock-source";
   });
 
-  # nixpkgs.rocmPackages.${suffix} narrowed scope. vllm/ds4/mlx hard-ref
-  # TheRock attrs and don't resolve here, but llama-cpp-rocm exercises
-  # the dispatcher cleanly.
+  # nixpkgs.rocmPackages.${suffix} narrowed scope. The package overlay
+  # hides TheRock-shaped attrs for this provider, so llama-cpp-rocm is
+  # the provider-dispatch smoke here.
   nixpkgsRocmPkgs = lib.optionalAttrs (system == "x86_64-linux") (mkPkgsForProvider {
     rocmProvider = "nixpkgs";
   });
@@ -376,9 +425,7 @@ let
     vllm-throughput-smoke =
       afterPrQuick "vllm-throughput-smoke"
         benchmarks."bench-qwen3-0-6b-vllm-rocm-${defaultRocmTarget.packageSuffix}-throughput-smoke";
-    fastflowlm-npu-smoke =
-      afterPrQuick "fastflowlm-npu-smoke"
-        benchmarks.bench-llama3-2-1b-fastflowlm-medium;
+    fastflowlm-npu-smoke = afterPrQuick "fastflowlm-npu-smoke" benchmarks.bench-llama3-2-1b-fastflowlm-medium;
     cuda-rtx4090-device-smoke = afterPrQuick "cuda-rtx4090-device-smoke" benchmarks.bench-cuda-rtx4090-llama-cpp-master-device-smoke;
 
     # Provider-variant builds. Exercise the rocm.nix dispatcher
@@ -392,21 +439,28 @@ let
     # are TheRock-shaped).
     llama-cpp-rocm-nixpkgs = nixpkgsRocmPkgs.llama-cpp-rocm;
   };
+
+  defaultJobs = {
+    inherit benchmarks;
+
+    pr-quick = prQuickJobs // {
+      all = prQuick;
+    };
+
+    pr-full = prFullJobs // {
+      all = mkAggregate "pr-full" prFullJobs;
+    };
+  }
+  // lib.optionalAttrs (system == "x86_64-linux") {
+    # Re-export the raw ISO so Hydra's "download iso" UI can find the
+    # underlying build product. The linkFarm-wrapped `pr-full.live-iso`
+    # loses the `nix-support/hydra-build-products` file.
+    live-iso = self.packages.${system}.live-iso;
+  };
 in
-{
-  inherit benchmarks;
-
-  pr-quick = prQuickJobs // {
-    all = prQuick;
-  };
-
-  pr-full = prFullJobs // {
-    all = mkAggregate "pr-full" prFullJobs;
-  };
-}
-// lib.optionalAttrs (system == "x86_64-linux") {
-  # Re-export the raw ISO so Hydra's "download iso" UI can find the
-  # underlying build product. The linkFarm-wrapped `pr-full.live-iso`
-  # loses the `nix-support/hydra-build-products` file.
-  live-iso = self.packages.${system}.live-iso;
-}
+if jobset == "default" then
+  defaultJobs
+else if jobset == "benchmarks" then
+  benchmarkJobs
+else
+  throw "unknown hydra jobset ${jobset}; valid: default, benchmarks"

--- a/hydra/benchmark/flake.nix
+++ b/hydra/benchmark/flake.nix
@@ -13,33 +13,15 @@
         "x86_64-linux"
         "aarch64-darwin"
       ];
-
-      supportedFeatures = {
-        x86_64-linux = [
-          "benchmark"
-          "gfx1151"
-          "xdna2"
-          "rtx4090"
-        ];
-        aarch64-darwin = [ "benchmark" ];
-      };
-
-      addBenchmarkFeature =
-        drv:
-        drv.overrideAttrs (old: {
-          requiredSystemFeatures = lib.unique ((old.requiredSystemFeatures or [ ]) ++ [ "benchmark" ]);
-        });
-
-      supportedOn =
-        system: drv:
-        lib.all (feature: lib.elem feature supportedFeatures.${system}) (drv.requiredSystemFeatures or [ ]);
     in
     {
       hydraJobs = lib.genAttrs benchmarkSystems (
         system:
-        lib.filterAttrs (_: supportedOn system) (
-          lib.mapAttrs (_: addBenchmarkFeature) src.hydraJobs.${system}.benchmarks
-        )
+        import "${src}/hydra.nix" {
+          self = src;
+          inherit system;
+          jobset = "benchmarks";
+        }
       );
     };
 }

--- a/lib/providers.nix
+++ b/lib/providers.nix
@@ -32,12 +32,14 @@ let
     # TheRock-published cu/rocm wheels. Default. Implemented in
     # overlays/python.nix.
     "therock-wheels"
+  ];
 
-    # nixpkgs python3Packages.torch with rocmSupport = true. Stub.
+  pythonProviderStubs = [
+    # Reserved for nixpkgs python3Packages.torch with rocmSupport = true.
     "nixpkgs"
 
-    # PyTorch + Triton built from source against the chosen rocm
-    # provider. Stub.
+    # Reserved for PyTorch + Triton built from source against the chosen
+    # rocm provider.
     "therock-source"
   ];
 
@@ -46,7 +48,7 @@ let
     lib.assertMsg (lib.elem tag providers) "unknown ${kind} provider \"${tag}\"; valid: ${lib.concatStringsSep ", " providers}";
 in
 {
-  inherit rocmProviders pythonProviders;
+  inherit rocmProviders pythonProviders pythonProviderStubs;
 
   assertRocmProvider = tag: assertProvider "rocm" rocmProviders tag;
   assertPythonProvider = tag: assertProvider "python" pythonProviders tag;

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -3,6 +3,9 @@
   lib,
   inputVersion,
   rocmTarget,
+  rocmProvider ? "therock-bin",
+  pythonProvider ? "therock-wheels",
+  sources ? null,
 }:
 
 # Locally-defined packages. One overlay, one source of truth for "what
@@ -38,6 +41,30 @@ lib.optionalAttrs prev.stdenv.isLinux (
       cudaSupport = true;
       rpcSupport = true;
     };
+    suffix = rocmTarget.packageSuffix;
+    firstBuildTarget = builtins.head rocmTarget.buildTargets;
+
+    sourceHas = path: sources != null && lib.hasAttrByPath path sources;
+    sourceHasTherockRocm = sourceHas [
+      "rocm"
+      "linux"
+      suffix
+    ];
+    sourceHasTherockPython = sourceHas [
+      "pythonWheels"
+      "targets"
+      suffix
+    ];
+    finalHas = name: builtins.hasAttr name final;
+
+    rocmProviderHasTherockAttrs = rocmProvider == "therock-bin" || rocmProvider == "therock-source";
+    pythonProviderHasTherockAttrs = pythonProvider == "therock-wheels";
+    supportsTherockRocm =
+      rocmProviderHasTherockAttrs
+      && (if sources != null then sourceHasTherockRocm else finalHas "therock-rocm-${suffix}");
+    supportsTherockPython =
+      pythonProviderHasTherockAttrs
+      && (if sources != null then sourceHasTherockPython else finalHas "therock-python-${suffix}");
 
     georgewhewellMaintained =
       drv:
@@ -81,6 +108,12 @@ lib.optionalAttrs prev.stdenv.isLinux (
       drv.overrideAttrs (old: {
         requiredSystemFeatures = (old.requiredSystemFeatures or [ ]) ++ [ "big-parallel" ];
       });
+
+    setPname =
+      pname: drv:
+      drv.overrideAttrs (_: {
+        inherit pname;
+      });
   in
   {
     ec-su-axb35 = ecPackages.kernelModule;
@@ -101,45 +134,54 @@ lib.optionalAttrs prev.stdenv.isLinux (
       src = inputs.fastflowlm;
     };
 
-    llama-cpp-rocm = bigParallel (georgewhewellMaintained (prev.llama-cpp.override rocmOverride));
+    llama-cpp-rocm = bigParallel (
+      setPname "llama-cpp-rocm-${suffix}" (georgewhewellMaintained (prev.llama-cpp.override rocmOverride))
+    );
     llama-cpp-vulkan = georgewhewellMaintained (prev.llama-cpp.override vulkanOverride);
     llama-cpp-cuda = georgewhewellMaintained (prev.llama-cpp.override cudaOverride);
     llama-cpp-master = llamaCppMaster;
     llama-cpp-master-rocm = bigParallel (
-      georgewhewellMaintained (llamaCppMaster.override rocmOverride)
+      setPname "llama-cpp-master-rocm-${suffix}" (
+        georgewhewellMaintained (llamaCppMaster.override rocmOverride)
+      )
     );
     llama-cpp-master-vulkan = georgewhewellMaintained (llamaCppMaster.override vulkanOverride);
     llama-cpp-master-cuda = georgewhewellMaintained (llamaCppMaster.override cudaOverride);
-
+  }
+  // lib.optionalAttrs supportsTherockRocm {
     ds4-rocm = bigParallel (
       prev.callPackage ../pkgs/ds4-rocm {
         src = inputs.ds4-hip;
-        rocmSdk = final."therock-rocm-${rocmTarget.packageSuffix}";
+        rocmSdk = final."therock-rocm-${suffix}";
         version = inputVersion "experimental" inputs.ds4-hip;
         inherit (rocmTarget) packageSuffix;
-        offloadArch = builtins.head rocmTarget.buildTargets;
+        offloadArch = firstBuildTarget;
         hsaOverrideGfxVersion = rocmTarget.hsaOverride or null;
       }
     );
 
     mlx-rocm = bigParallel (
       final.python3Packages.callPackage ../pkgs/mlx/rocm.nix {
-        pname = "mlx-rocm";
+        pname = "mlx-rocm-${suffix}";
         rdma-core = final.rdma-core-usb4;
-        rocmPackages = final.therockRocmPackages.${builtins.head rocmTarget.buildTargets};
-        gfx = builtins.head rocmTarget.buildTargets;
+        rocmPackages = final.therockRocmPackages.${firstBuildTarget};
+        gfx = firstBuildTarget;
       }
     );
 
     # Unsuffixed aliases for the active rocmTarget. Lets consumers write
     # `pkgs.therock-rocm` instead of `pkgs.therock-rocm-gfx1151` once the
     # package set's target is fixed (which it is per pkgsFor invocation).
-    therock-rocm = final."therock-rocm-${rocmTarget.packageSuffix}";
-    therock-rocm-env = final."therock-rocm-${rocmTarget.packageSuffix}-env";
-    therock-python = final."therock-python-${rocmTarget.packageSuffix}";
-    therock-python-wheels = final."therock-python-wheels-${rocmTarget.packageSuffix}";
-    therock-amdsmi = final."therock-amdsmi-${rocmTarget.packageSuffix}";
-    torch-rocm = final."torch-rocm-${rocmTarget.packageSuffix}";
-    vllm-rocm = final."vllm-rocm-therock-${rocmTarget.packageSuffix}";
+    therock-rocm = final."therock-rocm-${suffix}";
+    therock-rocm-env = final."therock-rocm-${suffix}-env";
+  }
+  // lib.optionalAttrs supportsTherockPython {
+    therock-python = final."therock-python-${suffix}";
+    therock-python-wheels = final."therock-python-wheels-${suffix}";
+    therock-amdsmi = final."therock-amdsmi-${suffix}";
+    torch-rocm = final."torch-rocm-${suffix}";
+  }
+  // lib.optionalAttrs (supportsTherockRocm && supportsTherockPython) {
+    vllm-rocm = final."vllm-rocm-therock-${suffix}";
   }
 )

--- a/overlays/python.nix
+++ b/overlays/python.nix
@@ -9,10 +9,7 @@
 #
 #   - "therock-wheels"  TheRock-published binary wheels. Default.
 #                        Delegates to overlays/therock-python.nix.
-#   - "nixpkgs"         nixpkgs torch with rocmSupport=true and the
-#                        target's gpuTargets. Stub — see TODO.
-#   - "therock-source"  PyTorch + Triton built from source against the
-#                        chosen rocm provider. Stub.
+# Reserved future providers are listed in lib.providers.pythonProviderStubs.
 
 final: prev:
 if !prev.stdenv.isLinux then
@@ -30,19 +27,6 @@ else
         inherit lib;
         target = rocmTarget;
       } final prev
-    else if provider == "nixpkgs" then
-      throw ''
-        python provider "nixpkgs" is not implemented yet. Would override
-        pythonPackagesExtensions to swap torch -> nixpkgs torch with
-        rocmSupport=true and gpuTargets = rocmTarget.gpuTargets, plus
-        triton -> triton-no-cuda. See lib/providers.nix.
-      ''
-    else if provider == "therock-source" then
-      throw ''
-        python provider "therock-source" is not implemented yet. Would
-        build PyTorch and Triton from source against the active rocm
-        provider's SDK. See lib/providers.nix.
-      ''
     else
       throw "unreachable: assertPythonProvider should have rejected ${provider}"
   )

--- a/overlays/rocm.nix
+++ b/overlays/rocm.nix
@@ -17,9 +17,9 @@
 #                        point at the source build.
 #   - "nixpkgs"         nixpkgs.rocmPackages.${target}, which nixpkgs
 #                        already publishes as the per-arch narrowed
-#                        scope. Doesn't pull in any TheRock attrs, so
-#                        downstream packages that reference
-#                        therock-rocm-* (vllm, ds4, mlx) won't resolve.
+#                        scope. Doesn't pull in any TheRock attrs; the
+#                        local package overlay only exposes packages
+#                        that can build without them.
 
 let
   providers = import ../lib/providers.nix { inherit lib; };
@@ -63,8 +63,7 @@ else if provider == "therock-source" then
 else if provider == "nixpkgs" then
   let
     narrowed =
-      prev.rocmPackages.${suffix}
-        or (throw "nixpkgs.rocmPackages has no narrowed scope for ${suffix}");
+      prev.rocmPackages.${suffix} or (throw "nixpkgs.rocmPackages has no narrowed scope for ${suffix}");
   in
   {
     rocmPackages = narrowed;

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -3,12 +3,14 @@
   target,
   vllmSrc,
   vllmVersion,
+  enabled ? true,
 }:
 let
   s = target.packageSuffix;
 in
 final: prev:
 let
+  hasTherockVllmInputs = enabled && prev.stdenv.isLinux;
   sdkBase = final."therock-rocm-${s}";
   vllmGpuTargets = target.buildTargets;
   sdk = sdkBase // {
@@ -310,6 +312,6 @@ let
 
   vllmTherock = lib.makeOverridable mkVllmTherock { };
 in
-{
+lib.optionalAttrs hasTherockVllmInputs {
   "vllm-rocm-therock-${s}" = vllmTherock;
 }


### PR DESCRIPTION
## Summary
- Gate TheRock-only package aliases by active provider/source pins, so non-default ROCm targets and the nixpkgs ROCm provider evaluate cleanly.
- Add source/package-surface checks and wire them into `hydra.nix` `pr-quick`.
- Keep the root flake from importing `hydra.nix`; Hydra now consumes `hydra.nix`, which imports the flake.
- Add `hydra.nix` `jobset = "benchmarks"` mode so benchmark-only jobsets can also use the same Nix expression entry point.
- Preserve target suffixes in ROCm package pnames and document the current provider surface.

## Infra
Yes, `../infra` should switch nix-strix-halo jobsets from flake jobsets to Nix-expression jobsets with `nixexprinput = "src"` and `nixexprpath = "hydra.nix"`. I prepared that local infra diff against the current `grw/ci/tf` checkout; it is not pushed here because that branch is already 22 commits ahead of its remote.

## Validation
- `nix fmt -- --fail-on-change`
- `nix flake check --no-build`
- `nix-build hydra.nix --argstr system x86_64-linux -A pr-quick.all --no-out-link`
- `nix-instantiate --eval hydra.nix --argstr system x86_64-linux --argstr jobset benchmarks -A bench-mlx-rocm-gfx1151-gemm-smoke.drvPath`
- `nix eval ./hydra/benchmark#hydraJobs.x86_64-linux --apply builtins.attrNames --json`
- `nix eval .#legacyPackages.x86_64-linux.gfx1103 --apply 'pkgs: { hasLlama = pkgs ? llama-cpp-rocm; hasDs4 = pkgs ? ds4-rocm; hasVllm = pkgs ? vllm-rocm; llamaDrv = pkgs.llama-cpp-rocm.drvPath; }' --json`\n- `git diff --check`