### PR TITLE
thunderbolt-ibverbs: update to v0.3.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -147,10 +147,10 @@
     "linux-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779802034,
-        "narHash": "sha256-AtgoTQnF7yPt7dyYJjQIy8zt1JGdebkHSmVcoUxu7Xo=",
+        "lastModified": 1780549139,
+        "narHash": "sha256-HkhLiKigaUCQeH6z5enWhExJtW2LLh4NHVBrSlZc3XU=",
         "ref": "refs/heads/next",
-        "rev": "d73a08958e66849ea713d2f458b2fcf7b183f987",
+        "rev": "503c5ae1e72aa9ed91925dafa3d82ee2e992747f",
         "shallow": true,
         "type": "git",
         "url": "https://git.kernel.org/pub/scm/linux/kernel/git/westeri/thunderbolt.git"
@@ -1265,11 +1265,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780321682,
-        "narHash": "sha256-RVom8lwovRCk6YAZaWQBdhxOK7xxJ474zw1PWOpfsco=",
+        "lastModified": 1781582759,
+        "narHash": "sha256-1vyhdys7A0HjdJL6/Y7whRi2/Ym4hvtCyK7Qjn2mAVg=",
         "owner": "hellas-ai",
         "repo": "thunderbolt-ibverbs",
-        "rev": "1f7833dd440ca3b957d1f6710f4c19e4ae3e28f8",
+        "rev": "f6ea14b3f570dd2004519e504a03768d2661255b",
         "type": "github"
       },
       "original": {

--- a/lib/hydra/benchmark/flake.lock
+++ b/lib/hydra/benchmark/flake.lock
@@ -154,10 +154,10 @@
     "linux-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1779802034,
-        "narHash": "sha256-AtgoTQnF7yPt7dyYJjQIy8zt1JGdebkHSmVcoUxu7Xo=",
+        "lastModified": 1780549139,
+        "narHash": "sha256-HkhLiKigaUCQeH6z5enWhExJtW2LLh4NHVBrSlZc3XU=",
         "ref": "refs/heads/next",
-        "rev": "d73a08958e66849ea713d2f458b2fcf7b183f987",
+        "rev": "503c5ae1e72aa9ed91925dafa3d82ee2e992747f",
         "shallow": true,
         "type": "git",
         "url": "https://git.kernel.org/pub/scm/linux/kernel/git/westeri/thunderbolt.git"
@@ -1288,11 +1288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780321682,
-        "narHash": "sha256-RVom8lwovRCk6YAZaWQBdhxOK7xxJ474zw1PWOpfsco=",
+        "lastModified": 1781582759,
+        "narHash": "sha256-1vyhdys7A0HjdJL6/Y7whRi2/Ym4hvtCyK7Qjn2mAVg=",
         "owner": "hellas-ai",
         "repo": "thunderbolt-ibverbs",
-        "rev": "1f7833dd440ca3b957d1f6710f4c19e4ae3e28f8",
+        "rev": "f6ea14b3f570dd2004519e504a03768d2661255b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Update the top-level and benchmark flake locks for `hellas-ai/thunderbolt-ibverbs` to the `v0.3.4` release commit (`f6ea14b`).

This picks up the merged Apple compatibility fixes and bench-tool queue-depth handling from thunderbolt-ibverbs v0.3.4.

## Validation

- `git diff --check`
- `nix flake check --no-build --builders '' --print-build-logs`
- `nix flake check ./lib/hydra/benchmark --no-build --builders '' --print-build-logs`
- `nix build .#packages.x86_64-linux.thunderbolt-ibverbs .#packages.x86_64-linux.thunderbolt-ibverbs-bench-tools .#packages.x86_64-linux.thunderbolt-ibverbs-linux-thunderbolt --builders '' --no-link --print-out-paths --print-build-logs`
