### PR TITLE
mlx: use shared ROCm-support source

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -181,17 +181,17 @@
     "mlx-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1777394396,
-        "narHash": "sha256-3OOYc2MlBAMVZGwulp25X0VOVKS/vYTIWQjSz16DmFg=",
-        "owner": "ml-explore",
+        "lastModified": 1781500641,
+        "narHash": "sha256-muzdcRnY53Q1R0HeBeoT9yI4GtdgNpSdVOJCFUGN42M=",
+        "owner": "NripeshN",
         "repo": "mlx",
-        "rev": "e8ebdebeeb655feaa85a51f6b24ece5b6d5518d1",
+        "rev": "24c1065fabec9c42b822eff161dc796496b2e949",
         "type": "github"
       },
       "original": {
-        "owner": "ml-explore",
+        "owner": "NripeshN",
+        "ref": "rocm-support",
         "repo": "mlx",
-        "rev": "e8ebdebeeb655feaa85a51f6b24ece5b6d5518d1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -650,6 +650,8 @@
           s = defaultRocmTarget.packageSuffix;
           aiTools = inputs.nix-ai-tools.packages.${pkgs.stdenv.hostPlatform.system};
           cudaPkgs = cudaPkgsFor pkgs.stdenv.hostPlatform.system;
+          packageRuntimeEnv = import ./lib/runtime-env.nix { inherit lib; };
+          inherit (packageRuntimeEnv) wrapRuntimeEnv;
           jacclPackage = pkgs.callPackage ./pkgs/jaccl (
             {
               inherit (inputs) mlx-src;
@@ -660,16 +662,40 @@
           );
           mkMlxLm =
             mlxPackage:
-            pkgs.python3Packages.mlx-lm.overridePythonAttrs (oldAttrs: {
-              dependencies =
-                lib.filter (dep: dep.pname or "" != "mlx") (
-                  oldAttrs.dependencies or oldAttrs.propagatedBuildInputs or [ ]
-                )
-                ++ [ mlxPackage ];
-              meta = (oldAttrs.meta or { }) // {
-                mainProgram = "mlx_lm";
-              };
-            });
+            let
+              mlxLm = pkgs.python3Packages.mlx-lm.overridePythonAttrs (
+                oldAttrs:
+                {
+                  dependencies = lib.unique (
+                    lib.filter (dep: dep.pname or "" != "mlx") (
+                      oldAttrs.dependencies or oldAttrs.propagatedBuildInputs or [ ]
+                    )
+                    ++ [
+                      mlxPackage
+                    ]
+                    ++ lib.optional pkgs.stdenv.isLinux pkgs.python3Packages.sentencepiece
+                  );
+                  meta = (oldAttrs.meta or { }) // {
+                    mainProgram = "mlx_lm";
+                  };
+                }
+                // lib.optionalAttrs pkgs.stdenv.isLinux {
+                  doCheck = false;
+                  doInstallCheck = false;
+                  dontCheckRuntimeDeps = true;
+                  pythonImportsCheck = [ "mlx_lm" ];
+                }
+              );
+            in
+            if mlxPackage ? passthru && mlxPackage.passthru ? rocmRuntimeEnv then
+              wrapRuntimeEnv {
+                inherit pkgs;
+                package = mlxLm;
+                name = "mlx-lm-rocm-runtime";
+                env = mlxPackage.passthru.rocmRuntimeEnv;
+              }
+            else
+              mlxLm;
 
           # Dynamically extract the keys of the local packages defined in overlays/pkgs.nix.
           # This avoids duplicate maintenance of the package list.
@@ -717,23 +743,30 @@
             ];
           };
 
