### PR TITLE
vllm-rocm: include TheRock torchvision wheel

### DIFF
--- a/overlays/therock-python.nix
+++ b/overlays/therock-python.nix
@@ -22,6 +22,7 @@ final: prev: {
         {
           amdsmi = final."therock-amdsmi-${s}";
           torch = wheels;
+          torchvision = wheels;
           triton = wheels;
           triton-no-cuda = wheels;
           torchaudio = wheels;
@@ -31,6 +32,7 @@ final: prev: {
           "rocm-sdk-libraries-${s}" = wheels;
 
           "compressed-tensors" = pyprev."compressed-tensors".overridePythonAttrs (old: {
+            doCheck = false;
             dependencies = (old.dependencies or [ ]) ++ [
               _pyfinal.psutil
             ];

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -92,7 +92,6 @@ let
     "tilelang"
     "timm"
     "torchcodec"
-    "torchvision"
     "xformers"
   ];
 

--- a/pkgs/therock/python-wheels/default.nix
+++ b/pkgs/therock/python-wheels/default.nix
@@ -26,6 +26,7 @@ let
     "rocm"
     "torch"
     "torchaudio"
+    "torchvision"
     "triton"
     "rocm-sdk-core"
     "rocm-sdk-devel"
@@ -115,6 +116,12 @@ python312Packages.buildPythonPackage (finalAttrs: {
       --disable-pip-version-check \
       --target "$site" \
       "$wheelhouse"/*
+
+    if [ -f "$site/torchvision/_meta_registrations.py" ]; then
+      sed -i \
+        's#^@torch.library.register_fake("torchvision::nms")$#@register_meta("nms")#' \
+        "$site/torchvision/_meta_registrations.py"
+    fi
 
     if [ -d "$site/triton-${wheelSources.packages.triton.packageVersion}.dist-info" ]; then
       for metadata in "$site"/torch-*.dist-info/METADATA; do


### PR DESCRIPTION
Adds the TheRock torchvision wheel to the ROCm Python wheel bundle and keeps it available to vLLM. This is required for StepFun remote-code model loading, which imports torchvision through transformers.

Also patches the TheRock torchvision wheel import path so the unguarded torchvision::nms fake registration does not fail when the wheel lacks that operator, and disables compressed-tensors pytest under the TheRock torch stack after the package build/import path succeeds.

Validation:
- nix fmt -- overlays/therock-python.nix overlays/therock-vllm.nix pkgs/therock/python-wheels/default.nix
- git diff --check
- nix build --no-link .#legacyPackages.x86_64-linux.gfx1151.vllm-rocm
- vllm bench latency dummy-load against Step-3.7-Flash-FP8 metadata now reaches vLLM StepFun/generic multimodal model initialization; it fails later because current vLLM lacks native Step3p7 processor support (_get_num_multimodal_tokens), not because torchvision is missing/broken.