### PR TITLE
Add shared Python compatibility overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -591,6 +591,9 @@
         default = lib.composeManyExtensions (mkOverlays {
           rocmTarget = defaultRocmTarget;
         });
+        python = self.lib.mkPythonOverlay {
+          provider = "nixpkgs";
+        };
       };
 
       # NixOS modules

--- a/lib/providers.nix
+++ b/lib/providers.nix
@@ -29,15 +29,17 @@ let
   ];
 
   pythonProviders = [
+    # Stock nixpkgs Python packages plus small compatibility fixes from
+    # overlays/python.nix. Useful for downstream flakes that want the shared
+    # Python fixes without TheRock wheels or ROCm package attrs.
+    "nixpkgs"
+
     # TheRock-published cu/rocm wheels. Default. Implemented in
     # overlays/python.nix.
     "therock-wheels"
   ];
 
   pythonProviderStubs = [
-    # Reserved for nixpkgs python3Packages.torch with rocmSupport = true.
-    "nixpkgs"
-
     # Reserved for PyTorch + Triton built from source against the chosen
     # rocm provider.
     "therock-source"

--- a/overlays/python.nix
+++ b/overlays/python.nix
@@ -1,32 +1,53 @@
 {
   lib,
-  provider ? "therock-wheels",
-  rocmTarget,
+  provider ? "nixpkgs",
+  rocmTarget ? null,
 }:
 
-# Parameterised python overlay. Swaps `python312Packages.torch`,
+# Parameterised Python overlay. Always applies shared Python package
+# compatibility fixes, and optionally swaps `python312Packages.torch`,
 # `triton`, `amdsmi`, and the `rocm-sdk-*` shims depending on provider.
 #
-#   - "therock-wheels"  TheRock-published binary wheels. Default.
-#                        Delegates to overlays/therock-python.nix.
+#   - "nixpkgs"         Stock nixpkgs Python packages plus the shared fixes.
+#   - "therock-wheels"  TheRock-published binary wheels, used by the
+#                        flake's default package set.
 # Reserved future providers are listed in lib.providers.pythonProviderStubs.
 
 final: prev:
-if !prev.stdenv.isLinux then
-  { }
-else
-  (
-    let
-      providers = import ../lib/providers.nix { inherit lib; };
-    in
+let
+  providers = import ../lib/providers.nix { inherit lib; };
+  pythonFixes =
+    _pyfinal: pyprev:
+    lib.optionalAttrs (prev.stdenv.hostPlatform.isDarwin && pyprev ? sentence-transformers) {
+      # sentence-transformers' runtime closure is usable on Darwin, but its
+      # nixpkgs test extras pull `phonemizer -> dlinfo`, and dlinfo is marked
+      # broken on Darwin. Downstream eval tooling only needs runtime imports.
+      sentence-transformers = pyprev.sentence-transformers.overridePythonAttrs (_old: {
+        nativeCheckInputs = [ ];
+        doCheck = false;
+        pythonImportsCheck = [ ];
+      });
+    };
 
+  providerAttrs =
     assert providers.assertPythonProvider provider;
 
-    if provider == "therock-wheels" then
+    # TheRock wheels are Linux-only; non-Linux systems stay on stock
+    # nixpkgs Python packages and still receive pythonFixes below.
+    if provider == "nixpkgs" || !prev.stdenv.hostPlatform.isLinux then
+      { }
+    else if provider == "therock-wheels" then
+      assert lib.assertMsg (rocmTarget != null) "therock-wheels python provider requires rocmTarget";
       import ./therock-python.nix {
         inherit lib;
         target = rocmTarget;
       } final prev
     else
-      throw "unreachable: assertPythonProvider should have rejected ${provider}"
-  )
+      throw "unreachable: assertPythonProvider should have rejected ${provider}";
+in
+providerAttrs
+// {
+  pythonPackagesExtensions =
+    (providerAttrs.pythonPackagesExtensions or (prev.pythonPackagesExtensions or [ ]))
+    ++ [ pythonFixes ];
+}


### PR DESCRIPTION
Summary
- add nixpkgs as a concrete Python provider for shared compatibility fixes
- expose overlays.python for downstream flakes that want those fixes without TheRock/ROCm package attrs
- keep TheRock wheel substitutions Linux-only while applying the Darwin sentence-transformers check fix

Checks
- nix flake check --no-build --all-systems
- nix build .#checks.x86_64-linux.deadnix .#checks.x86_64-linux.statix .#checks.x86_64-linux.nixfmt --no-link