### PR TITLE
llama.cpp: enable RDMA RPC on Strix variants

### DIFF
--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -74,6 +74,19 @@ lib.optionalAttrs prev.stdenv.isLinux (
         };
       });
 
+    # Compose Strix llama.cpp variants with the thunderbolt-ibverbs
+    # rdma-core overlay so ggml's RPC backend builds its RDMA transport.
+    # Keep this in one helper so ROCm/Vulkan and master/current variants
+    # do not drift.
+    withRdmaRpc =
+      drv:
+      drv.overrideAttrs (old: {
+        buildInputs = (old.buildInputs or [ ]) ++ [ final.rdma-core-usb4 ];
+        cmakeFlags = (old.cmakeFlags or [ ]) ++ [
+          (lib.cmakeBool "GGML_RPC_RDMA" true)
+        ];
+      });
+
     masterRev = inputs.llama-cpp-master.shortRev or inputs.llama-cpp-master.rev or "unknown";
     # llama-cpp-master is the upstream HEAD variant. Override is via
     # `.overrideAttrs` (the package doesn't expose `src` through .override),
@@ -135,17 +148,21 @@ lib.optionalAttrs prev.stdenv.isLinux (
     };
 
     llama-cpp-rocm = bigParallel (
-      setPname "llama-cpp-rocm-${suffix}" (georgewhewellMaintained (prev.llama-cpp.override rocmOverride))
+      setPname "llama-cpp-rocm-${suffix}" (
+        withRdmaRpc (georgewhewellMaintained (prev.llama-cpp.override rocmOverride))
+      )
     );
-    llama-cpp-vulkan = georgewhewellMaintained (prev.llama-cpp.override vulkanOverride);
+    llama-cpp-vulkan = withRdmaRpc (georgewhewellMaintained (prev.llama-cpp.override vulkanOverride));
     llama-cpp-cuda = georgewhewellMaintained (prev.llama-cpp.override cudaOverride);
     llama-cpp-master = llamaCppMaster;
     llama-cpp-master-rocm = bigParallel (
       setPname "llama-cpp-master-rocm-${suffix}" (
-        georgewhewellMaintained (llamaCppMaster.override rocmOverride)
+        withRdmaRpc (georgewhewellMaintained (llamaCppMaster.override rocmOverride))
       )
     );
-    llama-cpp-master-vulkan = georgewhewellMaintained (llamaCppMaster.override vulkanOverride);
+    llama-cpp-master-vulkan = withRdmaRpc (
+      georgewhewellMaintained (llamaCppMaster.override vulkanOverride)
+    );
     llama-cpp-master-cuda = georgewhewellMaintained (llamaCppMaster.override cudaOverride);
   }
   // lib.optionalAttrs supportsTherockRocm {


### PR DESCRIPTION
## Summary

- compose the thunderbolt-ibverbs `rdma-core-usb4` userspace into Strix llama.cpp ROCm/Vulkan variants
- force `GGML_RPC_RDMA=ON` so ggml RPC keeps RDMA enabled across future nixpkgs/llama.cpp default changes
- leave CUDA variants unchanged

## Validation

- `git diff --check`
- `nix flake check --no-build`
- `nix build .#llama-cpp-master-rocm --no-link --print-out-paths`
  - `/nix/store/c340g5vpnjy0fjkq6vni7s2v9kgrl4c2-llama-cpp-master-rocm-gfx1151-master-60130d1`
- verified `libggml-rpc.so` links the thunderbolt `rdma-core-usb4` `libibverbs.so.1`
- StepFun smoke on `strix-2` client -> `strix-1` RPC server with `Step-3.7-Flash-GGUF/IQ4_XS`, `-ngl 1`, `GGML_RDMA_DEV=usb4_rdma5`, `GGML_RDMA_GID=1`
  - client/server both logged `RDMA probed` and `RDMA activated`
  - prompt: 8 tokens, 4.37 tok/s
  - gen: 1 token, 3.56 tok/s

## Known Follow-Up

The direct Strix-to-Strix `ardma0` path maps to `usb4_rdma4`, but it does not currently support the RC QP that ggml RDMA needs:

- `ibv_rc_pingpong -d usb4_rdma4 -g 1 ...` fails immediately with `Couldn't create QP`
- `usb4_rdma4` advertises `max_qp=1`, `max_qp_rd_atom=0`, `max_qp_init_rd_atom=0`
- the bridge-bound `usb4_rdma5/6` devices advertise `max_qp=256`, `max_qp_rd_atom=128`, and complete RC ping-pong

So this PR fixes the packaging/overlay composition. The direct `ardma0` provider issue remains in thunderbolt-ibverbs.
