### PR TITLE
ci: update Dependabot benchmark flake path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "nix"
     directories:
       - "/"
-      - "/hydra/benchmark"
+      - "/lib/hydra/benchmark"
     schedule:
       interval: "daily"
     groups:


### PR DESCRIPTION
## Summary
- point Dependabot at the current benchmark wrapper flake under `lib/hydra/benchmark`
- drop the stale `/hydra/benchmark` path left over from the cleanup

## Verification
- confirmed `lib/hydra/benchmark/flake.nix` exists