### PR TITLE
bench: add Strix Halo two-host vLLM pair benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ TheRock-published Python wheels.
 | `mlx-rocm` | MLX with the ROCm backend |
 | `ds4-rocm` | DwarfStar 4 HIP build |
 | `fastflowlm` | XDNA2 NPU CLI (`flm`) |
+| `strix-halo-vllm-pair-bench-gfx1151` | two-host vLLM transport-matrix bench driver |
 | `therock-rocm`, `therock-python`, `torch-rocm` | TheRock binary SDK + wheels |
 | `xrt`, `xrt-amdxdna`, `tokenizers-cpp`, `strix-halo-mes-firmware`, `ec-su-axb35-monitor` | hardware support bits |
 | `live-iso` | USB-flashable strix-halo live system |
@@ -60,6 +61,27 @@ nix build .#vllm-rocm
 nix build .#live-iso             # iso at ./result/iso/*.iso
 nix run  .#live-iso-vm           # boot the iso in QEMU
 ```
+
+### Two-host vLLM pair benchmark
+
+`strix-halo-vllm-pair-bench-gfx1151` drives the multi-host vLLM transport
+matrix for real lab runs. It copies the vLLM, GCC, RDMA, and benchmark-script
+closures to both hosts, runs the matrix from the master node, then fetches the
+result CSV. Scenarios: `qwen-peak`, `llama-tp2-win`, `qwen35-122b-awq-capacity`,
+`qwen35-122b-awq-prime`, `minimax-m27-awq-strix-2h`.
+
+```bash
+nix run .#strix-halo-vllm-pair-bench-gfx1151 -- \
+  --scenario qwen-peak \
+  --master grw@strix-1.lan.satanic.link \
+  --worker grw@strix-2.lan.satanic.link
+
+# inspect the plan without touching the hosts
+nix run .#strix-halo-vllm-pair-bench-gfx1151 -- --scenario qwen-peak --dry-run
+```
+
+Each scenario fixes the model, transports (`solo`, `lan_tcp`, `usb4_rdma`),
+concurrencies, and vLLM args; results land in `./out-vllm-<scenario>-<ts>/`.
 
 ## Non-default targets and providers
 

--- a/flake.nix
+++ b/flake.nix
@@ -647,6 +647,7 @@
       packages = perSystem (
         pkgs:
         let
+          s = defaultRocmTarget.packageSuffix;
           aiTools = inputs.nix-ai-tools.packages.${pkgs.stdenv.hostPlatform.system};
           cudaPkgs = cudaPkgsFor pkgs.stdenv.hostPlatform.system;
           jacclPackage = pkgs.callPackage ./pkgs/jaccl (
@@ -693,6 +694,17 @@
             jaccl = jacclPackage;
           };
 
+          # Two-host vLLM transport-matrix driver. The driver only needs the
+          # vLLM closure to expose both `vllm` and `ray`, so join the default
+          # ROCm vLLM package with ray rather than baking ray into vllm-rocm.
+          vllmPairBenchEnv = pkgs.symlinkJoin {
+            name = "vllm-rocm-${s}-ray-env";
+            paths = [
+              pkgs.vllm-rocm
+              pkgs.python312Packages.ray
+            ];
+          };
+
           linuxPackages = lib.genAttrs localPackagesKeys (name: pkgs.${name}) // {
             inherit (pkgs)
               linux-thunderbolt
@@ -705,6 +717,10 @@
             inherit (cudaPkgs) llama-cpp-cuda llama-cpp-master-cuda;
             live-iso = self.nixosConfigurations.live-iso.config.system.build.isoImage;
             mlx = pkgs.mlx-rocm;
+            "strix-halo-vllm-pair-bench-${s}" = pkgs.callPackage ./pkgs/strix-halo-vllm-pair-bench {
+              vllmPackage = vllmPairBenchEnv;
+              packageSuffix = s;
+            };
           };
 
           darwinPackages =
@@ -778,6 +794,9 @@
               ap llamaRocmRuntime "llama-server"
                 "Run llama-server with ROCm (default target ${defaultRocmTarget.description})";
             flm = ap pkgs.fastflowlm "flm" "Run the FastFlowLM CLI on AMD Ryzen AI NPUs";
+            "strix-halo-vllm-pair-bench-${s}" =
+              ap self.packages.${system}."strix-halo-vllm-pair-bench-${s}" "strix-halo-vllm-pair-bench-${s}"
+                "Run vLLM transport-matrix scenarios across a Strix Halo pair";
             therock-rocm-env =
               ap pkgs.therock-rocm-env "therock-rocm-${s}-env"
                 "Run a command in the pinned TheRock ROCm ${s} environment";
@@ -954,6 +973,45 @@
 
                   touch "$out"
                 '';
+
+            # Build the pair-bench driver against stub vLLM/RDMA/GCC closures so
+            # CI validates the wrapper, matrix script, and client without the
+            # heavy ROCm closure or a real two-host lab.
+            fakeVllmEnv = pkgs.runCommandLocal "ci-fake-vllm-env" { } ''
+              mkdir -p "$out/bin"
+              for exe in vllm ray python python3; do
+                printf '%s\n' \
+                  '#!/bin/sh' \
+                  'echo "fake $(basename "$0") $*"' \
+                  > "$out/bin/$exe"
+                chmod +x "$out/bin/$exe"
+              done
+            '';
+            fakeRdmaCore = pkgs.runCommandLocal "ci-fake-rdma-core" { } ''
+              mkdir -p "$out/bin" "$out/lib"
+              touch "$out/lib/libibverbs.so.1"
+              printf '%s\n' \
+                '#!/bin/sh' \
+                'echo "device"' \
+                'echo "------"' \
+                'echo "usb4_rdma0"' \
+                > "$out/bin/ibv_devices"
+              chmod +x "$out/bin/ibv_devices"
+            '';
+            fakeGcc = pkgs.runCommandLocal "ci-fake-gcc-prefix" { } ''
+              mkdir -p "$out/bin"
+              printf '%s\n' \
+                '#!/bin/sh' \
+                'echo "fake gcc $*"' \
+                > "$out/bin/gcc"
+              chmod +x "$out/bin/gcc"
+            '';
+            vllmPairBenchCheckPackage = pkgs.callPackage ./pkgs/strix-halo-vllm-pair-bench {
+              gcc = fakeGcc;
+              rdma-core = fakeRdmaCore;
+              vllmPackage = fakeVllmEnv;
+              packageSuffix = "ci";
+            };
           in
           {
             deadnix = runSourceCheck "deadnix" [ pkgs.deadnix ] "deadnix --fail .";
@@ -963,6 +1021,22 @@
             ] "treefmt --tree-root . --walk filesystem --fail-on-change .";
             cuda-host-driver-runtime = cudaHostDriverRuntime;
             package-surface = packageSurface;
+            vllm-pair-bench-dry-run =
+              pkgs.runCommandLocal "ci-vllm-pair-bench-dry-run"
+                {
+                  nativeBuildInputs = [
+                    pkgs.gnugrep
+                    pkgs.python3
+                    vllmPairBenchCheckPackage
+                  ];
+                  meta.maintainers = with lib.maintainers; [ georgewhewell ];
+                }
+                ''
+                  bash -n ${./lib/bench/vllm-transport-matrix.sh}
+                  python3 -m py_compile ${./lib/bench/vllm-stream-client.py}
+                  strix-halo-vllm-pair-bench-ci --scenario qwen-peak --dry-run | tee "$out"
+                  grep -q "dry-run: not invoking" "$out"
+                '';
           }
         )
       );

--- a/lib/bench/vllm-stream-client.py
+++ b/lib/bench/vllm-stream-client.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Streaming vLLM benchmark client.
+
+This measures what the OpenAI-compatible completions API exposes directly:
+time-to-first-token and total request time. In the CSV, prefill time is the
+TTFT proxy: it includes queueing plus prompt prefill plus the first decode
+step. Decode time is total time after TTFT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime as dt
+import json
+import math
+import os
+import socket
+import statistics
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+
+FIELDS = [
+    "timestamp_utc",
+    "run_id",
+    "host",
+    "transport",
+    "parallelism",
+    "model",
+    "concurrency",
+    "max_tokens",
+    "prompt_chars",
+    "prompt_tokens_per_req",
+    "requests_ok",
+    "requests_failed",
+    "status",
+    "skip_reason",
+    "wall_s",
+    "total_prompt_tokens",
+    "total_completion_tokens",
+    "total_tps",
+    "ttft_mean_s",
+    "ttft_p50_s",
+    "ttft_p95_s",
+    "prefill_mean_s",
+    "decode_mean_s",
+    "decode_tps_mean",
+    "output_tps_mean",
+    "endpoint",
+    "socket_ifname",
+    "rdma_hca",
+    "vllm_extra_args",
+    "server_log",
+    "errors",
+]
+
+
+def now_utc() -> str:
+    return dt.datetime.now(dt.UTC).isoformat(timespec="seconds")
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (pct / 100.0) * (len(ordered) - 1)
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return ordered[lo]
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (rank - lo)
+
+
+def fmt(value: float | int | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return ""
+        return f"{value:.6f}"
+    return str(value)
+
+
+def base_row(args: argparse.Namespace, prompt: str) -> dict[str, str]:
+    return {
+        "timestamp_utc": now_utc(),
+        "run_id": args.run_id,
+        "host": socket.gethostname(),
+        "transport": args.transport,
+        "parallelism": args.parallelism,
+        "model": args.model,
+        "concurrency": str(args.concurrency),
+        "max_tokens": str(args.max_tokens),
+        "prompt_chars": str(len(prompt)),
+        "endpoint": args.endpoint,
+        "socket_ifname": args.socket_ifname,
+        "rdma_hca": args.rdma_hca,
+        "vllm_extra_args": args.vllm_extra_args,
+        "server_log": args.server_log,
+    }
+
+
+def append_csv(path: Path, row: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    exists = path.exists() and path.stat().st_size > 0
+    with path.open("a", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=FIELDS, extrasaction="ignore")
+        if not exists:
+            writer.writeheader()
+        writer.writerow({field: row.get(field, "") for field in FIELDS})
+
+
+def stream_one(
+    *,
+    endpoint: str,
+    model: str,
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    ignore_eos: bool,
+    timeout_s: float,
+    barrier: threading.Barrier,
+    request_index: int,
+) -> dict[str, Any]:
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "ignore_eos": ignore_eos,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+
+    barrier.wait()
+    start = time.perf_counter()
+    first_token: float | None = None
+    usage: dict[str, Any] = {}
+    text_parts: list[str] = []
+
+    try:
+        req = urllib.request.Request(
+            endpoint,
+            data=json.dumps(payload).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            for raw in resp:
+                line = raw.decode("utf-8", errors="replace").strip()
+                if not line or not line.startswith("data:"):
+                    continue
+
+                data = line[5:].strip()
+                if data == "[DONE]":
+                    break
+
+                obj = json.loads(data)
+                if obj.get("usage") is not None:
+                    usage = obj["usage"]
+
+                for choice in obj.get("choices", []):
+                    piece = choice.get("text") or ""
+                    if piece:
+                        if first_token is None:
+                            first_token = time.perf_counter()
+                        text_parts.append(piece)
+
+        end = time.perf_counter()
+        completion_tokens = usage.get("completion_tokens")
+        prompt_tokens = usage.get("prompt_tokens")
+        duration = end - start
+        ttft = None if first_token is None else first_token - start
+        decode = None if ttft is None else max(0.0, duration - ttft)
+
+        return {
+            "request_index": request_index,
+            "ok": True,
+            "start": start,
+            "end": end,
+            "duration_s": duration,
+            "ttft_s": ttft,
+            "decode_s": decode,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "text_bytes": len("".join(text_parts).encode("utf-8")),
+            "error": "",
+        }
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")[:4000]
+        return {
+            "request_index": request_index,
+            "ok": False,
+            "start": start,
+            "end": time.perf_counter(),
+            "error": f"HTTP {exc.code}: {body}",
+        }
+    except Exception as exc:  # noqa: BLE001 - benchmark row should record failures.
+        return {
+            "request_index": request_index,
+            "ok": False,
+            "start": start,
+            "end": time.perf_counter(),
+            "error": repr(exc),
+        }
+
+
+def aggregate(args: argparse.Namespace, prompt: str) -> dict[str, str]:
+    barrier = threading.Barrier(args.concurrency)
+    wall_start = time.perf_counter()
+    rows: list[dict[str, Any]] = []
+
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        futures = [
+            pool.submit(
+                stream_one,
+                endpoint=args.endpoint,
+                model=args.model,
+                prompt=prompt,
+                max_tokens=args.max_tokens,
+                temperature=args.temperature,
+                ignore_eos=args.ignore_eos,
+                timeout_s=args.timeout,
+                barrier=barrier,
+                request_index=i,
+            )
+            for i in range(args.concurrency)
+        ]
+        for fut in as_completed(futures):
+            rows.append(fut.result())
+
+    wall_s = time.perf_counter() - wall_start
+    ok_rows = [row for row in rows if row.get("ok")]
+    bad_rows = [row for row in rows if not row.get("ok")]
+    prompt_tokens = [
+        int(row["prompt_tokens"])
+        for row in ok_rows
+        if row.get("prompt_tokens") is not None
+    ]
+    completion_tokens = [
+        int(row["completion_tokens"])
+        for row in ok_rows
+        if row.get("completion_tokens") is not None
+    ]
+    ttfts = [
+        float(row["ttft_s"])
+        for row in ok_rows
+        if row.get("ttft_s") is not None
+    ]
+    decodes = [
+        float(row["decode_s"])
+        for row in ok_rows
+        if row.get("decode_s") is not None
+    ]
+    decode_tps = []
+    output_tps = []
+    for row in ok_rows:
+        ctok = row.get("completion_tokens")
+        duration = row.get("duration_s")
+        decode_s = row.get("decode_s")
+        if ctok is None or duration is None:
+            continue
+        ctok_i = int(ctok)
+        if duration > 0:
+            output_tps.append(ctok_i / duration)
+        if decode_s and decode_s > 0:
+            decode_tps.append(max(0, ctok_i - 1) / decode_s)
+
+    total_completion = sum(completion_tokens)
+    total_prompt = sum(prompt_tokens)
+    errors = " | ".join(str(row.get("error", ""))[:300] for row in bad_rows)
+
+    row = base_row(args, prompt)
+    row.update(
+        {
+            "prompt_tokens_per_req": fmt(statistics.median(prompt_tokens) if prompt_tokens else None),
+            "requests_ok": str(len(ok_rows)),
+            "requests_failed": str(len(bad_rows)),
+            "status": "ok" if ok_rows and not bad_rows else ("partial" if ok_rows else "failed"),
+            "skip_reason": "",
+            "wall_s": fmt(wall_s),
+            "total_prompt_tokens": str(total_prompt),
+            "total_completion_tokens": str(total_completion),
+            "total_tps": fmt(total_completion / wall_s if wall_s > 0 else None),
+            "ttft_mean_s": fmt(statistics.mean(ttfts) if ttfts else None),
+            "ttft_p50_s": fmt(percentile(ttfts, 50)),
+            "ttft_p95_s": fmt(percentile(ttfts, 95)),
+            "prefill_mean_s": fmt(statistics.mean(ttfts) if ttfts else None),
+            "decode_mean_s": fmt(statistics.mean(decodes) if decodes else None),
+            "decode_tps_mean": fmt(statistics.mean(decode_tps) if decode_tps else None),
+            "output_tps_mean": fmt(statistics.mean(output_tps) if output_tps else None),
+            "errors": errors,
+        }
+    )
+    return row
+
+
+def parse_args() -> argparse.Namespace:
+    def parse_bool(value: str) -> bool:
+        lowered = value.lower()
+        if lowered in {"1", "true", "yes", "on"}:
+            return True
+        if lowered in {"0", "false", "no", "off"}:
+            return False
+        raise argparse.ArgumentTypeError(f"invalid boolean: {value}")
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--csv", required=True, type=Path)
+    parser.add_argument("--endpoint", default="http://127.0.0.1:8000/v1/completions")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--transport", required=True)
+    parser.add_argument("--parallelism", required=True)
+    parser.add_argument("--concurrency", required=True, type=int)
+    parser.add_argument("--max-tokens", required=True, type=int)
+    parser.add_argument("--prompt-file", type=Path)
+    parser.add_argument("--prompt", default="")
+    parser.add_argument("--temperature", default=0.0, type=float)
+    parser.add_argument("--ignore-eos", default=True, type=parse_bool)
+    parser.add_argument("--timeout", default=900.0, type=float)
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--socket-ifname", default="")
+    parser.add_argument("--rdma-hca", default="")
+    parser.add_argument("--vllm-extra-args", default="")
+    parser.add_argument("--server-log", default="")
+    parser.add_argument("--skip-reason", default="")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.prompt_file:
+        prompt = args.prompt_file.read_text()
+    else:
+        prompt = args.prompt
+
+    if args.skip_reason:
+        row = base_row(args, prompt)
+        row.update(
+            {
+                "requests_ok": "0",
+                "requests_failed": "0",
+                "status": "skipped",
+                "skip_reason": args.skip_reason,
+            }
+        )
+        append_csv(args.csv, row)
+        return 0
+
+    if args.concurrency < 1:
+        print("--concurrency must be >= 1", file=sys.stderr)
+        return 2
+
+    row = aggregate(args, prompt)
+    append_csv(args.csv, row)
+    print(
+        "  "
+        f"conc={args.concurrency} max={args.max_tokens}: "
+        f"status={row['status']} total_tps={row['total_tps']} "
+        f"ttft_p50={row['ttft_p50_s']} decode_tps_mean={row['decode_tps_mean']}"
+    )
+    return 0 if row["status"] in {"ok", "partial"} else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/bench/vllm-transport-matrix.sh
+++ b/lib/bench/vllm-transport-matrix.sh
@@ -1,0 +1,691 @@
+#!/usr/bin/env bash
+# Benchmark the fixed vLLM model set across usb4_rdma, TCP, thunderbolt-net,
+# rxe-over-thunderbolt-net, and single-device mode.
+#
+# Default axes:
+#   models: Qwen3-0.6B, SmolLM3-3B, Qwen3-4B, Olmo-7B, Llama-3.1-8B
+#   transports: solo lan_tcp usb4_rdma tb_tcp tb_rxe
+#   concurrencies: 1 4 16 64 256
+#
+# By default the script runs a deterministic random subset. Use
+# SAMPLE_CASES=0 for the full Cartesian product. The selected plan is saved
+# beside the output CSV.
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+REPO_DIR=${REPO_DIR:-$(cd -- "$SCRIPT_DIR/../.." && pwd)}
+
+find_prefix_for() {
+  local tool=$1 path
+  path=$(command -v "$tool" 2>/dev/null || true)
+  [[ -n "$path" ]] || return 1
+  cd -- "$(dirname -- "$path")/.." && pwd
+}
+
+find_bin_dir_for() {
+  local tool=$1 path
+  path=$(command -v "$tool" 2>/dev/null || true)
+  [[ -n "$path" ]] || return 1
+  cd -- "$(dirname -- "$path")" && pwd
+}
+
+VLLM_ENV=${VLLM_ENV:-$(find_prefix_for vllm || true)}
+GCCBIN=${GCCBIN:-$(find_bin_dir_for gcc || true)}
+RDMA=${RDMA:-$(find_prefix_for ibv_devices || true)}
+ROCR=${ROCR:-${RCCL_ROCR_PATH:-}}
+ROCR=${ROCR%/}
+if [[ -z "$VLLM_ENV" || ! -x "$VLLM_ENV/bin/vllm" || ! -x "$VLLM_ENV/bin/ray" ]]; then
+  echo "VLLM_ENV is not set to a vLLM environment; use the Nix-generated vllm-transport-matrix wrapper or export VLLM_ENV" >&2
+  exit 2
+fi
+if [[ -z "$GCCBIN" || ! -x "$GCCBIN/gcc" ]]; then
+  echo "GCCBIN is not set to a directory containing gcc; use the Nix-generated vllm-transport-matrix wrapper or export GCCBIN" >&2
+  exit 2
+fi
+if [[ -z "$RDMA" || ! -d "$RDMA/lib" ]]; then
+  echo "RDMA is not set to an rdma-core prefix; use the Nix-generated vllm-transport-matrix wrapper or export RDMA" >&2
+  exit 2
+fi
+if [[ -n "$ROCR" && ! -d "$ROCR" ]]; then
+  echo "ROCR is set but is not a directory: $ROCR" >&2
+  exit 2
+fi
+RDMA_BIN=${RDMA_BIN:-/run/current-system/sw/bin/rdma}
+if [[ ! -x "$RDMA_BIN" ]]; then
+  RDMA_BIN=$(command -v rdma || echo rdma)
+fi
+
+SSH_HOST=${SSH_HOST:-strix-2}
+LAN_IFNAME=${LAN_IFNAME:-br0.lan}
+REMOTE_LAN_IFNAME=${REMOTE_LAN_IFNAME:-$LAN_IFNAME}
+TB_IFNAME=${TB_IFNAME:-thunderbolt0}
+REMOTE_TB_IFNAME=${REMOTE_TB_IFNAME:-$TB_IFNAME}
+USB4_HCA=${USB4_HCA:-usb4_rdma2,usb4_rdma3}
+RXE_HCA=${RXE_HCA:-rxe_tb}
+PORT=${PORT:-8000}
+
+MODELS=${MODELS:-"Qwen/Qwen3-0.6B HuggingFaceTB/SmolLM3-3B Qwen/Qwen3-4B-Instruct-2507 allenai/Olmo-3-7B-Instruct unsloth/Meta-Llama-3.1-8B-Instruct"}
+TRANSPORTS=${TRANSPORTS:-"solo lan_tcp usb4_rdma tb_tcp tb_rxe"}
+CONCURRENCIES=${CONCURRENCIES:-"1 4 16 64 256"}
+MAX_TOKENS=${MAX_TOKENS:-64}
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-2048}
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-512}
+MAX_NUM_BATCHED_TOKENS=${MAX_NUM_BATCHED_TOKENS:-}
+PROMPT_SECTIONS=${PROMPT_SECTIONS:-24}
+IGNORE_EOS=${IGNORE_EOS:-true}
+VLLM_EXTRA_ARGS=${VLLM_EXTRA_ARGS:-}
+VLLM_ENFORCE_EAGER=${VLLM_ENFORCE_EAGER:-1}
+VLLM_DISABLE_CUSTOM_ALL_REDUCE=${VLLM_DISABLE_CUSTOM_ALL_REDUCE:-1}
+NCCL_DEBUG_LEVEL=${NCCL_DEBUG_LEVEL:-${NCCL_DEBUG:-WARN}}
+CLIENT_TIMEOUT_S=${CLIENT_TIMEOUT_S:-900}
+STARTUP_TIMEOUT_S=${STARTUP_TIMEOUT_S:-360}
+SAMPLE_CASES=${SAMPLE_CASES:-30}
+RANDOM_SEED=${RANDOM_SEED:-20260502}
+ALLOW_MODPROBE_TB=${ALLOW_MODPROBE_TB:-0}
+SETUP_RXE=${SETUP_RXE:-1}
+DRY_RUN=${DRY_RUN:-0}
+RESUME=${RESUME:-0}
+
+RUN_ID=${RUN_ID:-$(date -u +%Y%m%dT%H%M%SZ)}
+LOG_DIR=${LOG_DIR:-/tmp/usb4-rdma-vllm-matrix/$RUN_ID}
+OUTPUT_CSV=${OUTPUT_CSV:-$REPO_DIR/results/vllm-transport-matrix-$RUN_ID.csv}
+PLAN_FILE=${PLAN_FILE:-$LOG_DIR/plan.tsv}
+PROMPT_FILE=${PROMPT_FILE:-$LOG_DIR/long-prompt.txt}
+
+VLLM_PID=
+CURRENT_LOG=
+CURRENT_TRANSPORT=
+CURRENT_MODEL=
+
+read -r -a VLLM_EXTRA_ARGS_ARY <<< "$VLLM_EXTRA_ARGS"
+VLLM_LIMIT_ARGS=(--max-model-len "$MAX_MODEL_LEN" --max-num-seqs "$MAX_NUM_SEQS")
+if [[ -n "$MAX_NUM_BATCHED_TOKENS" ]]; then
+  VLLM_LIMIT_ARGS+=(--max-num-batched-tokens "$MAX_NUM_BATCHED_TOKENS")
+fi
+VLLM_MODE_ARGS=()
+if [[ "$VLLM_ENFORCE_EAGER" == "1" ]]; then
+  VLLM_MODE_ARGS+=(--enforce-eager)
+fi
+if [[ "$VLLM_DISABLE_CUSTOM_ALL_REDUCE" == "1" ]]; then
+  VLLM_MODE_ARGS+=(--disable-custom-all-reduce)
+fi
+
+mkdir -p "$LOG_DIR" "$(dirname -- "$OUTPUT_CSV")"
+
+if [[ ! -s "$PROMPT_FILE" ]]; then
+  "$VLLM_ENV/bin/python" - "$PROMPT_FILE" "$PROMPT_SECTIONS" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+sections = int(sys.argv[2])
+if sections < 1:
+    raise SystemExit("PROMPT_SECTIONS must be >= 1")
+text = []
+for i in range(1, sections + 1):
+    text.append(
+        f"Section {i:03d}: The system connects two compact workstations over "
+        "USB4 and evaluates tensor parallel inference. Each request contains "
+        "a technical design note with latency, bandwidth, memory bandwidth, "
+        "completion queue, and transport observations. "
+    )
+text.append("Summarize the design tradeoffs, identify bottlenecks, and give practical next steps.")
+path.write_text("".join(text))
+PY
+fi
+
+iface_ipv4() {
+  local iface=$1
+  ip -o -4 addr show dev "$iface" 2>/dev/null | awk '{split($4,a,"/"); print a[1]; exit}'
+}
+
+remote_iface_ipv4() {
+  local iface=$1
+  ssh -n -o ConnectTimeout=5 "$SSH_HOST" \
+    "ip -o -4 addr show dev '$iface' 2>/dev/null | awk '{split(\$4,a,\"/\"); print a[1]; exit}'"
+}
+
+have_iface_both() {
+  local iface=$1
+  [[ -n "$(iface_ipv4 "$iface")" ]] && [[ -n "$(remote_iface_ipv4 "$iface")" ]]
+}
+
+have_iface_pair() {
+  local local_iface=$1 remote_iface=$2
+  [[ -d "/sys/class/net/$local_iface" ]] &&
+    ssh -n -o ConnectTimeout=5 "$SSH_HOST" "test -d /sys/class/net/'$remote_iface'"
+}
+
+stop_ray() {
+  "$VLLM_ENV/bin/ray" stop --force >/dev/null 2>&1 || true
+  ssh -n -o ConnectTimeout=5 "$SSH_HOST" "$VLLM_ENV/bin/ray stop --force" >/dev/null 2>&1 || true
+}
+
+stop_server() {
+  local status=${1:-0}
+  if [[ -n "${VLLM_PID:-}" ]]; then
+    kill "$VLLM_PID" 2>/dev/null || true
+    wait "$VLLM_PID" 2>/dev/null || true
+    VLLM_PID=
+  fi
+  stop_ray
+  if [[ "$status" -ne 0 && -n "${CURRENT_LOG:-}" && -s "$CURRENT_LOG" ]]; then
+    echo "recent vLLM log ($CURRENT_LOG):" >&2
+    tail -120 "$CURRENT_LOG" >&2 || true
+  fi
+}
+
+cleanup() {
+  local status=$?
+  trap - EXIT INT TERM
+  stop_server "$status"
+  exit "$status"
+}
+trap cleanup EXIT INT TERM
+
+tune_env=()
+TUNE_VARS=(
+  NCCL_P2P_NET_CHUNKSIZE
+  NCCL_CHUNK_SIZE
+  NCCL_BUFFSIZE
+  NCCL_P2P_LL_THRESHOLD
+  RCCL_P2P_NET_THRESHOLD
+  NCCL_NCHANNELS_PER_NET_PEER
+  NCCL_NCHANNELS_PER_PEER
+  NCCL_MIN_P2P_NCHANNELS
+  NCCL_MAX_P2P_NCHANNELS
+  NCCL_MIN_NCHANNELS
+  NCCL_MAX_NCHANNELS
+  NCCL_IB_QPS_PER_CONNECTION
+  NCCL_IB_SPLIT_DATA_ON_QPS
+  NCCL_IB_GID_INDEX
+  NCCL_NET_MERGE_LEVEL
+  NCCL_DEBUG_SUBSYS
+  NCCL_PROTO
+  NCCL_NET_SHARED_BUFFERS
+  NCCL_NET_SHARED_COMMS
+  RCCL_P2P_BATCH_ENABLE
+  RCCL_P2P_BATCH_THRESHOLD
+  HSA_NO_SCRATCH_RECLAIM
+  HSA_ENABLE_INTERRUPT
+  CUDA_VISIBLE_DEVICES
+  HIP_VISIBLE_DEVICES
+  ROCR_VISIBLE_DEVICES
+  RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO
+  RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES
+  RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES
+  RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES
+  RAY_CGRAPH_get_timeout
+  RAY_DEDUP_LOGS
+  VLLM_ROCM_USE_AITER
+  VLLM_ROCM_SHUFFLE_KV_CACHE_LAYOUT
+  VLLM_SLEEP_WHEN_IDLE
+  VLLM_USE_DEEP_GEMM
+  VLLM_USE_FLASHINFER_SAMPLER
+  VLLM_USE_FLASHINFER_MOE_FP16
+  OMP_NUM_THREADS
+  TOKENIZERS_PARALLELISM
+  TORCHDYNAMO_DISABLE
+  SAFETENSORS_FAST_GPU
+  VLLM_USE_RAY_COMPILED_DAG
+  VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE
+  VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM
+  VLLM_USE_RAY_WRAPPED_PP_COMM
+  VLLM_USE_RAY_V2_EXECUTOR_BACKEND
+  VLLM_USE_RAY_SPMD_WORKER
+  NCCL_GDRCOPY_ENABLE
+  NCCL_GDRCOPY_FIFO_ENABLE
+  NCCL_GDRCOPY_SYNC_ENABLE
+  NCCL_GDRCOPY_FLUSH_ENABLE
+  NCCL_NET_GDR_LEVEL
+  NCCL_NET_GDR_READ
+)
+for name in "${TUNE_VARS[@]}"; do
+  if [[ -v "$name" ]]; then
+    tune_env+=("$name=${!name}")
+  fi
+done
+
+remote_tune_env() {
+  local item
+  for item in "${tune_env[@]}"; do
+    printf ' %q' "$item"
+  done
+}
+
+remote_rocr_env() {
+  if [[ -n "${RCCL_ROCR_PATH:-}" ]]; then
+    printf ' RCCL_ROCR_PATH=%q' "$RCCL_ROCR_PATH"
+  fi
+}
+
+rail_map_hcas() {
+  local rdma_bin=${RDMA}/bin/ibv_devices
+
+  if [[ -x "$rdma_bin" ]]; then
+    "$rdma_bin" | awk '$1 ~ /^usb4_rdma/ {print $1}'
+    return
+  fi
+  sudo -n cat /sys/kernel/debug/usb4_rdma/data/rail_map 2>/dev/null |
+    awk 'NR > 1 && $1 ~ /^usb4_rdma/ {print $1}'
+}
+
+remote_rail_map_hcas() {
+  ssh -n -o ConnectTimeout=5 "$SSH_HOST" \
+    "if [ -x '$RDMA/bin/ibv_devices' ]; then '$RDMA/bin/ibv_devices' | awk '\$1 ~ /^usb4_rdma/ {print \$1}'; else sudo -n cat /sys/kernel/debug/usb4_rdma/data/rail_map 2>/dev/null | awk 'NR > 1 && \$1 ~ /^usb4_rdma/ {print \$1}'; fi"
+}
+
+resolve_usb4_hca() {
+  local local_hcas remote_hcas resolved hca
+
+  if [[ "$USB4_HCA" != "auto" ]]; then
+    printf '%s\n' "$USB4_HCA"
+    return
+  fi
+
+  local_hcas=$(rail_map_hcas || true)
+  remote_hcas=$(remote_rail_map_hcas || true)
+  resolved=
+  while IFS= read -r hca; do
+    [[ -n "$hca" ]] || continue
+    if grep -qxF "$hca" <<<"$remote_hcas"; then
+      resolved+="${resolved:+,}$hca"
+    fi
+  done <<<"$local_hcas"
+  if [[ -z "$resolved" ]]; then
+    echo "USB4_HCA=auto failed: no common HCAs in local/remote rail_map" >&2
+    echo "local:" >&2
+    printf '%s\n' "$local_hcas" >&2
+    echo "remote:" >&2
+    printf '%s\n' "$remote_hcas" >&2
+    return 1
+  fi
+  printf '%s\n' "$resolved"
+}
+
+make_plan() {
+  "$VLLM_ENV/bin/python" - "$PLAN_FILE" "$SAMPLE_CASES" "$RANDOM_SEED" \
+    "$MODELS" "$TRANSPORTS" "$CONCURRENCIES" "$MAX_TOKENS" "$RESUME" "$OUTPUT_CSV" <<'PY'
+import csv
+import itertools
+import random
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+sample_cases = int(sys.argv[2])
+seed = int(sys.argv[3])
+models = sys.argv[4].split()
+transports = sys.argv[5].split()
+concs = [int(x) for x in sys.argv[6].split()]
+max_tokens = int(sys.argv[7])
+resume = sys.argv[8] == "1"
+csv_path = Path(sys.argv[9])
+
+done = set()
+if resume and csv_path.exists():
+    raw = csv_path.read_bytes().replace(b"\0", b"")
+    text = raw.decode("utf-8", "replace")
+    rows = csv.DictReader(line for line in text.splitlines() if line.strip())
+    for row in rows:
+        if row.get("status") not in {"ok", "skipped"}:
+            continue
+        try:
+            done.add((
+                row["transport"],
+                row["model"],
+                int(row["concurrency"]),
+                int(row["max_tokens"]),
+            ))
+        except (KeyError, TypeError, ValueError):
+            pass
+
+cases = [
+    (transport, model, conc, max_tokens)
+    for transport, model, conc in itertools.product(transports, models, concs)
+]
+if done:
+    cases = [case for case in cases if case not in done]
+if sample_cases > 0 and sample_cases < len(cases):
+    rnd = random.Random(seed)
+    cases = rnd.sample(cases, sample_cases)
+
+transport_order = {name: i for i, name in enumerate(transports)}
+model_order = {name: i for i, name in enumerate(models)}
+cases.sort(key=lambda c: (transport_order[c[0]], model_order[c[1]], c[2]))
+
+with path.open("w") as fh:
+    for case in cases:
+        fh.write("\t".join(map(str, case)) + "\n")
+PY
+}
+
+append_skip() {
+  local transport=$1 model=$2 conc=$3 max_tokens=$4 parallelism=$5 reason=$6 socket_ifname=${7:-} rdma_hca=${8:-}
+  "$VLLM_ENV/bin/python" "$SCRIPT_DIR/vllm-stream-client.py" \
+    --csv "$OUTPUT_CSV" \
+    --endpoint "http://127.0.0.1:$PORT/v1/completions" \
+    --model "$model" \
+    --transport "$transport" \
+    --parallelism "$parallelism" \
+    --concurrency "$conc" \
+    --max-tokens "$max_tokens" \
+    --prompt-file "$PROMPT_FILE" \
+    --run-id "$RUN_ID" \
+    --socket-ifname "$socket_ifname" \
+    --rdma-hca "$rdma_hca" \
+    --vllm-extra-args="$VLLM_EXTRA_ARGS" \
+    --server-log "$CURRENT_LOG" \
+    --timeout "$CLIENT_TIMEOUT_S" \
+    --skip-reason "$reason"
+}
+
+wait_ready() {
+  local log=$1
+  local waited=0
+  while (( waited < STARTUP_TIMEOUT_S )); do
+    sleep 5
+    waited=$((waited + 5))
+    if grep -q "Application startup complete" "$log"; then
+      echo "  ready in ${waited}s"
+      return 0
+    fi
+    if [[ -n "${VLLM_PID:-}" ]] && ! kill -0 "$VLLM_PID" 2>/dev/null; then
+      echo "vLLM exited before startup completed" >&2
+      return 1
+    fi
+  done
+  echo "vLLM did not become ready within ${STARTUP_TIMEOUT_S}s" >&2
+  return 1
+}
+
+warmup() {
+  "$VLLM_ENV/bin/python" - "$CURRENT_MODEL" "$IGNORE_EOS" <<'PY' | \
+    curl --fail-with-body -sS --max-time "$CLIENT_TIMEOUT_S" "http://127.0.0.1:8000/v1/completions" \
+      -H 'Content-Type: application/json' -d @- >/dev/null
+import json
+import sys
+
+model, ignore_eos = sys.argv[1:]
+print(json.dumps({
+    "model": model,
+    "prompt": "Hi",
+    "max_tokens": 4,
+    "temperature": 0,
+    "ignore_eos": ignore_eos == "true",
+}))
+PY
+}
+
+transport_parallelism() {
+  case "$1" in
+    solo) echo "solo" ;;
+    *) echo "tp2" ;;
+  esac
+}
+
+ensure_thunderbolt_net() {
+  if have_iface_pair "$TB_IFNAME" "$REMOTE_TB_IFNAME"; then
+    return 0
+  fi
+  if [[ "$ALLOW_MODPROBE_TB" != "1" ]]; then
+    return 1
+  fi
+  sudo modprobe thunderbolt_net || true
+  ssh -n -o ConnectTimeout=5 "$SSH_HOST" "sudo modprobe thunderbolt_net || true" || true
+  sleep 8
+  have_iface_pair "$TB_IFNAME" "$REMOTE_TB_IFNAME"
+}
+
+rdma_link_exists() {
+  local hca=$1
+  "$RDMA_BIN" link show 2>/dev/null | grep -q "link $hca/"
+}
+
+remote_rdma_link_exists() {
+  local hca=$1
+  ssh -n -o ConnectTimeout=5 "$SSH_HOST" \
+    "'$RDMA_BIN' link show 2>/dev/null | grep -q 'link $hca/'"
+}
+
+ensure_rxe() {
+  if [[ "$SETUP_RXE" != "1" ]]; then
+    rdma_link_exists "$RXE_HCA" && remote_rdma_link_exists "$RXE_HCA"
+    return
+  fi
+
+  sudo modprobe rdma_rxe || true
+  ssh -n -o ConnectTimeout=5 "$SSH_HOST" "sudo modprobe rdma_rxe || true" || true
+
+  if ! rdma_link_exists "$RXE_HCA"; then
+    sudo "$RDMA_BIN" link add "$RXE_HCA" type rxe netdev "$TB_IFNAME"
+  fi
+  if ! remote_rdma_link_exists "$RXE_HCA"; then
+    ssh -n -o ConnectTimeout=5 "$SSH_HOST" \
+      "sudo '$RDMA_BIN' link add '$RXE_HCA' type rxe netdev '$REMOTE_TB_IFNAME'"
+  fi
+}
+
+start_server() {
+  local transport=$1 model=$2
+  local safe_model=${model//\//_}
+  local socket_ifname= remote_socket_ifname= rdma_hca= ib_disable= head= worker= ld_path= parallelism
+
+  parallelism=$(transport_parallelism "$transport")
+  CURRENT_TRANSPORT=$transport
+  CURRENT_MODEL=$model
+  CURRENT_LOG="$LOG_DIR/${transport}-${safe_model}.log"
+
+  stop_server 0
+  mkdir -p /tmp/aiter-jit
+  ssh -n -o ConnectTimeout=5 "$SSH_HOST" 'mkdir -p /tmp/aiter-jit' >/dev/null 2>&1 || true
+
+  case "$transport" in
+    solo)
+      socket_ifname=""
+      rdma_hca=""
+      ib_disable=1
+      ;;
+    lan_tcp)
+      socket_ifname=$LAN_IFNAME
+      remote_socket_ifname=$REMOTE_LAN_IFNAME
+      head=${HEAD:-$(iface_ipv4 "$LAN_IFNAME")}
+      worker=${WORKER:-$(remote_iface_ipv4 "$REMOTE_LAN_IFNAME")}
+      rdma_hca=""
+      ib_disable=1
+      ;;
+    usb4_rdma)
+      socket_ifname=$LAN_IFNAME
+      remote_socket_ifname=$REMOTE_LAN_IFNAME
+      head=${HEAD:-$(iface_ipv4 "$LAN_IFNAME")}
+      worker=${WORKER:-$(remote_iface_ipv4 "$REMOTE_LAN_IFNAME")}
+      rdma_hca=$USB4_HCA
+      ib_disable=0
+      ld_path=$RDMA/lib
+      ;;
+    tb_tcp)
+      ensure_thunderbolt_net || return 10
+      socket_ifname=$TB_IFNAME
+      remote_socket_ifname=$REMOTE_TB_IFNAME
+      head=${TB_HEAD:-$(iface_ipv4 "$TB_IFNAME")}
+      worker=${TB_WORKER:-$(remote_iface_ipv4 "$REMOTE_TB_IFNAME")}
+      rdma_hca=""
+      ib_disable=1
+      ;;
+    tb_rxe)
+      ensure_thunderbolt_net || return 10
+      ensure_rxe
+      socket_ifname=$TB_IFNAME
+      remote_socket_ifname=$REMOTE_TB_IFNAME
+      head=${TB_HEAD:-$(iface_ipv4 "$TB_IFNAME")}
+      worker=${TB_WORKER:-$(remote_iface_ipv4 "$REMOTE_TB_IFNAME")}
+      rdma_hca=$RXE_HCA
+      ib_disable=0
+      ld_path=$RDMA/lib
+      ;;
+    *)
+      echo "unknown transport: $transport" >&2
+      return 2
+      ;;
+  esac
+
+  if [[ "$transport" != "solo" ]]; then
+    if [[ -z "$head" || -z "$worker" ]]; then
+      echo "missing IP for transport=$transport iface=$socket_ifname" >&2
+      return 10
+    fi
+  fi
+
+  if [[ -n "$ld_path" && -n "$ROCR" ]]; then
+    ld_path=$ld_path:$ROCR
+    export RCCL_ROCR_PATH=${RCCL_ROCR_PATH:-$ROCR/}
+  fi
+
+  echo
+  echo "=== transport=$transport parallelism=$parallelism model=$model ==="
+  printf '  prompt-chars: %d\n' "$(wc -c <"$PROMPT_FILE")"
+  if [[ -n "$socket_ifname" ]]; then
+    echo "  socket-ifname: $socket_ifname remote=$remote_socket_ifname head=$head worker=$worker"
+  fi
+  if [[ -n "$rdma_hca" ]]; then
+    echo "  rdma-hca: $rdma_hca"
+    echo "  rocr: ${ROCR:-}"
+  fi
+  if [[ "${#VLLM_EXTRA_ARGS_ARY[@]}" -gt 0 ]]; then
+    printf '  vllm-extra:'
+    printf ' %s' "${VLLM_EXTRA_ARGS_ARY[@]}"
+    printf '\n'
+  fi
+  if [[ "${#VLLM_MODE_ARGS[@]}" -gt 0 ]]; then
+    printf '  vllm-mode:'
+    printf ' %s' "${VLLM_MODE_ARGS[@]}"
+    printf '\n'
+  fi
+
+  >"$CURRENT_LOG"
+
+  if [[ "$transport" == "solo" ]]; then
+    env "${tune_env[@]}" \
+      PATH=$GCCBIN:$PATH \
+      AITER_JIT_DIR=/tmp/aiter-jit CC=$GCCBIN/gcc NCCL_IB_DISABLE=1 \
+      "$VLLM_ENV/bin/vllm" serve "$model" \
+        --host 0.0.0.0 --port "$PORT" \
+        "${VLLM_LIMIT_ARGS[@]}" \
+        "${VLLM_MODE_ARGS[@]}" \
+        "${VLLM_EXTRA_ARGS_ARY[@]}" \
+        >>"$CURRENT_LOG" 2>&1 &
+    VLLM_PID=$!
+  else
+    env "${tune_env[@]}" \
+      PATH=$GCCBIN:$PATH LD_LIBRARY_PATH=${ld_path:-} \
+      VLLM_HOST_IP=$head NCCL_SOCKET_IFNAME=$socket_ifname GLOO_SOCKET_IFNAME=$socket_ifname \
+      NCCL_IB_HCA=$rdma_hca NCCL_IB_DISABLE=$ib_disable NCCL_DEBUG=$NCCL_DEBUG_LEVEL \
+      RCCL_ROCR_PATH=${RCCL_ROCR_PATH:-} \
+      AITER_JIT_DIR=/tmp/aiter-jit \
+      "$VLLM_ENV/bin/ray" start --head --port=6379 --node-ip-address="$head" \
+        --num-gpus=1 --include-dashboard=false --disable-usage-stats >/dev/null 2>&1
+    ssh -n -o ConnectTimeout=5 "$SSH_HOST" \
+      "env$(remote_tune_env)$(remote_rocr_env) PATH=$GCCBIN:\$PATH LD_LIBRARY_PATH=$(printf '%q' "${ld_path:-}") VLLM_HOST_IP=$worker NCCL_SOCKET_IFNAME=$remote_socket_ifname GLOO_SOCKET_IFNAME=$remote_socket_ifname NCCL_IB_HCA=$rdma_hca NCCL_IB_DISABLE=$ib_disable NCCL_DEBUG=$NCCL_DEBUG_LEVEL AITER_JIT_DIR=/tmp/aiter-jit $VLLM_ENV/bin/ray start --address=$head:6379 --node-ip-address=$worker --num-gpus=1 --disable-usage-stats" >/dev/null 2>&1
+    sleep 2
+
+    env "${tune_env[@]}" \
+      PATH=$GCCBIN:$PATH LD_LIBRARY_PATH=${ld_path:-} \
+      VLLM_HOST_IP=$head NCCL_SOCKET_IFNAME=$socket_ifname GLOO_SOCKET_IFNAME=$socket_ifname \
+      NCCL_IB_HCA=$rdma_hca NCCL_IB_DISABLE=$ib_disable NCCL_DEBUG=$NCCL_DEBUG_LEVEL \
+      RCCL_ROCR_PATH=${RCCL_ROCR_PATH:-} \
+      AITER_JIT_DIR=/tmp/aiter-jit CC=$GCCBIN/gcc \
+      "$VLLM_ENV/bin/vllm" serve "$model" \
+        --tensor-parallel-size 2 --distributed-executor-backend ray \
+        --host 0.0.0.0 --port "$PORT" \
+        "${VLLM_LIMIT_ARGS[@]}" \
+        "${VLLM_MODE_ARGS[@]}" \
+        "${VLLM_EXTRA_ARGS_ARY[@]}" \
+        >>"$CURRENT_LOG" 2>&1 &
+    VLLM_PID=$!
+  fi
+
+  wait_ready "$CURRENT_LOG"
+  warmup
+  echo "  --- transport log sample ---"
+  grep -iE "NET/Socket|NET/IB|$USB4_HCA|$RXE_HCA|thunderbolt|P2P Chunksize|Channel [0-9]|fall.*back" \
+    "$CURRENT_LOG" | head -25 || true
+}
+
+run_case() {
+  local transport=$1 model=$2 conc=$3 max_tokens=$4 parallelism socket_ifname= rdma_hca=
+  parallelism=$(transport_parallelism "$transport")
+
+  case "$transport" in
+    lan_tcp) socket_ifname="$LAN_IFNAME/$REMOTE_LAN_IFNAME" ;;
+    usb4_rdma) socket_ifname="$LAN_IFNAME/$REMOTE_LAN_IFNAME"; rdma_hca=$(resolve_usb4_hca) ;;
+    tb_tcp) socket_ifname="$TB_IFNAME/$REMOTE_TB_IFNAME" ;;
+    tb_rxe) socket_ifname="$TB_IFNAME/$REMOTE_TB_IFNAME"; rdma_hca=$RXE_HCA ;;
+  esac
+
+  "$VLLM_ENV/bin/python" "$SCRIPT_DIR/vllm-stream-client.py" \
+    --csv "$OUTPUT_CSV" \
+    --endpoint "http://127.0.0.1:$PORT/v1/completions" \
+    --model "$model" \
+    --transport "$transport" \
+    --parallelism "$parallelism" \
+    --concurrency "$conc" \
+    --max-tokens "$max_tokens" \
+    --prompt-file "$PROMPT_FILE" \
+    --ignore-eos="$IGNORE_EOS" \
+    --run-id "$RUN_ID" \
+    --socket-ifname "$socket_ifname" \
+    --rdma-hca "$rdma_hca" \
+    --vllm-extra-args="$VLLM_EXTRA_ARGS" \
+    --server-log "$CURRENT_LOG" \
+    --timeout "$CLIENT_TIMEOUT_S"
+}
+
+make_plan
+
+echo "run-id: $RUN_ID"
+echo "plan: $PLAN_FILE"
+echo "csv: $OUTPUT_CSV"
+echo "logs: $LOG_DIR"
+echo "sample-cases: $SAMPLE_CASES seed=$RANDOM_SEED"
+echo "resume: $RESUME"
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo
+  echo "dry-run plan:"
+  column -t -s $'\t' "$PLAN_FILE" || cat "$PLAN_FILE"
+  exit 0
+fi
+
+last_key=
+start_failed_reason=
+while IFS=$'\t' read -r transport model conc max_tokens; do
+  key="$transport	$model"
+  parallelism=$(transport_parallelism "$transport")
+
+  if [[ "$key" != "$last_key" ]]; then
+    start_failed_reason=
+    if ! start_server "$transport" "$model"; then
+      start_failed_reason="server-start-failed-or-transport-unavailable"
+      echo "  skipping transport=$transport model=$model: $start_failed_reason" >&2
+      stop_server 1
+    fi
+    last_key=$key
+  fi
+
+  if [[ -n "$start_failed_reason" ]]; then
+    case "$transport" in
+      lan_tcp) append_skip "$transport" "$model" "$conc" "$max_tokens" "$parallelism" "$start_failed_reason" "$LAN_IFNAME" "" ;;
+      usb4_rdma) append_skip "$transport" "$model" "$conc" "$max_tokens" "$parallelism" "$start_failed_reason" "$LAN_IFNAME" "$USB4_HCA" ;;
+      tb_tcp) append_skip "$transport" "$model" "$conc" "$max_tokens" "$parallelism" "$start_failed_reason" "$TB_IFNAME" "" ;;
+      tb_rxe) append_skip "$transport" "$model" "$conc" "$max_tokens" "$parallelism" "$start_failed_reason" "$TB_IFNAME" "$RXE_HCA" ;;
+      *) append_skip "$transport" "$model" "$conc" "$max_tokens" "$parallelism" "$start_failed_reason" "" "" ;;
+    esac
+    continue
+  fi
+
+  run_case "$transport" "$model" "$conc" "$max_tokens"
+done < "$PLAN_FILE"
+
+stop_server 0
+echo
+echo "wrote $OUTPUT_CSV"

--- a/pkgs/strix-halo-vllm-pair-bench/default.nix
+++ b/pkgs/strix-halo-vllm-pair-bench/default.nix
@@ -1,0 +1,293 @@
+{
+  lib,
+  writeShellApplication,
+  runCommand,
+  coreutils,
+  openssh,
+  rsync,
+  nixVersions,
+  gcc,
+  rdma-core,
+  vllmPackage,
+  packageSuffix,
+  vllmTransportMatrix ? ../../lib/bench/vllm-transport-matrix.sh,
+  vllmStreamClient ? ../../lib/bench/vllm-stream-client.py,
+}:
+
+let
+  benchSrc = runCommand "strix-halo-vllm-matrix-bench-src" { } ''
+    mkdir -p "$out"
+    cp ${vllmTransportMatrix} "$out/vllm-transport-matrix.sh"
+    cp ${vllmStreamClient} "$out/vllm-stream-client.py"
+    chmod +x "$out/vllm-transport-matrix.sh" "$out/vllm-stream-client.py"
+  '';
+in
+writeShellApplication {
+  name = "strix-halo-vllm-pair-bench-${packageSuffix}";
+
+  runtimeInputs = [
+    coreutils
+    openssh
+    rsync
+    nixVersions.stable
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    SCENARIO=""
+    MASTER="grw@strix-1.lan.satanic.link"
+    WORKER="grw@strix-2.lan.satanic.link"
+    USB4_HCA="usb4_rdma0,usb4_rdma1,usb4_rdma5,usb4_rdma6"
+    OUT_DIR=""
+    DRY_RUN=0
+    EXTRA_TRANSPORTS=""
+    PROMPT_SECTIONS=36
+    MAX_MODEL_LEN=2048
+    MAX_NUM_SEQS=512
+    MAX_NUM_BATCHED_TOKENS=""
+    VLLM_EXTRA_ARGS=""
+    SCENARIO_EXTRA_ENV=""
+    CLIENT_TIMEOUT_S=1800
+    STARTUP_TIMEOUT_S=600
+    GCC_PREFIX=${gcc}
+    RDMA=${rdma-core}
+    VLLM_ENV=${vllmPackage}
+    BENCH_DIR=${benchSrc}
+
+    usage() {
+      cat >&2 <<USAGE
+    Usage: $(basename "$0") --scenario SCENARIO [opts]
+
+    Scenarios:
+      qwen-peak
+      llama-tp2-win
+      qwen35-122b-awq-capacity
+      qwen35-122b-awq-prime
+      minimax-m27-awq-strix-2h
+
+    Options:
+      --master HOST             default: $MASTER
+      --worker HOST             default: $WORKER
+      --usb4-hca CSV            default: $USB4_HCA
+      --out DIR                 default: ./out-vllm-<scenario>-<timestamp>
+      --extra-transports LIST   e.g. "lan_tcp tb_tcp"
+      --vllm-env PATH           vLLM environment to copy/use on both hosts
+      --rdma-prefix PATH        RDMA prefix to copy/use on both hosts
+      --gcc-prefix PATH         GCC prefix to copy/use on both hosts
+      --bench-dir PATH          matrix script directory to copy/use on both hosts
+      --dry-run                 print env + plan without SSH execution
+      -h, --help                show this help
+    USAGE
+    }
+
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --scenario)         SCENARIO="$2"; shift 2 ;;
+        --master)           MASTER="$2"; shift 2 ;;
+        --worker)           WORKER="$2"; shift 2 ;;
+        --usb4-hca)         USB4_HCA="$2"; shift 2 ;;
+        --out)              OUT_DIR="$2"; shift 2 ;;
+        --dry-run)          DRY_RUN=1; shift ;;
+        --extra-transports) EXTRA_TRANSPORTS="$2"; shift 2 ;;
+        --vllm-env)         VLLM_ENV="$2"; shift 2 ;;
+        --rdma-prefix)      RDMA="$2"; shift 2 ;;
+        --gcc-prefix)       GCC_PREFIX="$2"; shift 2 ;;
+        --bench-dir)        BENCH_DIR="$2"; shift 2 ;;
+        -h|--help)          usage; exit 0 ;;
+        *)                  echo "unknown arg: $1" >&2; usage; exit 2 ;;
+      esac
+    done
+
+    case "$SCENARIO" in
+      qwen-peak)
+        MODELS="Qwen/Qwen3-0.6B"
+        BASE_TRANSPORTS="solo usb4_rdma"
+        CONCURRENCIES="256"
+        MAX_TOKENS=256
+        ;;
+      llama-tp2-win)
+        MODELS="unsloth/Meta-Llama-3.1-8B-Instruct"
+        BASE_TRANSPORTS="solo usb4_rdma"
+        CONCURRENCIES="256"
+        MAX_TOKENS=256
+        ;;
+      qwen35-122b-awq-capacity)
+        MODELS="cyankiwi/Qwen3.5-122B-A10B-AWQ-8bit"
+        BASE_TRANSPORTS="lan_tcp usb4_rdma"
+        CONCURRENCIES="1 2 4 8 16"
+        MAX_TOKENS=1024
+        PROMPT_SECTIONS=72
+        MAX_MODEL_LEN=8192
+        MAX_NUM_SEQS=16
+        MAX_NUM_BATCHED_TOKENS=16384
+        VLLM_EXTRA_ARGS="--language-model-only"
+        CLIENT_TIMEOUT_S=3600
+        STARTUP_TIMEOUT_S=1800
+        ;;
+      qwen35-122b-awq-prime)
+        MODELS="cyankiwi/Qwen3.5-122B-A10B-AWQ-8bit"
+        BASE_TRANSPORTS="lan_tcp"
+        CONCURRENCIES="1 4 16"
+        MAX_TOKENS=64
+        PROMPT_SECTIONS=72
+        MAX_MODEL_LEN=8192
+        MAX_NUM_SEQS=16
+        MAX_NUM_BATCHED_TOKENS=16384
+        VLLM_EXTRA_ARGS="--language-model-only"
+        CLIENT_TIMEOUT_S=3600
+        STARTUP_TIMEOUT_S=1800
+        ;;
+      minimax-m27-awq-strix-2h)
+        MODELS="ayysasha/MiniMax-M2.7-AWQ-G32-STRIX-2H"
+        BASE_TRANSPORTS="usb4_rdma lan_tcp"
+        CONCURRENCIES="1 2"
+        MAX_TOKENS=1024
+        PROMPT_SECTIONS=72
+        MAX_MODEL_LEN=196608
+        MAX_NUM_SEQS=2
+        MAX_NUM_BATCHED_TOKENS=20480
+        VLLM_EXTRA_ARGS="--gpu-memory-utilization 0.92 --dtype auto --load-format safetensors --trust-remote-code --tool-call-parser minimax_m2 --reasoning-parser minimax_m2_append_think --enable-auto-tool-choice"
+        SCENARIO_EXTRA_ENV=$'VLLM_ROCM_USE_AITER=0\nOMP_NUM_THREADS=1\nTOKENIZERS_PARALLELISM=false\nTORCHDYNAMO_DISABLE=1\nRAY_CGRAPH_get_timeout=1800\nVLLM_SLEEP_WHEN_IDLE=1\nVLLM_USE_DEEP_GEMM=0\nVLLM_USE_FLASHINFER_SAMPLER=0\nVLLM_USE_FLASHINFER_MOE_FP16=0'
+        CLIENT_TIMEOUT_S=7200
+        STARTUP_TIMEOUT_S=3600
+        ;;
+      *)
+        echo "scenario must be one of: qwen-peak | llama-tp2-win | qwen35-122b-awq-capacity | qwen35-122b-awq-prime | minimax-m27-awq-strix-2h (got '$SCENARIO')" >&2
+        exit 2 ;;
+    esac
+
+    TRANSPORTS="$BASE_TRANSPORTS''${EXTRA_TRANSPORTS:+ $EXTRA_TRANSPORTS}"
+    if [ -z "$OUT_DIR" ]; then
+      OUT_DIR="./out-vllm-$SCENARIO-$(date -u +%Y%m%dT%H%M%SZ)"
+    fi
+    mkdir -p "$OUT_DIR"
+
+    for required in \
+      "$GCC_PREFIX/bin/gcc" \
+      "$RDMA/lib" \
+      "$VLLM_ENV/bin/vllm" \
+      "$VLLM_ENV/bin/ray" \
+      "$BENCH_DIR/vllm-transport-matrix.sh" \
+      "$BENCH_DIR/vllm-stream-client.py"
+    do
+      [ -e "$required" ] || { echo "FATAL: missing path: $required" >&2; exit 2; }
+    done
+
+    echo "scenario:        $SCENARIO"
+    echo "master:          $MASTER"
+    echo "worker:          $WORKER"
+    echo "transports:      $TRANSPORTS"
+    echo "concurrencies:   $CONCURRENCIES"
+    echo "max_tokens:      $MAX_TOKENS"
+    echo "prompt_sections: $PROMPT_SECTIONS"
+    echo "max_model_len:   $MAX_MODEL_LEN"
+    echo "max_num_seqs:    $MAX_NUM_SEQS"
+    echo "batched_tokens:  ''${MAX_NUM_BATCHED_TOKENS:-<default>}"
+    echo "vllm_extra_args: ''${VLLM_EXTRA_ARGS:-<none>}"
+    echo "usb4_hca:        $USB4_HCA"
+    echo "vllm-env:        $VLLM_ENV"
+    echo "gcc-wrapper:     $GCC_PREFIX"
+    echo "rdma-core:       $RDMA"
+    echo "bench-dir:       $BENCH_DIR"
+    echo "out:             $OUT_DIR"
+
+    RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$SCENARIO"
+    REMOTE_LOG_DIR="/tmp/vllm-pair-$RUN_ID"
+    REMOTE_CSV="$REMOTE_LOG_DIR/vllm-pair-$RUN_ID.csv"
+
+    REMOTE_ENV=$(cat <<EOF
+    VLLM_ENV=$VLLM_ENV
+    GCCBIN=$GCC_PREFIX/bin
+    RDMA=$RDMA
+    SSH_HOST=$WORKER
+    LAN_IFNAME=br0.lan
+    TB_IFNAME=thunderbolt0
+    USB4_HCA=$USB4_HCA
+    MODELS="$MODELS"
+    TRANSPORTS="$TRANSPORTS"
+    CONCURRENCIES="$CONCURRENCIES"
+    MAX_TOKENS=$MAX_TOKENS
+    MAX_MODEL_LEN=$MAX_MODEL_LEN
+    MAX_NUM_SEQS=$MAX_NUM_SEQS
+    MAX_NUM_BATCHED_TOKENS=$MAX_NUM_BATCHED_TOKENS
+    PROMPT_SECTIONS=$PROMPT_SECTIONS
+    VLLM_EXTRA_ARGS="$VLLM_EXTRA_ARGS"
+    CLIENT_TIMEOUT_S=$CLIENT_TIMEOUT_S
+    STARTUP_TIMEOUT_S=$STARTUP_TIMEOUT_S
+    SAMPLE_CASES=0
+    SETUP_RXE=0
+    RUN_ID=$RUN_ID
+    LOG_DIR=$REMOTE_LOG_DIR
+    OUTPUT_CSV=$REMOTE_CSV
+    NCCL_IB_GID_INDEX=1
+    NCCL_NET_MERGE_LEVEL=LOC
+    NCCL_MIN_NCHANNELS=4
+    NCCL_MAX_NCHANNELS=4
+    NCCL_IB_QPS_PER_CONNECTION=1
+    NCCL_IB_SPLIT_DATA_ON_QPS=0
+    NCCL_DEBUG_LEVEL=INFO
+    NCCL_DEBUG_SUBSYS=INIT,NET,ENV
+    CUDA_VISIBLE_DEVICES=0
+    HIP_VISIBLE_DEVICES=0
+    ROCR_VISIBLE_DEVICES=0
+    RAY_ACCEL_ENV_VAR_OVERRIDE_ON_ZERO=0
+    RAY_EXPERIMENTAL_NOSET_CUDA_VISIBLE_DEVICES=1
+    RAY_EXPERIMENTAL_NOSET_HIP_VISIBLE_DEVICES=1
+    RAY_EXPERIMENTAL_NOSET_ROCR_VISIBLE_DEVICES=1
+    VLLM_USE_RAY_V2_EXECUTOR_BACKEND=0
+    RAY_DEDUP_LOGS=0
+    $SCENARIO_EXTRA_ENV
+    EOF
+    )
+
+    echo
+    echo "=== planned matrix invocation ==="
+    printf '%s\n' "$REMOTE_ENV"
+
+    if [ "$DRY_RUN" = "1" ]; then
+      echo "(dry-run: not invoking)"
+      exit 0
+    fi
+
+    echo
+    echo "=== copying closures to hosts ($MASTER, $WORKER) ==="
+    copy_paths=()
+    for path in "$VLLM_ENV" "$RDMA" "$GCC_PREFIX" "$BENCH_DIR"; do
+      case "$path" in
+        /nix/store/*) copy_paths+=("$path") ;;
+        *) echo "not a nix-store path; remote must already provide: $path" >&2 ;;
+      esac
+    done
+
+    for host in "$MASTER" "$WORKER"; do
+      if [ "''${#copy_paths[@]}" -gt 0 ]; then
+        nix copy --no-check-sigs --to "ssh://$host" "''${copy_paths[@]}"
+      fi
+    done
+
+    echo
+    echo "=== invoking matrix script on master ==="
+    env_file="$OUT_DIR/remote-env"
+    printf '%s\n' "$REMOTE_ENV" > "$env_file"
+    printf -v remote_log_dir_q '%q' "$REMOTE_LOG_DIR"
+    printf -v bench_script_q '%q' "$BENCH_DIR/vllm-transport-matrix.sh"
+    # shellcheck disable=SC2029
+    ssh "$MASTER" "mkdir -p $remote_log_dir_q"
+    scp "$env_file" "$MASTER:$REMOTE_LOG_DIR/env"
+    # shellcheck disable=SC2029
+    ssh "$MASTER" "set -a; . $remote_log_dir_q/env; set +a; exec bash $bench_script_q"
+
+    echo
+    echo "=== fetching results ==="
+    rsync -av "$MASTER:$REMOTE_LOG_DIR/" "$OUT_DIR/"
+    echo
+    echo "CSV: $OUT_DIR/vllm-pair-$RUN_ID.csv"
+  '';
+
+  meta = with lib; {
+    description = "vLLM transport-matrix benchmark driver for a two-host Strix Halo pair";
+    mainProgram = "strix-halo-vllm-pair-bench-${packageSuffix}";
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Salvages the two-host vLLM transport-matrix benchmark from the abandoned
`grw/feat/app-benchmarks` branch and re-fits it onto the current `lib/bench`
layout (the original predated the `bench/` → `lib/bench/` rename and the flake
package/app restructure).

## What

- **`pkgs/strix-halo-vllm-pair-bench`** — a `writeShellApplication` driver that
  copies the vLLM, GCC, RDMA, and benchmark-script closures to both hosts of a
  Strix Halo pair, runs the matrix from the master node, then fetches the
  result CSV. Scenarios: `qwen-peak`, `llama-tp2-win`,
  `qwen35-122b-awq-capacity`, `qwen35-122b-awq-prime`, `minimax-m27-awq-strix-2h`.
- **`lib/bench/vllm-transport-matrix.sh`** + **`vllm-stream-client.py`** — the
  matrix runner + streaming client.
- **flake**: `packages` + `apps` outputs for the default ROCm target, plus a CI
  `vllm-pair-bench-dry-run` check that builds the driver against **stub**
  vLLM/RDMA/GCC closures and validates the scripts (`bash -n`, `py_compile`,
  `--dry-run`) — no GPU or real lab needed.
- **README**: package-table entry + usage block.

## Verification

Locally on x86_64-linux:
- `nix eval .#packages.x86_64-linux.strix-halo-vllm-pair-bench-gfx1151.drvPath` ✓
- `nix eval .#apps.x86_64-linux.strix-halo-vllm-pair-bench-gfx1151.program` ✓
- `nix build .#checks.x86_64-linux.vllm-pair-bench-dry-run` ✓ (builds + passes)
- `deadnix` / `statix` / `nixfmt` checks ✓

Real multi-host runs target the `strix-1`/`strix-2` lab; the package itself only
needs the vLLM closure to expose `vllm` + `ray`.