### PR TITLE
bench: use standard /run/opengl-driver for CUDA host runtime

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -935,11 +935,11 @@
                   JSON
 
                   jq -e '
-                    .env.LD_LIBRARY_PATH == "/run/benchmark-nvidia-driver/lib"
-                    and (.requirements.sandboxPaths | index("/run/benchmark-nvidia-driver") != null)
-                    and (.requirements.sandboxPaths | index("/run/benchmark-nvidia-driver-bin") != null)
-                    and .target.runtimeDriver.libraryPath == "/run/benchmark-nvidia-driver/lib"
-                    and .target.runtimeDriver.binPath == "/run/benchmark-nvidia-driver-bin/bin"
+                    .env.LD_LIBRARY_PATH == "/run/opengl-driver-lib"
+                    and (.requirements.sandboxPaths | index("/run/opengl-driver") != null)
+                    and (.requirements.sandboxPaths | index("/run/opengl-driver-lib") != null)
+                    and .target.runtimeDriver.libraryPath == "/run/opengl-driver-lib"
+                    and (.target.runtimeDriver | has("binPath") | not)
                     and .tool.packageRole == "llama-cpp-master-cuda"
                     and (.packages | index("nvidia-x11") == null)
                   ' benchmark.json
@@ -948,8 +948,10 @@
                     (.features | index("benchmark") != null)
                     and (.features | index("rtx4090") != null)
                     and (.sandboxPaths | index("/dev/nvidia0?") != null)
-                    and (.sandboxPaths | map(select(test("^/run/benchmark-nvidia-driver=/nix/store/"))) | length) == 1
-                    and (.sandboxPaths | map(select(test("^/run/benchmark-nvidia-driver-bin=/nix/store/"))) | length) == 1
+                    and (.sandboxPaths | index("/run/opengl-driver") != null)
+                    and (.sandboxPaths | index("/run/opengl-driver-lib=/run/opengl-driver/lib") != null)
+                    and (.sandboxPaths | map(select(test("^/nix/store/.*nvidia-x11"))) | length) == 1
+                    and (.sandboxPaths | map(select(test("benchmark-nvidia-driver"))) | length) == 0
                   ' runner.json
 
                   touch "$out"

