### PR TITLE
ci: simplify Hydra gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nix-strix-halo
 
-[![Hydra full](https://img.shields.io/endpoint?label=hydra%20full&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fnix-strix-halo%2Fx86_64-linux.pr-full.all%2Fshield)](https://hydra.hellas.ai/job/hellas/nix-strix-halo/x86_64-linux.pr-full.all)
+[![Hydra CI](https://img.shields.io/endpoint?label=hydra%20ci&url=https%3A%2F%2Fhydra.hellas.ai%2Fjob%2Fhellas%2Fnix-strix-halo%2Fx86_64-linux.ci.smoke%2Fshield)](https://hydra.hellas.ai/job/hellas/nix-strix-halo/x86_64-linux.ci.smoke)
 
 *NO SUPPORT / WARRANTY*
 
@@ -99,16 +99,23 @@ the tag in `lib/providers.nix`.
 
 ## Hydra / CI
 
-`hydra.nix` (project root, not a flake output) composes the build matrix
-Hydra reads. It imports the flake to reuse its packages, checks, overlays,
-and helper libraries. Each default-target package gets a job, plus
-`-from-source` variants of `vllm-rocm`, `therock-rocm`, and
-`llama-cpp-rocm` that exercise the parameterised abstraction end-to-end.
+Hydra reads the root flake's `hydraJobs` output. Required PR CI is split
+into three gates:
+
+- `ci.checks` runs source/meta checks such as formatting and Nix linting.
+- `ci.build` builds the package surface, including cross-platform package
+  outputs and provider variants.
+- `ci.smoke` runs one small real-hardware smoke per accelerated engine.
+
+The separate `hydraBenchmarkJobs` output is used by the background benchmark
+jobset. Those benchmark sweeps are useful for regression data but are not
+required for PR merge.
 
 ```bash
-nix-build hydra.nix --argstr system x86_64-linux -A pr-full.all
-nix-build hydra.nix --argstr system x86_64-linux -A pr-full.vllm-rocm-from-source
-nix-build hydra.nix --argstr system x86_64-linux --argstr jobset benchmarks -A bench-mlx-rocm-gfx1151-gemm-smoke
+nix build .#hydraJobs.x86_64-linux.ci.checks
+nix build .#hydraJobs.x86_64-linux.ci.build
+nix build .#hydraJobs.x86_64-linux.ci.smoke
+nix build .#hydraBenchmarkJobs.x86_64-linux.bench-mlx-rocm-gfx1151-gemm-smoke
 ```
 
 ## Development

--- a/lib/bench/ds4.nix
+++ b/lib/bench/ds4.nix
@@ -100,12 +100,24 @@ let
     fastFull = true;
   };
 
+  metalCtxSweepCase = fastFullCase // {
+    scenario = "ctx-sweep";
+    fastFull = false;
+  };
+
   modelConfigs = {
     deepseek-v4-flash = {
       path = resolvedModelPath;
       repo = "antirez/deepseek-v4-gguf";
       description = "DeepSeek V4 Flash GGUF for DwarfStar 4";
-      cases = if cases == null then [ smokeCase ] ++ lib.optionals (!isMetal) [ fastFullCase ] else cases;
+      cases =
+        if cases == null then
+          [
+            smokeCase
+            (if isMetal then metalCtxSweepCase else fastFullCase)
+          ]
+        else
+          cases;
     };
   };
 

--- a/lib/hydra.nix
+++ b/lib/hydra.nix
@@ -13,7 +13,10 @@ let
       "xdna2"
       "rtx4090"
     ];
-    aarch64-darwin = [ "benchmark" ];
+    aarch64-darwin = [
+      "benchmark"
+      "metal"
+    ];
   };
 
   mkBenchmarkJobs =
@@ -40,7 +43,11 @@ let
     pkgs:
     let
       system = pkgs.stdenv.hostPlatform.system;
-      benchmarks = self.benchmarks.${system};
+      isGateSystem = system == "x86_64-linux";
+      x86Packages = self.packages.x86_64-linux;
+      x86Benchmarks = self.benchmarks.x86_64-linux;
+      darwinPackages = self.packages.aarch64-darwin;
+      darwinBenchmarks = self.benchmarks.aarch64-darwin;
 
       maintainerMeta = {
         maintainers = with lib.maintainers; [ georgewhewell ];
@@ -67,27 +74,6 @@ let
           }) jobs
         );
 
-      isSourceCheckSystem = system == "x86_64-linux";
-
-      prQuickJobs = lib.optionalAttrs isSourceCheckSystem self.checks.${system};
-      prQuick = mkAggregate "pr-quick" prQuickJobs;
-
-      afterPrQuick =
-        name: path:
-        mkLinkFarm "nix-strix-halo-pr-full-${name}" (
-          lib.optionals isSourceCheckSystem [
-            {
-              name = "pr-quick";
-              path = prQuick;
-            }
-          ]
-          ++ [
-            {
-              inherit name path;
-            }
-          ]
-        );
-
       mkPkgsForProvider =
         {
           rocmProvider,
@@ -97,68 +83,66 @@ let
           inherit system rocmProvider pythonProvider;
         };
 
