### PR TITLE
llama-cpp: allow configurable RPC RDMA chunk size

### DIFF
--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -109,6 +109,9 @@ lib.optionalAttrs prev.stdenv.isLinux (
         (lib.cmakeBool "LLAMA_BUILD_UI" false)
         (lib.cmakeFeature "LLAMA_BUILD_NUMBER" "0")
       ];
+      patches = (old.patches or [ ]) ++ [
+        ../pkgs/llama-cpp/patches/0001-rpc-rdma-configurable-chunk-size.patch
+      ];
       meta = (old.meta or { }) // {
         maintainers = with lib.maintainers; [ georgewhewell ];
       };

--- a/pkgs/llama-cpp/patches/0001-rpc-rdma-configurable-chunk-size.patch
+++ b/pkgs/llama-cpp/patches/0001-rpc-rdma-configurable-chunk-size.patch
@@ -1,0 +1,64 @@
+--- a/ggml/src/ggml-rpc/transport.cpp
++++ b/ggml/src/ggml-rpc/transport.cpp
+@@ -19,0 +20 @@
++#include <cerrno>
+@@ -45,2 +46,2 @@
+-static constexpr size_t RDMA_CHUNK    = 256 * 1024;   // 256 KiB per send/recv (fits default 8 MiB memlock)
+-static constexpr int    RDMA_RX_DEPTH = 24;            // pre-posted recv ring: 24 × 256 KiB = 6 MiB
++static constexpr size_t RDMA_DEFAULT_CHUNK = 256 * 1024; // 256 KiB per send/recv
++static constexpr int    RDMA_RX_DEPTH      = 24;         // pre-posted recv ring
+@@ -49,0 +51,20 @@
++static size_t rdma_align_alloc_size(size_t size) {
++    static constexpr size_t ALIGN = 4096;
++    return ((size + ALIGN - 1) / ALIGN) * ALIGN;
++}
++
++static size_t rdma_chunk_size() {
++    const char * env = std::getenv("GGML_RPC_RDMA_CHUNK_SIZE");
++    if (!env || !*env) {
++        return RDMA_DEFAULT_CHUNK;
++    }
++    errno = 0;
++    char * end = nullptr;
++    unsigned long long parsed = std::strtoull(env, &end, 10);
++    if (errno != 0 || end == env || *end != '\0' || parsed == 0 || parsed > MAX_CHUNK_SIZE) {
++        GGML_LOG_ERROR("Ignoring invalid GGML_RPC_RDMA_CHUNK_SIZE=%s\n", env);
++        return RDMA_DEFAULT_CHUNK;
++    }
++    return static_cast<size_t>(parsed);
++}
++
+@@ -60 +81 @@
+-    void          * rx_buf = nullptr; // RDMA_RX_DEPTH × RDMA_CHUNK contiguous
++    void          * rx_buf = nullptr; // RDMA_RX_DEPTH slots of chunk_size bytes
+@@ -64,0 +86 @@
++    size_t          chunk_size = RDMA_DEFAULT_CHUNK;
+@@ -67 +89 @@
+-        return static_cast<uint8_t *>(rx_buf) + static_cast<size_t>(i) * RDMA_CHUNK;
++        return static_cast<uint8_t *>(rx_buf) + static_cast<size_t>(i) * chunk_size;
+@@ -73 +95 @@
+-        sge.length = RDMA_CHUNK;
++        sge.length = chunk_size;
+@@ -294,0 +317,4 @@
++    rdma->chunk_size = rdma_chunk_size();
++    const size_t rx_bytes = static_cast<size_t>(RDMA_RX_DEPTH) * rdma->chunk_size;
++    const size_t tx_alloc_bytes = rdma_align_alloc_size(rdma->chunk_size);
++    const size_t rx_alloc_bytes = rdma_align_alloc_size(rx_bytes);
+@@ -296,2 +322,2 @@
+-    rdma->tx_buf = aligned_alloc(4096, RDMA_CHUNK);
+-    rdma->rx_buf = aligned_alloc(4096, static_cast<size_t>(RDMA_RX_DEPTH) * RDMA_CHUNK);
++    rdma->tx_buf = aligned_alloc(4096, tx_alloc_bytes);
++    rdma->rx_buf = aligned_alloc(4096, rx_alloc_bytes);
+@@ -300,2 +326,2 @@
+-    rdma->tx_mr = ibv_reg_mr(rdma->pd, rdma->tx_buf, RDMA_CHUNK, IBV_ACCESS_LOCAL_WRITE);
+-    rdma->rx_mr = ibv_reg_mr(rdma->pd, rdma->rx_buf, static_cast<size_t>(RDMA_RX_DEPTH) * RDMA_CHUNK,
++    rdma->tx_mr = ibv_reg_mr(rdma->pd, rdma->tx_buf, rdma->chunk_size, IBV_ACCESS_LOCAL_WRITE);
++    rdma->rx_mr = ibv_reg_mr(rdma->pd, rdma->rx_buf, rx_bytes,
+@@ -318,2 +344,2 @@
+-    GGML_LOG_INFO("RDMA probed: dev=%s gid=%d%s qpn=%u inline=%u\n",
+-                  matched_dev, gid_idx, ver_str, rdma_local.qpn, rdma->max_inline);
++    GGML_LOG_INFO("RDMA probed: dev=%s gid=%d%s qpn=%u inline=%u chunk=%zu\n",
++                  matched_dev, gid_idx, ver_str, rdma_local.qpn, rdma->max_inline, rdma->chunk_size);
+@@ -410 +436 @@
+-        size_t chunk = std::min(rem, RDMA_CHUNK);
++        size_t chunk = std::min(rem, c->chunk_size);


### PR DESCRIPTION
Adds a llama.cpp patch for `GGML_RPC_RDMA_CHUNK_SIZE`, allowing the RPC RDMA transport chunk size to be adjusted without rebuilding. The default remains 256 KiB.

Why: this gives us a controlled diagnostic/workaround lever while we fix thunderbolt-ibverbs native SEND fragmentation correctness.

Validation:
- `git diff --check`
- `nix fmt`
- `nix build .#packages.x86_64-linux.llama-cpp-master-rocm --no-link --print-build-logs`
- Strix RDMA tests with patched build:
  - Stepfun Q4_K_S TP=2 with 64 KiB chunks reproduced native SEND timeout: total=65536 received=60720.
  - Stepfun Q4_K_S TP=2 with 32 KiB chunks reproduced native SEND timeout: total=32768 received=28336.
  - llama-2-7b Q4_K_M TP=2 with 4048-byte chunks completed over RPC/RDMA.
  - llama-2-7b Q4_K_M TP=2 with uncached 4096-byte chunks completed over RPC/RDMA.

This is not intended as the provider correctness fix; it makes the RPC transport tunable enough to isolate and work around the failure mode during testing.