--- a/lib/bench/default.nix
+++ b/lib/bench/default.nix
@@ -149,7 +149,7 @@ let
 
   cudaRtx4090Benchmarks = lib.optionalAttrs pkgs.stdenv.isLinux (
     let
-      inherit (nvidiaRuntime) binPath libraryPath sandboxPaths;
+      inherit (nvidiaRuntime) fallbackLibraryPath libraryPath sandboxPaths;
     in
     {
       bench-cuda-rtx4090-llama-cpp-master-device-smoke = benchLib.mkBenchmark {
@@ -159,8 +159,13 @@ let
         command = [
           (cudaPkgs.writeShellScript "cuda-rtx4090-llama-cpp-master-device-smoke" ''
             set -euo pipefail
-            ${binPath}/nvidia-smi --query-gpu=driver_version,name --format=csv,noheader
-            ${binPath}/nvidia-smi -L
+            cat /proc/driver/nvidia/version
+            driver_lib=${libraryPath}
+            if [ ! -e "$driver_lib/libcuda.so.1" ] && [ -e ${fallbackLibraryPath}/libcuda.so.1 ]; then
+              driver_lib=${fallbackLibraryPath}
+            fi
+            test -e "$driver_lib/libcuda.so.1"
+            export LD_LIBRARY_PATH="$driver_lib"
             ${cudaPkgs.llama-cpp-master-cuda}/bin/llama-bench --list-devices
           '')
         ];
@@ -194,7 +199,7 @@ let
             deviceClass = "rtx4090";
             systemFeature = "rtx4090";
             runtimeDriver = {
-              inherit binPath libraryPath;
+              inherit libraryPath;
             };
           };
           tool = {

--- a/lib/bench/ds4-pi.nix
+++ b/lib/bench/ds4-pi.nix
@@ -27,6 +27,9 @@ let
     export DS4_METAL_NO_RESIDENCY=1
     export DS4_METAL_NO_MODEL_WARMUP=1
     export DS4_SERVER_PERFLEVEL=skip
+    # Shared darwin /tmp: a stale 0600 lock from another _nixbld user kills
+    # the run. Use the per-build TMPDIR.
+    export DS4_LOCK_FILE="$TMPDIR/ds4.lock"
 
     port="$(${pkgs.python3}/bin/python3 - <<'PY'
     import socket

--- a/lib/bench/ds4-pi.nix
+++ b/lib/bench/ds4-pi.nix
@@ -39,6 +39,8 @@ let
     PY
     )"
 
+    echo "ds4-pi-smoke: host=$(hostname) port=$port lock=$DS4_LOCK_FILE" >&2
+
     server_log="$out/ds4-server.log"
     ${ds4Package}/bin/ds4-server \
       --metal \

--- a/lib/bench/ds4.nix
+++ b/lib/bench/ds4.nix
@@ -145,6 +145,12 @@ let
     pkgs.writeShellScript "${namePrefix}-benchmark-runner" ''
       set -euo pipefail
 
+      # ds4's single-instance lock defaults to /tmp/ds4.lock. The darwin
+      # sandbox shares /tmp, so a lock left by an aborted run under another
+      # _nixbld user is unopenable (0600) and fails the whole benchmark.
+      # Keep it in the per-build TMPDIR instead.
+      export DS4_LOCK_FILE="$TMPDIR/ds4.lock"
+
       prompt="$TMPDIR/ds4-prompt.txt"
       for i in $(seq 1 ${toString promptRepeats}); do
         printf 'DwarfStar 4 ${promptBackend} benchmark prompt paragraph %05d. This text is intentionally repetitive and deterministic so the fixed token sequence is long enough for context frontier measurement. It discusses GPU memory bandwidth, attention prefill, routed experts, and decode throughput. ' "$i"

--- a/lib/nvidia-runtime.nix
+++ b/lib/nvidia-runtime.nix
@@ -1,10 +1,23 @@
+# Host NVIDIA userspace driver paths shared by the benchmark derivations,
+# the benchmark-runner module, and the cuda-host-driver-runtime CI check.
+#
+# libcuda.so.1 must match the host's loaded kernel module, so benchmark
+# derivations cannot depend on an nvidia_x11 derivation (it would both
+# diverge from the host module and leak per-host driver versions into
+# benchmark hashes). NixOS already maintains /run/opengl-driver as the
+# canonical host GPU userspace; the runner module binds it into the build
+# sandbox, plus a symlink-free alias for LD_LIBRARY_PATH:
+#
+#   /run/opengl-driver                              (canonical symlink)
+#   /run/opengl-driver-lib=/run/opengl-driver/lib   (resolved at bind time)
+#
+# The store path of config.hardware.nvidia.package is also exposed so that the
+# aggregate's symlinks resolve inside the sandbox.
 {
-  driverPath = "/run/benchmark-nvidia-driver";
-  driverBinPath = "/run/benchmark-nvidia-driver-bin";
-  libraryPath = "/run/benchmark-nvidia-driver/lib";
-  binPath = "/run/benchmark-nvidia-driver-bin/bin";
+  libraryPath = "/run/opengl-driver-lib";
+  fallbackLibraryPath = "/run/opengl-driver/lib";
   sandboxPaths = [
-    "/run/benchmark-nvidia-driver"
-    "/run/benchmark-nvidia-driver-bin"
+    "/run/opengl-driver"
+    "/run/opengl-driver-lib"
   ];
 }

--- a/modules/benchmark-runner.nix
+++ b/modules/benchmark-runner.nix
@@ -65,9 +65,14 @@ let
   hasRdma = any (runner: runner.rdma.enable) enabledRunners;
 
   optionalSandboxPaths = paths: map (path: "${path}?") paths;
+  # Expose the standard NixOS host GPU userspace to build sandboxes.
+  # /run/opengl-driver-lib binds the lib dir with the /run symlink resolved
+  # at mount time; the driver store path makes the aggregate's symlinks
+  # resolvable inside the sandbox.
   nvidiaDriverSandboxPaths = optionals hasNvidiaGpu [
-    "${nvidiaRuntime.driverPath}=${config.hardware.nvidia.package}"
-    "${nvidiaRuntime.driverBinPath}=${getBin config.hardware.nvidia.package}"
+    "/run/opengl-driver"
+    "${nvidiaRuntime.libraryPath}=${nvidiaRuntime.fallbackLibraryPath}"
+    "${config.hardware.nvidia.package}"
   ];
 
   # Pair with lib/bench/lib.nix: every benchmark derivation requires the


### PR DESCRIPTION
Removes the custom `/run/benchmark-nvidia-driver{,-bin}` sandbox-alias scheme in favor of the canonical NixOS `/run/opengl-driver` host GPU userspace path.

## Why

`libcuda.so.1` must match the host kernel module, so benchmark derivations can't depend on an `nvidia_x11` derivation — but the previous fix (#83) invented a bespoke `/run` namespace to deliver the host driver into sandboxes, including a `-bin` variant solely so the smoke could run `nvidia-smi`. NixOS already maintains `/run/opengl-driver` for exactly this.

**This is also why every PR's smoke is currently red**: the 4090 builder host already carries the new-style nix.conf mappings (`/run/opengl-driver-lib=/run/opengl-driver/lib` + driver store path), so benchmarks expecting the old aliases die with exit 127 inside the sandbox.

## What

- `lib/nvidia-runtime.nix`: now defines the standard paths (+ fallback) shared by bench lib, runner module, and CI check
- runner module emits `/run/opengl-driver`, the symlink-resolved `-lib` alias, and `hardware.nvidia.package` store path (matching what the builder already has deployed)
- smoke drops `nvidia-smi`; driver version comes from `/proc/driver/nvidia/version` (already sandboxed), CUDA init proven by `llama-bench --list-devices`
- `cuda-host-driver-runtime` check asserts the new paths and that no old aliases remain

## Validation

- `nix flake check --no-build`
- `nix build .#checks.x86_64-linux.cuda-host-driver-runtime` ✓
- End-to-end on the actual 4090 builder: `nix build .#benchmarks.x86_64-linux.bench-cuda-rtx4090-llama-cpp-master-device-smoke` → found RTX 4090, CUDA backend loaded, NVRM 610.43.02

Once merged, #70/#71/#76/#79/#93/#94 need a rebase/update-branch to go green.