-      fromSourcePkgs = lib.optionalAttrs (system == "x86_64-linux") (mkPkgsForProvider {
+      fromSourcePkgs = lib.optionalAttrs isGateSystem (mkPkgsForProvider {
         rocmProvider = "therock-source";
       });
 
-      nixpkgsRocmPkgs = lib.optionalAttrs (system == "x86_64-linux") (mkPkgsForProvider {
+      nixpkgsRocmPkgs = lib.optionalAttrs isGateSystem (mkPkgsForProvider {
         rocmProvider = "nixpkgs";
       });
 
-      prFullJobs = {
-        default = afterPrQuick "default" self.packages.${system}.default;
-        jaccl = afterPrQuick "jaccl" self.packages.${system}.jaccl;
-      }
-      // lib.optionalAttrs (system == "aarch64-darwin") {
-        ds4 = afterPrQuick "ds4" self.packages.${system}.ds4;
-        mlx = afterPrQuick "mlx" self.packages.${system}.mlx;
-        mlx-metal = afterPrQuick "mlx-metal" self.packages.${system}.mlx-metal;
-        mlx-metal-gemm-smoke = afterPrQuick "mlx-metal-gemm-smoke" benchmarks.bench-mlx-metal-gemm-smoke;
-      }
-      // lib.optionalAttrs (system == "x86_64-linux") {
-        inherit (self.packages.${system})
+      checkJobs = lib.optionalAttrs isGateSystem self.checks.x86_64-linux;
+
+      buildJobs = lib.optionalAttrs isGateSystem {
+        inherit (x86Packages)
+          default
+          jaccl
           ds4-rocm
           ec-su-axb35-monitor
           fastflowlm
           llama-cpp-rocm
           llama-cpp-vulkan
           llama-cpp-master
+          mlx-rocm
           strix-halo-mes-firmware
           therock-rocm
           tokenizers-cpp
           vllm-rocm
           xrt-amdxdna
+          live-iso
           ;
-        mlx-rocm = afterPrQuick "mlx-rocm" self.packages.${system}.mlx-rocm;
-        mlx-rocm-gemm-smoke =
-          afterPrQuick "mlx-rocm-gemm-smoke"
-            benchmarks."bench-mlx-rocm-${defaultRocmTarget.packageSuffix}-gemm-smoke";
-        live-iso = afterPrQuick "live-iso" self.packages.${system}.live-iso;
-        vllm-throughput-smoke =
-          afterPrQuick "vllm-throughput-smoke"
-            benchmarks."bench-qwen3-0-6b-vllm-rocm-${defaultRocmTarget.packageSuffix}-throughput-smoke";
-        ds4-rocm-smoke = afterPrQuick "ds4-rocm-smoke" benchmarks.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke;
-        fastflowlm-npu-smoke = afterPrQuick "fastflowlm-npu-smoke" benchmarks.bench-llama3-2-1b-fastflowlm-medium;
-        cuda-rtx4090-device-smoke = afterPrQuick "cuda-rtx4090-device-smoke" benchmarks.bench-cuda-rtx4090-llama-cpp-master-device-smoke;
+
+        darwin-default = darwinPackages.default;
+        darwin-jaccl = darwinPackages.jaccl;
+        ds4-metal = darwinPackages.ds4;
+        inherit (darwinPackages)
+          mlx
+          mlx-metal
+          ;
 
         vllm-rocm-from-source = fromSourcePkgs.vllm-rocm;
         therock-rocm-from-source = fromSourcePkgs.therock-rocm;
         llama-cpp-rocm-from-source = fromSourcePkgs.llama-cpp-rocm;
         llama-cpp-rocm-nixpkgs = nixpkgsRocmPkgs.llama-cpp-rocm;
       };
+
+      smokeJobs = lib.optionalAttrs isGateSystem {
+        ds4-metal = darwinBenchmarks.bench-deepseek-v4-flash-ds4-metal-smoke;
+        ds4-rocm = x86Benchmarks.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke;
+        mlx-metal = darwinBenchmarks.bench-mlx-metal-gemm-smoke;
+        mlx-rocm = x86Benchmarks."bench-mlx-rocm-${defaultRocmTarget.packageSuffix}-gemm-smoke";
+        fastflowlm-npu = x86Benchmarks.bench-llama3-2-1b-fastflowlm-medium;
+        vllm-rocm =
+          x86Benchmarks."bench-qwen3-0-6b-vllm-rocm-${defaultRocmTarget.packageSuffix}-throughput-smoke";
+        cuda-rtx4090 = x86Benchmarks.bench-cuda-rtx4090-llama-cpp-master-device-smoke;
+      };
     in
-    lib.optionalAttrs isSourceCheckSystem {
-      pr-quick = prQuickJobs // {
-        all = prQuick;
+    lib.optionalAttrs isGateSystem {
+      ci = {
+        checks = mkAggregate "ci-checks" checkJobs;
+        build = mkAggregate "ci-build" buildJobs;
+        smoke = mkAggregate "ci-smoke" smokeJobs;
       };
-    }
-    // {
-      pr-full = prFullJobs // {
-        all = mkAggregate "pr-full" prFullJobs;
-      };
-    }
-    // lib.optionalAttrs (system == "x86_64-linux") {
-      live-iso = self.packages.${system}.live-iso;
     };
 in
 {


### PR DESCRIPTION
## Summary
- replace pr-quick/pr-full Hydra outputs with three required gate aggregates: ci.checks, ci.build, ci.smoke
- keep benchmark sweeps in hydraBenchmarkJobs and add DS4 Metal smoke plus context sweep coverage
- update README badge and CI docs for the new gate names

## Verification
- nix build .#hydraJobs.x86_64-linux.ci.checks --no-link
- nix flake check --no-build
- nix eval --json .#hydraBenchmarkJobs.aarch64-darwin --apply 'builtins.attrNames' | jq '[.[] | select(test("ds4"))]'\n- nix eval --json .#hydraBenchmarkJobs.x86_64-linux --apply 'builtins.attrNames' | jq '[.[] | select(test("ds4"))]'