### PR TITLE
readme: fix hydra badge rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # nix-strix-halo
 
-[![Hydra full][hydra-full-badge]][hydra-full]
-[hydra-full]: https://hydra.hellas.ai/job/hellas/nix-strix-halo/x86_64-linux.pr-full.all
-[hydra-full-badge]: https://img.shields.io/endpoint?label=hydra%20full&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fnix-strix-halo%2Fx86_64-linux.pr-full.all%2Fshield
+[![Hydra full](https://img.shields.io/endpoint?label=hydra%20full&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fnix-strix-halo%2Fx86_64-linux.pr-full.all%2Fshield)](https://hydra.hellas.ai/job/hellas/nix-strix-halo/x86_64-linux.pr-full.all)
 
 *NO SUPPORT / WARRANTY*
 


### PR DESCRIPTION
## Summary
- replace the reference-style Hydra badge with inline badge markdown
- fixes GitHub rendering the badge definitions as literal README text

## Validation
- `git diff --check`
- rendered the README header through GitHub's markdown API and confirmed it emits an `<img>` for the badge
- verified the Shields endpoint title is `hydra full: passing`