-          linuxPackages = lib.genAttrs localPackagesKeys (name: pkgs.${name}) // {
-            inherit (pkgs)
-              linux-thunderbolt
-              linux-thunderbolt-dev
-              linux-thunderbolt-modules
-              rdma-core-usb4
-              thunderbolt-ibverbs
-              thunderbolt-ibverbs-linux-thunderbolt
-              ;
-            inherit (cudaPkgs) llama-cpp-cuda llama-cpp-master-cuda;
-            live-iso = self.nixosConfigurations.live-iso.config.system.build.isoImage;
-            mlx = pkgs.mlx-rocm;
-            "strix-halo-vllm-pair-bench-${s}" = pkgs.callPackage ./pkgs/strix-halo-vllm-pair-bench {
-              vllmPackage = vllmPairBenchEnv;
-              packageSuffix = s;
+          linuxPackages =
+            let
+              mlxRocm = pkgs.mlx-rocm;
+              mlxLmRocm = mkMlxLm mlxRocm;
+            in
+            lib.genAttrs localPackagesKeys (name: pkgs.${name})
+            // {
+              inherit (pkgs)
+                linux-thunderbolt
+                linux-thunderbolt-dev
+                linux-thunderbolt-modules
+                rdma-core-usb4
+                thunderbolt-ibverbs
+                thunderbolt-ibverbs-linux-thunderbolt
+                ;
+              inherit (cudaPkgs) llama-cpp-cuda llama-cpp-master-cuda;
+              live-iso = self.nixosConfigurations.live-iso.config.system.build.isoImage;
+              mlx = mlxRocm;
+              mlx-lm = mlxLmRocm;
+              "strix-halo-vllm-pair-bench-${s}" = pkgs.callPackage ./pkgs/strix-halo-vllm-pair-bench {
+                vllmPackage = vllmPairBenchEnv;
+                packageSuffix = s;
+              };
             };
-          };
 
           darwinPackages =
             let
@@ -820,6 +853,14 @@
             therock-python-env =
               ap pkgs.therock-python "therock-python-env"
                 "Run a command in the pinned TheRock ROCm/PyTorch wheel environment";
