### PR TITLE
Add environment-driven pi wrapper

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,63 @@
 {
   "nodes": {
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-ai-tools",
+          "nixpkgs"
+        ],
+        "systems": [
+          "nix-ai-tools",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "nix-ai-tools",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nix-ai-tools",
+          "nixpkgs"
+        ],
+        "systems": [
+          "nix-ai-tools",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "nix-ai-tools",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "ds4": {
       "flake": false,
       "locked": {
@@ -65,6 +123,27 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix-ai-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "linux-src": {
       "flake": false,
       "locked": {
@@ -116,6 +195,31 @@
         "type": "github"
       }
     },
+    "nix-ai-tools": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1780379877,
+        "narHash": "sha256-n58coAnv42rXda/GvoZh1D3TmfXikx9I8t3/msIXFn4=",
+        "owner": "numtide",
+        "repo": "nix-ai-tools",
+        "rev": "a531ef0f9dcbaed0f8026a9f82c32281c4a6dad2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-ai-tools",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779560665,
@@ -140,6 +244,7 @@
         "fastflowlm": "fastflowlm",
         "llama-cpp-master": "llama-cpp-master",
         "mlx-src": "mlx-src",
+        "nix-ai-tools": "nix-ai-tools",
         "nixpkgs": "nixpkgs",
         "therock-src-7-13-gfx1151-base-half-011b45bd": "therock-src-7-13-gfx1151-base-half-011b45bd",
         "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84": "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84",
@@ -200,6 +305,21 @@
         "vllm-src": "vllm-src",
         "xdna-driver-src": "xdna-driver-src",
         "xrt-src": "xrt-src"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "therock-src-7-13-gfx1151-base-half-011b45bd": {
@@ -1155,6 +1275,27 @@
       "original": {
         "owner": "hellas-ai",
         "repo": "thunderbolt-ibverbs",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-ai-tools",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,11 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    nix-ai-tools = {
+      url = "github:numtide/nix-ai-tools";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     ec-su-axb35 = {
       url = "github:cmetz/ec-su_axb35-linux";
       flake = false;
@@ -642,6 +647,7 @@
       packages = perSystem (
         pkgs:
         let
+          aiTools = inputs.nix-ai-tools.packages.${pkgs.stdenv.hostPlatform.system};
           cudaPkgs = cudaPkgsFor pkgs.stdenv.hostPlatform.system;
           jacclPackage = pkgs.callPackage ./pkgs/jaccl (
             {
@@ -675,6 +681,10 @@
 
           genericPackages = {
             default = pkgs.llama-cpp;
+            pi-wrap = pkgs.callPackage ./pkgs/pi-wrap {
+              inherit (aiTools) pi;
+            };
+            inherit (aiTools) pi;
             inherit (pkgs)
               llama-cpp
               thunderbolt-ibverbs-bench-tools
@@ -753,6 +763,9 @@
           };
 
           genericApps = {
+            pi-wrap =
+              ap self.packages.${system}.pi-wrap "pi-wrap"
+                "Run pi with provider settings from environment";
             llama-cli = ap pkgs.llama-cpp "llama-cli" "Run llama-cli";
             llama-server = ap pkgs.llama-cpp "llama-server" "Run llama-server";
           };
@@ -895,6 +908,12 @@
               nixfmt-tree
               statix
             ])
+            ++ (with inputs.nix-ai-tools.packages.${pkgs.stdenv.hostPlatform.system}; [
+              pi
+            ])
+            ++ [
+              self.packages.${pkgs.stdenv.hostPlatform.system}.pi-wrap
+            ]
             ++ lib.optionals pkgs.stdenv.isLinux [
               (pkgs.python3.withPackages (
                 ps: with ps; [

--- a/lib/bench/default.nix
+++ b/lib/bench/default.nix
@@ -128,6 +128,12 @@ let
           package = self.packages.${system}.ds4;
           accelerator = "metal";
         }).benchmarks;
+      ds4PiBenchmarks =
+        (import ./ds4-pi.nix {
+          inherit pkgs modelsRoot;
+          ds4Package = self.packages.${system}.ds4;
+          piWrapPackage = self.packages.${system}.pi-wrap;
+        }).benchmarks;
       mlxMetalBenchmarks =
         (import ./mlx.nix {
           inherit pkgs;
@@ -135,7 +141,9 @@ let
           accelerator = "metal";
         }).benchmarks;
     in
-    flattenBenchmarks ds4MetalBenchmarks // flattenBenchmarks mlxMetalBenchmarks
+    flattenBenchmarks ds4MetalBenchmarks
+    // flattenBenchmarks ds4PiBenchmarks
+    // flattenBenchmarks mlxMetalBenchmarks
   );
 
   cudaRtx4090Benchmarks = lib.optionalAttrs pkgs.stdenv.isLinux (

--- a/lib/bench/ds4-pi.nix
+++ b/lib/bench/ds4-pi.nix
@@ -1,0 +1,161 @@
+{
+  pkgs,
+  ds4Package,
+  piWrapPackage,
+  modelsRoot ? null,
+  modelRoot ? null,
+  modelPath ? null,
+}:
+
+let
+  inherit (pkgs) lib;
+  benchLib = import ./lib.nix { inherit lib; };
+
+  resolvedModelsRoot = if modelsRoot != null then modelsRoot else benchLib.defaultModelsRoot pkgs;
+  resolvedModelRoot =
+    if modelRoot != null then modelRoot else benchLib.modelPath resolvedModelsRoot [ "ds4" ];
+  resolvedModelPath =
+    if modelPath != null then modelPath else benchLib.modelPath resolvedModelRoot [ "ds4flash.gguf" ];
+
+  marker = "ds4-pi-smoke-ok";
+
+  runner = pkgs.writeShellScript "ds4-metal-pi-smoke-runner" ''
+    set -euo pipefail
+
+    mkdir -p "$out" "$TMPDIR/home" "$TMPDIR/ds4-kv"
+    export HOME="$TMPDIR/home"
+    export DS4_METAL_NO_RESIDENCY=1
+    export DS4_METAL_NO_MODEL_WARMUP=1
+    export DS4_SERVER_PERFLEVEL=skip
+
+    port="$(${pkgs.python3}/bin/python3 - <<'PY'
+    import socket
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        print(s.getsockname()[1])
+    PY
+    )"
+
+    server_log="$out/ds4-server.log"
+    ${ds4Package}/bin/ds4-server \
+      --metal \
+      -m ${lib.escapeShellArg resolvedModelPath} \
+      --host 127.0.0.1 \
+      --port "$port" \
+      --ctx 4096 \
+      --tokens 128 \
+      --kv-disk-dir "$TMPDIR/ds4-kv" \
+      --kv-disk-space-mb 256 \
+      > "$server_log" 2>&1 &
+    server_pid=$!
+
+    cleanup() {
+      kill "$server_pid" 2>/dev/null || true
+      wait "$server_pid" 2>/dev/null || true
+    }
+    trap cleanup EXIT
+
+    ready=0
+    for _ in $(seq 1 300); do
+      if ${pkgs.curl}/bin/curl -fsS --connect-timeout 1 --max-time 2 "http://127.0.0.1:$port/v1/models" > "$out/models.json" 2> "$out/readiness.log"; then
+        ready=1
+        break
+      fi
+      if ! kill -0 "$server_pid" 2>/dev/null; then
+        echo "ds4-server exited before becoming ready" >&2
+        cat "$server_log" >&2 || true
+        exit 1
+      fi
+      sleep 1
+    done
+
+    if [ "$ready" -ne 1 ]; then
+      echo "ds4-server did not become ready on port $port" >&2
+      cat "$out/readiness.log" >&2 || true
+      cat "$server_log" >&2 || true
+      exit 1
+    fi
+
+    if ! ${pkgs.jq}/bin/jq -e '.data[] | select(.id == "deepseek-v4-flash")' "$out/models.json" >/dev/null; then
+      echo "ds4-server did not report the expected OpenAI model id" >&2
+      cat "$out/models.json" >&2 || true
+      cat "$server_log" >&2 || true
+      exit 1
+    fi
+
+    set +e
+    OPENAI_BASE_URL="http://127.0.0.1:$port/v1" \
+    OPENAI_API_KEY=unused \
+    OPENAI_MODEL=deepseek-v4-flash \
+      ${piWrapPackage}/bin/pi-wrap \
+        -p \
+        --no-session \
+        --offline \
+        --verbose \
+        "Reply with exactly: ${marker}" \
+        > "$out/pi-output.txt" 2> "$out/pi-stderr.txt"
+    pi_status=$?
+    set -e
+
+    if [ "$pi_status" -ne 0 ]; then
+      echo "pi-wrap failed with exit status $pi_status" >&2
+      cat "$out/pi-output.txt" >&2 || true
+      cat "$out/pi-stderr.txt" >&2 || true
+      cat "$server_log" >&2 || true
+      exit "$pi_status"
+    fi
+
+    if ! grep -F ${lib.escapeShellArg marker} "$out/pi-output.txt" >/dev/null; then
+      echo "pi-wrap output did not contain the smoke marker" >&2
+      cat "$out/pi-output.txt" >&2 || true
+      cat "$out/pi-stderr.txt" >&2 || true
+      cat "$server_log" >&2 || true
+      exit 1
+    fi
+  '';
+
+  benchmark = benchLib.mkBenchmark {
+    inherit pkgs;
+    name = "ds4-metal-pi-smoke";
+    packages = [
+      ds4Package
+      piWrapPackage
+      pkgs.curl
+      pkgs.jq
+      pkgs.python3
+    ];
+    command = [ runner ];
+    env = {
+      DS4_MODEL = resolvedModelPath;
+      DS4_SERVER_PERFLEVEL = "skip";
+      DS4_METAL_NO_RESIDENCY = "1";
+      DS4_METAL_NO_MODEL_WARMUP = "1";
+    };
+    requirements = {
+      systemFeatures = [ "metal" ];
+      hostProfiles = [ "darwin-metal" ];
+      sandboxPaths = [ resolvedModelRoot ];
+    };
+    metadata = {
+      kind = "ds4-pi";
+      suite = "ds4";
+      accelerator = "metal";
+      scenario = "pi-smoke";
+      model = {
+        name = "deepseek-v4-flash";
+        path = resolvedModelPath;
+        repo = "antirez/deepseek-v4-gguf";
+      };
+      tool = {
+        backend = "metal";
+        packageRole = "ds4";
+        client = "pi";
+      };
+    };
+    meta.platforms = [ "aarch64-darwin" ];
+    description = "Run Pi against a local DS4 Metal server";
+  };
+in
+{
+  benchmarks.deepseek-v4-flash.ds4-metal-pi-smoke = benchmark;
+}

--- a/lib/hydra.nix
+++ b/lib/hydra.nix
@@ -128,6 +128,7 @@ let
 
       smokeJobs = lib.optionalAttrs isGateSystem {
         ds4-metal = darwinBenchmarks.bench-deepseek-v4-flash-ds4-metal-smoke;
+        ds4-pi-metal = darwinBenchmarks.bench-deepseek-v4-flash-ds4-metal-pi-smoke;
         ds4-rocm = x86Benchmarks.bench-deepseek-v4-flash-ds4-rocm-gfx1151-smoke;
         mlx-metal = darwinBenchmarks.bench-mlx-metal-gemm-smoke;
         mlx-rocm = x86Benchmarks."bench-mlx-rocm-${defaultRocmTarget.packageSuffix}-gemm-smoke";

--- a/pkgs/pi-wrap/default.nix
+++ b/pkgs/pi-wrap/default.nix
@@ -1,0 +1,91 @@
+{
+  coreutils,
+  jq,
+  pi,
+  writeShellApplication,
+}:
+
+writeShellApplication {
+  name = "pi-wrap";
+  runtimeInputs = [
+    coreutils
+    jq
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    json_string() {
+      jq -Rn --arg value "$1" '$value'
+    }
+
+    provider="''${PI_PROVIDER:-}"
+    if [ -z "$provider" ]; then
+      if [ -n "''${ANTHROPIC_BASE_URL:-}" ] && [ -z "''${OPENAI_BASE_URL:-}" ]; then
+        provider="anthropic"
+      else
+        provider="openai"
+      fi
+    fi
+
+    case "$provider" in
+      openai|openai-env)
+        provider_id="openai-env"
+        api="openai-completions"
+        base_url="''${OPENAI_BASE_URL:-https://api.openai.com/v1}"
+        api_key="''${OPENAI_API_KEY:-unused}"
+        model="''${OPENAI_MODEL:-''${PI_MODEL:-}}"
+        ;;
+      anthropic|anthropic-env)
+        provider_id="anthropic-env"
+        api="anthropic-messages"
+        base_url="''${ANTHROPIC_BASE_URL:-https://api.anthropic.com}"
+        api_key="''${ANTHROPIC_API_KEY:-unused}"
+        model="''${ANTHROPIC_MODEL:-''${PI_MODEL:-}}"
+        ;;
+      *)
+        echo "pi-wrap: unsupported PI_PROVIDER='$provider'" >&2
+        exit 2
+        ;;
+    esac
+
+    if [ -z "$model" ]; then
+      echo "pi-wrap: set OPENAI_MODEL, ANTHROPIC_MODEL, or PI_MODEL" >&2
+      exit 2
+    fi
+
+    extension="$(mktemp --suffix=.js -t pi-wrap-XXXXXX)"
+    cleanup() {
+      rm -f "$extension"
+    }
+    trap cleanup EXIT
+
+    provider_json="$(json_string "$provider_id")"
+    base_json="$(json_string "$base_url")"
+    key_json="$(json_string "$api_key")"
+    api_json="$(json_string "$api")"
+    model_json="$(json_string "$model")"
+
+    cat > "$extension" <<EOF
+    export default function (pi) {
+      const model = $model_json;
+      pi.registerProvider($provider_json, {
+        baseUrl: $base_json,
+        apiKey: $key_json,
+        api: $api_json,
+        models: [{
+          id: model,
+          name: model,
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 32768,
+          maxTokens: 2048,
+        }],
+      });
+    }
+    EOF
+
+    exec ${pi}/bin/pi -e "$extension" --provider "$provider_id" --model "$model" "$@"
+  '';
+}


### PR DESCRIPTION
Adds `nix-ai-tools` as a flake input and exposes `pi` plus `pi-wrap`.

`pi-wrap` generates a temporary Pi provider extension from runtime environment variables and execs upstream `pi`. It supports OpenAI-compatible and Anthropic-compatible endpoints via:

- `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `OPENAI_MODEL`
- `ANTHROPIC_BASE_URL`, `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`
- optional `PI_PROVIDER` / `PI_MODEL`

Checks run:

- `nix build --no-link .#pi-wrap`
- `nix build --no-link .#checks.x86_64-linux.nixfmt .#checks.x86_64-linux.deadnix .#checks.x86_64-linux.statix .#checks.x86_64-linux.package-surface`
- `OPENAI_BASE_URL=http://trex:8081/v1 OPENAI_API_KEY=unused OPENAI_MODEL=Qwen2.5-7B-Instruct-Q4_K_M nix run .#pi-wrap -- -p --no-session --offline "Reply with exactly: pong"`