+            mlx-lm = ap self.packages.${system}.mlx-lm "mlx_lm" "Run the MLX LM CLI with ROCm";
+            mlx-lm-generate =
+              ap self.packages.${system}.mlx-lm "mlx_lm.generate"
+                "Generate text with MLX LM on ROCm";
+            mlx-lm-chat = ap self.packages.${system}.mlx-lm "mlx_lm.chat" "Run the MLX LM chat CLI on ROCm";
+            mlx-lm-server =
+              ap self.packages.${system}.mlx-lm "mlx_lm.server"
+                "Run the MLX LM HTTP server on ROCm";
 
             live-iso-vm =
               let

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
     };
 
     mlx-src = {
-      url = "github:ml-explore/mlx/e8ebdebeeb655feaa85a51f6b24ece5b6d5518d1";
+      url = "github:NripeshN/mlx/rocm-support";
       flake = false;
     };
 

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -182,6 +182,7 @@ lib.optionalAttrs prev.stdenv.isLinux (
 
     mlx-rocm = bigParallel (
       final.python3Packages.callPackage ../pkgs/mlx/rocm.nix {
+        inherit (inputs) mlx-src;
         pname = "mlx-rocm-${suffix}";
         rdma-core = final.rdma-core-usb4;
         rocmPackages = final.therockRocmPackages.${firstBuildTarget};

--- a/pkgs/mlx/metal.nix
+++ b/pkgs/mlx/metal.nix
@@ -90,20 +90,42 @@ mlx.overrideAttrs (old: {
     export SDKROOT=${lib.escapeShellArg darwinSdkRoot}
     export MACOSX_DEPLOYMENT_TARGET=${lib.escapeShellArg darwinDeploymentTarget}
 
-    metal_tool="$(/usr/bin/xcrun -sdk macosx -find metal 2>/dev/null || true)"
-    if [ -z "$metal_tool" ] || ! "$metal_tool" --version >/dev/null 2>&1; then
-      metal_tool="$(find /private/var/run/com.apple.security.cryptexd/mnt \
-        -path '*/Metal.xctoolchain/usr/bin/metal' -type f | head -n 1 || true)"
-    fi
-    if [ -z "$metal_tool" ] || ! "$metal_tool" --version >/dev/null 2>&1; then
-      echo "mlx-metal: missing usable Apple Metal Toolchain" >&2
+    find_metal_tool() {
+      local tool="$1"
+      local path=""
+
+      path="$(/usr/bin/xcrun -sdk macosx -find "$tool" 2>/dev/null || true)"
+      if [ -n "$path" ] && [ -x "$path" ] && "$path" --version >/dev/null 2>&1; then
+        printf '%s\n' "$path"
+        return 0
+      fi
+
+      for root in \
+        /private/var/run/com.apple.security.cryptexd/mnt \
+        /var/run/com.apple.security.cryptexd/mnt; do
+        if [ -d "$root" ]; then
+          path="$(find "$root" -path "*/Metal.xctoolchain/usr/bin/$tool" 2>/dev/null | head -n 1 || true)"
+          if [ -n "$path" ] && [ -x "$path" ] && "$path" --version >/dev/null 2>&1; then
+            printf '%s\n' "$path"
+            return 0
+          fi
+        fi
+      done
+
+      return 1
+    }
+
+    metal_tool="$(find_metal_tool metal || true)"
+    if [ -z "$metal_tool" ]; then
+      echo "mlx-metal: missing usable Apple Metal compiler" >&2
       echo "mlx-metal: run xcodebuild -downloadComponent MetalToolchain on the builder" >&2
       exit 1
     fi
 
-    metallib_tool="$(dirname "$metal_tool")/metallib"
-    if [ ! -x "$metallib_tool" ]; then
-      echo "mlx-metal: missing metallib next to $metal_tool" >&2
+    metallib_tool="$(find_metal_tool metallib || true)"
+    if [ -z "$metallib_tool" ]; then
+      echo "mlx-metal: missing usable Apple Metal linker" >&2
+      echo "mlx-metal: run xcodebuild -downloadComponent MetalToolchain on the builder" >&2
       exit 1
     fi
 

--- a/pkgs/mlx/patches/darwin-sdk-version.patch
+++ b/pkgs/mlx/patches/darwin-sdk-version.patch
@@ -1,16 +1,16 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 27b772c..a316875 100644
+index 35e21a9..2437204 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -178,10 +178,7 @@ if(MLX_BUILD_METAL)
-   endif()
+@@ -231,10 +231,7 @@ if(MLX_BUILD_METAL)
+     message(STATUS "Building on macOS ${MACOS_VERSION}")
 
-   # Throw an error if xcrun not found
--  execute_process(
--    COMMAND zsh "-c" "/usr/bin/xcrun -sdk macosx --show-sdk-version"
--    OUTPUT_VARIABLE MACOS_SDK_VERSION
--    OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
-+  set(MACOS_SDK_VERSION @sdkVersion@)
-
-   if(${MACOS_SDK_VERSION} LESS 14.0)
-     message(
+     # Get macOS SDK version.
+-    execute_process(
+-      COMMAND xcrun -sdk macosx --show-sdk-version
+-      OUTPUT_VARIABLE MACOS_SDK_VERSION
+-      OUTPUT_STRIP_TRAILING_WHITESPACE COMMAND_ERROR_IS_FATAL ANY)
++    set(MACOS_SDK_VERSION @sdkVersion@)
+     if(MACOS_SDK_VERSION VERSION_LESS 14.0)
+       message(
+         FATAL_ERROR

--- a/pkgs/mlx/rocm.nix
+++ b/pkgs/mlx/rocm.nix
@@ -2,7 +2,9 @@
   lib,
   mlx,
   applyPatches,
-  fetchFromGitHub,
+  mlx-src,
+  patchelf,
+  python,
   rdma-core,
   rocmPackages,
   gfx ? "gfx1151",
@@ -11,17 +13,14 @@
 
 let
   mlx-rocm-src = applyPatches {
-    src = fetchFromGitHub {
-      owner = "NripeshN";
-      repo = "mlx";
-      rev = "39fac95d901c72175fce4baf973e375d4a054ba7";
-      hash = "sha256-LZB1gY0nZO0GGxHfRGaX5uk5BOJJ89g33vPBy3x45YA=";
-    };
+    name = "mlx-rocm-src";
+    src = mlx-src;
     patches = [ ./rocm-include-rocblas.patch ];
   };
 in
 mlx.overrideAttrs (old: {
   inherit pname;
+  version = "0.32.0";
   src = mlx-rocm-src;
 
   patches = [ ];
@@ -29,14 +28,14 @@ mlx.overrideAttrs (old: {
   postPatch = (old.postPatch or "") + ''
           substituteInPlace CMakeLists.txt \
             --replace-fail \
-              'FetchContent_Declare(
+              '  FetchContent_Declare(
         nanobind
         GIT_REPOSITORY https://github.com/wjakob/nanobind.git
-        GIT_TAG v2.10.2
+        GIT_TAG v2.12.0
         GIT_SHALLOW TRUE
         EXCLUDE_FROM_ALL)
       FetchContent_MakeAvailable(nanobind)' \
-              'find_package(nanobind CONFIG REQUIRED)'
+              '  find_package(nanobind CONFIG REQUIRED)'
 
           substituteInPlace CMakeLists.txt \
             --replace-fail \
@@ -50,21 +49,87 @@ mlx.overrideAttrs (old: {
               'find_package(nlohmann_json REQUIRED)
     target_link_libraries(mlx PRIVATE $<BUILD_INTERFACE:nlohmann_json::nlohmann_json>)'
 
+          substituteInPlace CMakeLists.txt \
+            --replace-fail \
+              '# Add standalone JACCL library (RDMA over Thunderbolt distributed backend)
+    if(MLX_BUILD_CPU
+       AND ''${CMAKE_SYSTEM_NAME} MATCHES "Darwin"
+       AND DEFINED MACOS_SDK_VERSION
+       AND MACOS_SDK_VERSION GREATER_EQUAL 26.2)
+      add_subdirectory(''${CMAKE_CURRENT_LIST_DIR}/mlx/distributed/jaccl/lib
+                       ''${CMAKE_BINARY_DIR}/jaccl)
+    endif()' \
+              '# Add standalone JACCL library (RDMA over Thunderbolt distributed backend)
+    if(MLX_BUILD_CPU AND NOT WIN32)
+      add_subdirectory(''${CMAKE_CURRENT_LIST_DIR}/mlx/distributed/jaccl/lib
+                       ''${CMAKE_BINARY_DIR}/jaccl)
+    endif()'
+
           substituteInPlace mlx/distributed/jaccl/CMakeLists.txt \
             --replace-fail \
               'if(MLX_BUILD_CPU
        AND ''${CMAKE_SYSTEM_NAME} MATCHES "Darwin"
-       AND MACOS_SDK_VERSION GREATER_EQUAL 26.2)' \
+       AND MACOS_SDK_VERSION VERSION_GREATER_EQUAL 26.2
+       AND CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER_EQUAL 26.2)' \
               'if(MLX_BUILD_CPU AND NOT WIN32)'
           substituteInPlace mlx/distributed/jaccl/CMakeLists.txt \
             --replace-fail \
               'if(MLX_BUILD_CPU AND NOT WIN32)
-      target_sources(' \
+      target_sources(mlx PRIVATE ''${CMAKE_CURRENT_SOURCE_DIR}/jaccl.cpp)' \
               'if(MLX_BUILD_CPU AND NOT WIN32)
-      target_include_directories(mlx PRIVATE ${rdma-core.dev}/include)
-      target_sources('
+      target_include_directories(mlx PRIVATE ${rdma-core.dev}/include ''${CMAKE_CURRENT_SOURCE_DIR}/lib)
+      target_sources(mlx PRIVATE ''${CMAKE_CURRENT_SOURCE_DIR}/jaccl.cpp)'
 
-          substituteInPlace mlx/distributed/jaccl/utils.cpp \
+          substituteInPlace mlx/distributed/jaccl/lib/CMakeLists.txt \
+            --replace-fail \
+              'message(STATUS "Downloading json for JACCL")
+    FetchContent_Declare(
+      json
+      URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz)
+    FetchContent_MakeAvailable(json)' \
+              'find_package(nlohmann_json REQUIRED)' \
+            --replace-fail \
+              '# Check platform and SDK version requirements
+    if(NOT ''${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      message(STATUS "JACCL requires macOS (Darwin). Skipping JACCL build.")
+      return()
+    endif()
+
+    # Try to determine MACOS_SDK_VERSION if not set
+    if(NOT DEFINED MACOS_SDK_VERSION)
+      execute_process(
+        COMMAND xcrun --sdk macosx --show-sdk-version
+        OUTPUT_VARIABLE MACOS_SDK_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+      if(MACOS_SDK_VERSION)
+        message(STATUS "Detected macOS SDK version: ''${MACOS_SDK_VERSION}")
+      endif()
+    endif()
+
+    if(DEFINED MACOS_SDK_VERSION AND MACOS_SDK_VERSION VERSION_LESS "26.2")
+      message(STATUS "JACCL requires macOS SDK >= 26.2. Skipping JACCL build.")
+      return()
+    endif()' \
+              '# Build JACCL on the selected MLX platform; Nix provides rdma-core on Linux.' \
+            --replace-fail \
+              'target_include_directories(
+      jaccl PRIVATE $<BUILD_INTERFACE:''${json_SOURCE_DIR}/single_include/nlohmann>)' \
+              'target_link_libraries(jaccl PRIVATE nlohmann_json::nlohmann_json)' \
+            --replace-fail \
+              'target_compile_features(jaccl PUBLIC cxx_std_20)' \
+              'target_include_directories(jaccl PRIVATE ${rdma-core.dev}/include)
+
+    target_compile_features(jaccl PUBLIC cxx_std_20)'
+
+          substituteInPlace mlx/distributed/jaccl/lib/jaccl/jaccl.h \
+            --replace-fail \
+              '#include <memory>
+    #include <vector>' \
+              '#include <memory>
+    #include <optional>
+    #include <vector>'
+
+          substituteInPlace mlx/distributed/jaccl/lib/jaccl/rdma.cpp \
             --replace-fail \
               '#include <dlfcn.h>
     #include <unistd.h>
@@ -79,7 +144,7 @@ mlx.overrideAttrs (old: {
               '  librdma_handle_ = dlopen("librdma.dylib", RTLD_NOW | RTLD_GLOBAL);' \
               '  librdma_handle_ = dlopen("${rdma-core}/lib/libibverbs.so.1", RTLD_NOW | RTLD_GLOBAL);'
 
-          substituteInPlace mlx/distributed/jaccl/utils.h \
+          substituteInPlace mlx/distributed/jaccl/lib/jaccl/rdma.h \
             --replace-fail \
               'constexpr int BUFFER_SIZES = 8;' \
               'constexpr int BUFFER_SIZES = 9;' \
@@ -94,7 +159,7 @@ mlx.overrideAttrs (old: {
     #include <cstring>
     #include <span>'
 
-          substituteInPlace mlx/distributed/jaccl/utils.h \
+          substituteInPlace mlx/distributed/jaccl/lib/jaccl/rdma.h \
             --replace-fail \
               'inline std::pair<int, int64_t> buffer_size_from_message(int64_t msg) {
       if (__builtin_available(macOS 26.3, iOS 26.3, tvOS 26.3, visionOS 26.3, *)) {
@@ -138,7 +203,7 @@ mlx.overrideAttrs (old: {
       int source_gid_index;
       ibv_gid global_identifier;'
 
-          substituteInPlace mlx/distributed/jaccl/utils.cpp \
+          substituteInPlace mlx/distributed/jaccl/lib/jaccl/rdma.cpp \
             --replace-fail \
               '  src.local_id = -1;
     }' \
@@ -147,7 +212,16 @@ mlx.overrideAttrs (old: {
     }' \
             --replace-fail \
               '  ibv_gid gid;
-      ibv().query_gid(ctx, 1, 1, &gid);
+      for (int i = 0; i < port_attr.gid_tbl_len; i++) {
+        ibv_gid tmp;
+        if (ibv().query_gid(ctx, 1, i, &tmp) == 0) {
+          if (*(uint64_t*)&tmp.raw[0] == 0 && *(uint16_t*)&tmp.raw[8] == 0 &&
+              *(uint16_t*)&tmp.raw[10] == 0xffff) {
+            gid = tmp;
+            break;
+          }
+        }
+      }
 
       src.local_id = port_attr.lid;' \
               '  ibv_gid gid = {};
@@ -169,9 +243,9 @@ mlx.overrideAttrs (old: {
 
       src.local_id = port_attr.lid;' \
             --replace-fail \
-              '  src.packet_sequence_number = 7; // TODO: Change to sth random
+              '  src.packet_sequence_number = 7;
       src.global_identifier = gid;' \
-              '  src.packet_sequence_number = 7; // TODO: Change to sth random
+              '  src.packet_sequence_number = 7;
       src.source_gid_index = gid_index;
       src.global_identifier = gid;' \
             --replace-fail \
@@ -212,114 +286,6 @@ mlx.overrideAttrs (old: {
           throw std::runtime_error(msg.str());
         }'
 
-          substituteInPlace mlx/distributed/jaccl/mesh.h \
-            --replace-fail \
-              '#include "mlx/distributed/distributed_impl.h"' \
-              '#include <functional>
-
-    #include "mlx/distributed/distributed_impl.h"' \
-            --replace-fail \
-              '      Stream stream,
-          ReduceOp reduce_op);' \
-              '      Stream stream,
-          ReduceOp reduce_op,
-          std::function<void()> recv_ready);'
-
-          substituteInPlace mlx/distributed/jaccl/mesh.cpp \
-            --replace-fail \
-              '    all_reduce<T>(input, output, stream, detail::SumOp<T>{});' \
-              '    all_reduce<T>(
-            input, output, stream, detail::SumOp<T>{}, [&] {
-              side_channel_.all_gather<int>(0);
-            });' \
-            --replace-fail \
-              '    all_reduce<T>(input, output, stream, detail::MaxOp<T>{});' \
-              '    all_reduce<T>(
-            input, output, stream, detail::MaxOp<T>{}, [&] {
-              side_channel_.all_gather<int>(0);
-            });' \
-            --replace-fail \
-              '    all_reduce<T>(input, output, stream, detail::MinOp<T>{});' \
-              '    all_reduce<T>(
-            input, output, stream, detail::MinOp<T>{}, [&] {
-              side_channel_.all_gather<int>(0);
-            });' \
-            --replace-fail \
-              '    Stream stream,
-        ReduceOp reduce_op) {' \
-              '    Stream stream,
-        ReduceOp reduce_op,
-        std::function<void()> recv_ready) {' \
-            --replace-fail \
-              '  encoder.dispatch([in_ptr, out_ptr, size, this, reduce_op]() {' \
-              '  encoder.dispatch([in_ptr, out_ptr, size, this, reduce_op, recv_ready]() {' \
-            --replace-fail \
-              '      mesh_.all_reduce(in_ptr, out_ptr, size, reduce_op);' \
-              '      mesh_.all_reduce(in_ptr, out_ptr, size, reduce_op, recv_ready);'
-
-          substituteInPlace mlx/distributed/jaccl/mesh_impl.h \
-            --replace-fail \
-              '#include <span>' \
-              '#include <functional>
-    #include <span>' \
-            --replace-fail \
-              '  all_reduce(const T* in_ptr, T* out_ptr, int64_t size, ReduceOp reduce_op) {' \
-              '  all_reduce(
-          const T* in_ptr,
-          T* out_ptr,
-          int64_t size,
-          ReduceOp reduce_op,
-          std::function<void()> recv_ready) {' \
-            --replace-fail \
-              '    // Prefill the pipeline
-        int buff = 0;
-        while (read_offset < total && buff < PIPELINE) {
-          post_recv_all(sz, buff);
-          std::copy(
-              data + read_offset,
-              data + std::min(read_offset + N, total),
-              send_buffer(sz, buff).begin<T>());
-          post_send_all(sz, buff);
-
-          buff++;
-          in_flight += 2 * num_peers;
-          read_offset += N;
-        }
-
-        // Main loop' \
-              '    // Prefill the pipeline
-        int buff = 0;
-        int preposted = 0;
-        while (read_offset < total && buff < PIPELINE) {
-          post_recv_all(sz, buff);
-          std::copy(
-              data + read_offset,
-              data + std::min(read_offset + N, total),
-              send_buffer(sz, buff).begin<T>());
-
-          buff++;
-          preposted++;
-          in_flight += num_peers;
-          read_offset += N;
-        }
-
-        recv_ready();
-
-        for (int b = 0; b < preposted; b++) {
-          post_send_all(sz, b);
-          in_flight += num_peers;
-        }
-
-        // Main loop'
-
-          for f in mlx/distributed/jaccl/mesh.cpp mlx/distributed/jaccl/ring.cpp; do
-            substituteInPlace "$f" \
-              --replace-fail \
-                '  side_channel_.all_gather<int>(0);' \
-                '  side_channel_.all_gather<int>(0);
-      side_channel_.all_gather<int>(0);'
-          done
-
           substituteInPlace mlx/backend/rocm/CMakeLists.txt \
             --replace-fail \
               'if(arch MATCHES "^gfx1[12]")' \
@@ -333,22 +299,7 @@ mlx.overrideAttrs (old: {
               'defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || defined(__gfx1103__) || \
         defined(__gfx1150__)' \
               'defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
-        defined(__gfx1150__)' \
-            --replace-fail \
-              '      } else if (std::strstr(arch_name, "gfx11") != nullptr) {
-            hw.tier = RocmQmvArchTier::Rdna3;
-            hw.simds_per_cu = 2;
-            hw.has_wmma = true;
-          } else if (std::strstr(arch_name, "gfx10") != nullptr) {' \
-              '      } else if (std::strstr(arch_name, "gfx1103") != nullptr) {
-            hw.tier = RocmQmvArchTier::Rdna3;
-            hw.simds_per_cu = 2;
-            hw.has_wmma = false;
-          } else if (std::strstr(arch_name, "gfx11") != nullptr) {
-            hw.tier = RocmQmvArchTier::Rdna3;
-            hw.simds_per_cu = 2;
-            hw.has_wmma = true;
-          } else if (std::strstr(arch_name, "gfx10") != nullptr) {'
+        defined(__gfx1150__)'
   '';
 
   buildInputs =
@@ -391,14 +342,18 @@ mlx.overrideAttrs (old: {
     NIX_CFLAGS_COMPILE = ((old.env or { }).NIX_CFLAGS_COMPILE or "") + " -I${rdma-core.dev}/include";
   };
 
+  postFixup = (old.postFixup or "") + ''
+    ${patchelf}/bin/patchelf --add-rpath '$ORIGIN/../lib' "$out/${python.sitePackages}/mlx/lib64/libmlx.so"
+  '';
+
   doCheck = false;
   doInstallCheck = false;
-  pythonImportsCheck = [ ];
+  pythonImportsCheck = [ "mlx.core" ];
   nativeCheckInputs = [ ];
 
   meta = old.meta // {
     description = "MLX with ROCm backend and portable JACCL support";
-    changelog = "https://github.com/NripeshN/mlx/commit/39fac95d901c72175fce4baf973e375d4a054ba7";
+    changelog = "https://github.com/NripeshN/mlx/tree/rocm-support";
     maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
     broken = false;

--- a/pkgs/mlx/rocm.nix
+++ b/pkgs/mlx/rocm.nix
@@ -1,8 +1,11 @@
 {
   lib,
+  stdenv,
   mlx,
   applyPatches,
+  bash,
   mlx-src,
+  makeWrapper,
   patchelf,
   python,
   rdma-core,
@@ -17,6 +20,37 @@ let
     src = mlx-src;
     patches = [ ./rocm-include-rocblas.patch ];
   };
+  gccCxxInclude = "${stdenv.cc.cc}/include/c++/${stdenv.cc.cc.version}";
+  rocmRuntimeEnv = {
+    ROCM_HOME = "${rocmPackages.clr}";
+    ROCM_PATH = "${rocmPackages.clr}";
+    HIP_PATH = "${rocmPackages.clr}";
+    HIP_PLATFORM = "amd";
+    HIP_CLANG_PATH = "${rocmPackages.clr}/llvm/bin";
+    HSA_PATH = "${rocmPackages.rocm-runtime}";
+    DEVICE_LIB_PATH = "${rocmPackages.rocm-device-libs}/amdgcn/bitcode";
+    HIP_DEVICE_LIB_PATH = "${rocmPackages.rocm-device-libs}/amdgcn/bitcode";
+    CPATH = lib.concatStringsSep ":" [
+      "${rocmPackages.clr}/include"
+      "${stdenv.cc.libc.dev}/include"
+    ];
+    CPLUS_INCLUDE_PATH = lib.concatStringsSep ":" [
+      gccCxxInclude
+      "${gccCxxInclude}/${stdenv.hostPlatform.config}"
+      "${gccCxxInclude}/backward"
+      "${stdenv.cc.libc.dev}/include"
+    ];
+    LIBRARY_PATH = lib.makeLibraryPath [
+      rocmPackages.clr
+      stdenv.cc.cc.lib
+      stdenv.cc.libc
+    ];
+  };
+  rocmWrapperArgs = lib.concatStringsSep " " (
+    lib.mapAttrsToList (
+      key: value: "--set ${lib.escapeShellArg key} ${lib.escapeShellArg (toString value)}"
+    ) rocmRuntimeEnv
+  );
 in
 mlx.overrideAttrs (old: {
   inherit pname;
@@ -26,6 +60,11 @@ mlx.overrideAttrs (old: {
   patches = [ ];
 
   postPatch = (old.postPatch or "") + ''
+          substituteInPlace python/mlx/_distributed_utils/launch.py \
+            --replace-fail \
+              'executable="/bin/bash"' \
+              'executable="${bash}/bin/bash"'
+
           substituteInPlace CMakeLists.txt \
             --replace-fail \
               '  FetchContent_Declare(
@@ -324,6 +363,9 @@ mlx.overrideAttrs (old: {
 
   nativeBuildInputs =
     (old.nativeBuildInputs or [ ])
+    ++ [
+      makeWrapper
+    ]
     ++ (with rocmPackages; [
       hipcc
       clang
@@ -344,6 +386,12 @@ mlx.overrideAttrs (old: {
 
   postFixup = (old.postFixup or "") + ''
     ${patchelf}/bin/patchelf --add-rpath '$ORIGIN/../lib' "$out/${python.sitePackages}/mlx/lib64/libmlx.so"
+
+    for bin in "$out"/bin/*; do
+      [ -e "$bin" ] || continue
+      [ ! -d "$bin" ] || continue
+      wrapProgram "$bin" ${rocmWrapperArgs}
+    done
   '';
 
   doCheck = false;
@@ -357,5 +405,9 @@ mlx.overrideAttrs (old: {
     maintainers = with lib.maintainers; [ georgewhewell ];
     platforms = [ "x86_64-linux" ];
     broken = false;
+  };
+
+  passthru = (old.passthru or { }) // {
+    inherit rocmRuntimeEnv;
   };
 })


### PR DESCRIPTION
## Summary

- use the flake `mlx-src` input for the ROCm MLX package instead of a second hardcoded fetch
- point `mlx-src` at the ROCm-support fork/branch so Linux ROCm, Linux default MLX, Darwin Metal MLX, and JACCL derive from the same MLX revision
- align `mlx-rocm` metadata to `0.32.0`

Upstream `ml-explore/mlx` at the previous pin does not include `mlx/backend/rocm`, so this keeps the ROCm-capable fork while removing the duplicate source pin.

## Verification

- `nix eval --json .#packages.x86_64-linux --apply 'p: { mlx = p.mlx.version; mlx_rocm = p.mlx-rocm.version; jaccl = p.jaccl.version; }'`
- `nix eval --json .#packages.aarch64-darwin --apply 'p: { mlx = p.mlx.version; mlx_metal = p.mlx-metal.version; jaccl = p.jaccl.version; }'`
- `nix build .#packages.x86_64-linux.mlx-rocm.src --no-link --print-out-paths`
- `nix build .#packages.x86_64-linux.mlx-rocm --no-link --dry-run`
- `nix build .#packages.x86_64-linux.jaccl --no-link --dry-run`
- `git diff --check`
- `nix flake check --no-build`
