### PR TITLE
therock: centralize Python wheel interpreter

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -376,6 +376,7 @@
 
       providers = import ./lib/providers.nix { inherit lib; };
       benchLib = import ./lib/bench/lib.nix { inherit lib; };
+      therockPythonConfig = import ./pkgs/therock/python-config.nix { inherit lib; };
 
       defaultTherockSources = {
         rocm = builtins.fromJSON (builtins.readFile ./pkgs/therock/sources/rocm.json);
@@ -445,18 +446,18 @@
           thunderboltIbverbsOverlay
           thunderboltRenamesOverlay
           (import ./overlays/rocm.nix {
-            inherit lib;
+            inherit lib therockPythonConfig;
             provider = rocmProvider;
             inherit rocmTarget rocmTargets;
             sources = defaultTherockSources;
           })
           (import ./overlays/python.nix {
-            inherit lib;
+            inherit lib therockPythonConfig;
             provider = pythonProvider;
             inherit rocmTarget;
           })
           (import ./overlays/therock-vllm.nix {
-            inherit lib;
+            inherit lib therockPythonConfig;
             target = rocmTarget;
             vllmSrc = inputs.vllm-src;
             vllmVersion = "0.23.0";
@@ -745,7 +746,7 @@
             name = "vllm-rocm-${s}-ray-env";
             paths = [
               pkgs.vllm-rocm
-              pkgs.python312Packages.ray
+              pkgs.${therockPythonConfig.packagesAttr}.ray
             ];
           };
 

--- a/overlays/python.nix
+++ b/overlays/python.nix
@@ -2,11 +2,12 @@
   lib,
   provider ? "nixpkgs",
   rocmTarget ? null,
+  therockPythonConfig ? import ../pkgs/therock/python-config.nix { inherit lib; },
 }:
 
 # Parameterised Python overlay. Always applies shared Python package
-# compatibility fixes, and optionally swaps `python312Packages.torch`,
-# `triton`, `amdsmi`, and the `rocm-sdk-*` shims depending on provider.
+# compatibility fixes, and optionally swaps the configured TheRock Python
+# package set's `torch`, `triton`, `amdsmi`, and `rocm-sdk-*` shims.
 #
 #   - "nixpkgs"         Stock nixpkgs Python packages plus the shared fixes.
 #   - "therock-wheels"  TheRock-published binary wheels, used by the
@@ -41,6 +42,7 @@ let
       import ./therock-python.nix {
         inherit lib;
         target = rocmTarget;
+        pythonConfig = therockPythonConfig;
       } final prev
     else
       throw "unreachable: assertPythonProvider should have rejected ${provider}";

--- a/overlays/rocm.nix
+++ b/overlays/rocm.nix
@@ -4,6 +4,7 @@
   rocmTarget,
   rocmTargets,
   sources,
+  therockPythonConfig ? import ../pkgs/therock/python-config.nix { inherit lib; },
 }:
 
 # Parameterised ROCm overlay. Picks one of:
@@ -33,6 +34,7 @@ let
     therockRocmSourcePins = sources.rocmSourcePins;
     therockRocmSourceTrees = sources.rocmSourceTrees;
     therockRocmThirdPartySources = sources.rocmThirdParty;
+    inherit therockPythonConfig;
   };
 
   suffix = rocmTarget.packageSuffix;

--- a/overlays/therock-python.nix
+++ b/overlays/therock-python.nix
@@ -1,7 +1,11 @@
-# Opt-in TheRock Python overlay. The TheRock wheels are currently cp312,
-# so keep the substitution scoped to python312 package sets. Other Python
-# interpreters stay on the nixpkgs/libibverbs defaults.
-{ lib, target }:
+# Opt-in TheRock Python overlay. Substitute only the interpreter selected
+# by pkgs/therock/python-config.nix; other Python interpreters stay on
+# nixpkgs defaults.
+{
+  lib,
+  target,
+  pythonConfig ? import ../pkgs/therock/python-config.nix { inherit lib; },
+}:
 let
   s = target.packageSuffix;
   disablePythonChecks =
@@ -15,7 +19,7 @@ final: prev: {
   pythonPackagesExtensions = (prev.pythonPackagesExtensions or [ ]) ++ [
     (
       _pyfinal: pyprev:
-      if lib.versions.majorMinor pyprev.python.version == "3.12" then
+      if lib.versions.majorMinor pyprev.python.version == pythonConfig.pythonVersion then
         let
           wheels = final."therock-python-wheels-${s}";
         in

--- a/overlays/therock-vllm.nix
+++ b/overlays/therock-vllm.nix
@@ -3,6 +3,7 @@
   target,
   vllmSrc,
   vllmVersion,
+  therockPythonConfig ? import ../pkgs/therock/python-config.nix { inherit lib; },
   enabled ? true,
 }:
 let
@@ -17,7 +18,7 @@ let
     localGpuTargets = vllmGpuTargets;
     gpuTargets = vllmGpuTargets;
   };
-  py = final.python312Packages;
+  py = final.${therockPythonConfig.packagesAttr};
   vllmSrcWithTag = vllmSrc // {
     tag = vllmSrc.tag or "v${vllmVersion}";
   };
@@ -259,7 +260,7 @@ let
           substituteInPlace CMakeLists.txt \
             --replace-fail \
               'set(PYTHON_SUPPORTED_VERSIONS' \
-              'set(PYTHON_SUPPORTED_VERSIONS "${lib.versions.majorMinor final.python312.version}"'
+              'set(PYTHON_SUPPORTED_VERSIONS "${therockPythonConfig.pythonVersion}"'
 
           # vLLM 0.22's Rust frontend is optional. Keep this local build on
           # the existing Python/C++/HIP surface until the Cargo deps are

--- a/pkgs/therock/default.nix
+++ b/pkgs/therock/default.nix
@@ -7,9 +7,13 @@
   therockRocmSourcePins,
   therockRocmSourceTrees,
   therockRocmThirdPartySources,
+  therockPythonConfig ? import ./python-config.nix { inherit lib; },
 }:
 final: prev:
 let
+  therockPython = prev.${therockPythonConfig.packageAttr};
+  therockPythonPackages = prev.${therockPythonConfig.packagesAttr};
+
   targetBySuffix = lib.listToAttrs (
     map (rocmTarget: {
       name = rocmTarget.packageSuffix;
@@ -63,44 +67,6 @@ let
   normalizeRocmVersion =
     version: if builtins.length (lib.splitVersion version) == 2 then "${version}.0" else version;
 
-  mkTorchRocm =
-    rocmTarget:
-    (final.python3Packages.torch.override {
-      rocmSupport = true;
-      cudaSupport = false;
-      rocmPackages = final.therockRocmPackages.${rocmTarget.runtimeArch};
-    }).overrideAttrs
-      (old: {
-        postPatch = (old.postPatch or "") + ''
-          # Current RCCL reports NCCL_VERSION_CODE 22803 (2.28.3) but does
-          # not ship the NCCL 2.28+ device-side symmetric memory APIs. Keep
-          # PyTorch's NCCL symmetric-memory gates closed on ROCm.
-          substituteInPlace torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp \
-            --replace-fail \
-              '#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0)' \
-              '#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 28, 0) && !defined(USE_ROCM)' \
-            --replace-fail \
-              '#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0)' \
-              '#if NCCL_VERSION_CODE >= NCCL_VERSION(2, 29, 0) && !defined(USE_ROCM)'
-
-          # intra_node_comm.cpp calls rsmi_init() under `#ifdef USE_ROCM`,
-          # but PyTorch's dependency list does not include rocm_smi64.
-          substituteInPlace cmake/Dependencies.cmake \
-            --replace-fail \
-              'hip::amdhip64 MIOpen hiprtc::hiprtc) # libroctx will be linked in with MIOpen' \
-              'hip::amdhip64 MIOpen hiprtc::hiprtc rocm_smi64) # libroctx will be linked in with MIOpen'
-        '';
-      });
-
-  torchRocmTargets = builtins.filter hasPythonWheelSources rocmTargets;
-
-  torchRocmPerArch = lib.listToAttrs (
-    map (rocmTarget: {
-      name = "torch-rocm-${rocmTarget.packageSuffix}";
-      value = mkTorchRocm rocmTarget;
-    }) torchRocmTargets
-  );
-
   mkTherockRocmSdkAttrs =
     suffix: source:
     let
@@ -137,16 +103,19 @@ let
       suffix = rocmTarget.packageSuffix;
       wheelSources = pythonWheelSourcesFor rocmTarget;
     in
+    assert lib.assertMsg (wheelSources.pythonTag == therockPythonConfig.pythonTag)
+      "TheRock wheel pin for ${suffix} uses ${wheelSources.pythonTag}, but Python config expects ${therockPythonConfig.pythonTag}";
     {
       "therock-python-${suffix}" = prev.callPackage ./python-env {
-        inherit wheelSources;
+        inherit therockPython therockPythonPackages wheelSources;
       };
       "therock-python-wheels-${suffix}" = prev.callPackage ./python-wheels {
-        inherit wheelSources;
+        inherit therockPython therockPythonPackages wheelSources;
       };
-      "therock-amdsmi-${suffix}" = prev.python312Packages.callPackage ./amdsmi {
+      "therock-amdsmi-${suffix}" = therockPythonPackages.callPackage ./amdsmi {
         wheels = final."therock-python-wheels-${suffix}";
       };
+      "torch-rocm-${suffix}" = final."therock-python-wheels-${suffix}";
     };
 
   therockPythonTargets = builtins.filter hasPythonWheelSources rocmTargets;
@@ -316,7 +285,6 @@ in
     }
   );
 }
-// torchRocmPerArch
 // therockRocmSdkPerArch
 // therockPythonPerArch
 // therockFromSourcePerArch

--- a/pkgs/therock/python-config.nix
+++ b/pkgs/therock/python-config.nix
@@ -1,0 +1,12 @@
+_:
+
+let
+  pythonVersion = "3.12";
+  pythonDigits = builtins.replaceStrings [ "." ] [ "" ] pythonVersion;
+in
+{
+  inherit pythonVersion;
+  pythonTag = "cp${pythonDigits}";
+  packageAttr = "python${pythonDigits}";
+  packagesAttr = "python${pythonDigits}Packages";
+}

--- a/pkgs/therock/python-env/default.nix
+++ b/pkgs/therock/python-env/default.nix
@@ -4,8 +4,8 @@
   fetchurl,
   makeWrapper,
   autoPatchelfHook,
-  python312,
-  python312Packages,
+  therockPython,
+  therockPythonPackages,
   bashInteractive,
   zlib,
   zstd,
@@ -23,7 +23,7 @@
 }:
 
 let
-  basePython = python312.withPackages (
+  basePython = therockPython.withPackages (
     ps: with ps; [
       filelock
       fsspec
@@ -48,6 +48,7 @@ let
       name = source.filename or "${project}.whl";
     };
   }) wheelSources.packages;
+  rocGdbPythonBinary = "rocgdb-py${lib.versions.majorMinor therockPython.version}";
 in
 stdenv.mkDerivation {
   pname = "therock-python-${wheelSources.target}";
@@ -60,9 +61,9 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     autoPatchelfHook
     makeWrapper
-    python312Packages.pip
-    python312Packages.setuptools
-    python312Packages.wheel
+    therockPythonPackages.pip
+    therockPythonPackages.setuptools
+    therockPythonPackages.wheel
   ];
 
   buildInputs = [
@@ -84,7 +85,7 @@ stdenv.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    site="$out/${python312.sitePackages}"
+    site="$out/${therockPython.sitePackages}"
     wheelhouse="$TMPDIR/therock-wheels"
     mkdir -p "$site" "$out/bin" "$wheelhouse"
 
@@ -102,7 +103,7 @@ stdenv.mkDerivation {
       "$wheelhouse"/*
 
     find "$site" -path "*/_rocm_sdk_core/bin/rocgdb-py3.*" \
-      ! -name "rocgdb-py3.12" -delete
+      ! -name "${rocGdbPythonBinary}" -delete
 
     chmod -R u+w "$out"
 
@@ -141,7 +142,8 @@ stdenv.mkDerivation {
 
   passthru = {
     inherit basePython wheelSources;
-    sitePackages = "${placeholder "out"}/${python312.sitePackages}";
+    pythonModule = therockPython;
+    sitePackages = "${placeholder "out"}/${therockPython.sitePackages}";
   };
 
   meta = {

--- a/pkgs/therock/python-wheels/default.nix
+++ b/pkgs/therock/python-wheels/default.nix
@@ -3,8 +3,8 @@
   stdenv,
   fetchurl,
   autoPatchelfHook,
-  python312,
-  python312Packages,
+  therockPython,
+  therockPythonPackages,
   zlib,
   zstd,
   ncurses,
@@ -48,7 +48,7 @@ let
       })
       (lib.filterAttrs (project: _source: lib.elem project selectedPackageNames) wheelSources.packages);
 in
-python312Packages.buildPythonPackage (finalAttrs: {
+therockPythonPackages.buildPythonPackage (finalAttrs: {
   pname = "therock-python-wheels-${wheelSources.target}";
   version = wheelSources.rocmVersion;
   format = "other";
@@ -60,9 +60,9 @@ python312Packages.buildPythonPackage (finalAttrs: {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    python312Packages.pip
-    python312Packages.setuptools
-    python312Packages.wheel
+    therockPythonPackages.pip
+    therockPythonPackages.setuptools
+    therockPythonPackages.wheel
   ];
 
   buildInputs = [
@@ -81,7 +81,7 @@ python312Packages.buildPythonPackage (finalAttrs: {
     ocl-icd
   ];
 
-  propagatedBuildInputs = with python312Packages; [
+  propagatedBuildInputs = with therockPythonPackages; [
     filelock
     fsspec
     jinja2
@@ -100,7 +100,7 @@ python312Packages.buildPythonPackage (finalAttrs: {
   installPhase = ''
     runHook preInstall
 
-    site="$out/${python312.sitePackages}"
+    site="$out/${therockPython.sitePackages}"
     wheelhouse="$TMPDIR/therock-wheels"
     mkdir -p "$site" "$wheelhouse"
 
@@ -133,7 +133,7 @@ python312Packages.buildPythonPackage (finalAttrs: {
     fi
 
     find "$site" -path "*/_rocm_sdk_core/bin/rocgdb-py3.*" \
-      ! -name "rocgdb-py3.12" -delete
+      ! -name "rocgdb-py${lib.versions.majorMinor therockPython.version}" -delete
 
     runHook postInstall
   '';
@@ -145,9 +145,9 @@ python312Packages.buildPythonPackage (finalAttrs: {
 
   passthru = {
     inherit wheelSources;
-    pythonModule = python312;
-    sitePackages = "${finalAttrs.finalPackage}/${python312.sitePackages}";
-    rocmtoolkit_joined = "${finalAttrs.finalPackage}/${python312.sitePackages}/_rocm_sdk_core";
+    pythonModule = therockPython;
+    sitePackages = "${finalAttrs.finalPackage}/${therockPython.sitePackages}";
+    rocmtoolkit_joined = "${finalAttrs.finalPackage}/${therockPython.sitePackages}/_rocm_sdk_core";
     gpuTargets = [ wheelSources.target ];
     gpuTargetString = wheelSources.target;
     cudaSupport = false;

--- a/pkgs/therock/scripts/update-python-wheels.py
+++ b/pkgs/therock/scripts/update-python-wheels.py
@@ -22,7 +22,6 @@ from pathlib import Path
 
 BASE_URL = "https://rocm.nightlies.amd.com/v2"
 DEFAULT_TARGET = "gfx1151"
-DEFAULT_PYTHON_TAG = "cp312"
 DEFAULT_SERIES = "7.13"
 BASE_PACKAGES = [
     "rocm",
@@ -274,10 +273,19 @@ def pinned_series(output: str) -> str | None:
     return None
 
 
+def pinned_python_tag(sources: dict, target: str) -> str | None:
+    target_sources = sources.get("targets", {}).get(target)
+    if isinstance(target_sources, dict):
+        python_tag = target_sources.get("pythonTag")
+        if isinstance(python_tag, str):
+            return python_tag
+    return None
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target", default=DEFAULT_TARGET)
-    parser.add_argument("--python-tag", default=DEFAULT_PYTHON_TAG)
+    parser.add_argument("--python-tag", help="Python ABI tag; defaults to the current pin")
     parser.add_argument(
         "--series",
         help="Version prefix to select; defaults to the currently pinned series",
@@ -286,6 +294,10 @@ def main() -> None:
     parser.add_argument("--package", action="append", default=[], help="Project to pin")
     parser.add_argument("--output", default="pkgs/therock/sources/python-wheels.json")
     args = parser.parse_args()
+    sources = load_sources(Path(args.output))
+    python_tag = args.python_tag or pinned_python_tag(sources, args.target)
+    if python_tag is None:
+        parser.error("--python-tag is required when the output has no current pin for this target")
 
     if not args.series and not args.rocm_version:
         args.series = pinned_series(args.output) or DEFAULT_SERIES
@@ -296,14 +308,14 @@ def main() -> None:
     rocm_version = args.rocm_version or choose_rocm_version(
         distributions_by_project,
         series=args.series,
-        python_tag=args.python_tag,
+        python_tag=python_tag,
     )
 
     target_sources = {
         "target": args.target,
         "series": args.series,
         "rocmVersion": rocm_version,
-        "pythonTag": args.python_tag,
+        "pythonTag": python_tag,
         "index": f"{BASE_URL}/{target_slug(args.target)}/",
         "packages": {},
         "updated": datetime.now(timezone.utc).isoformat(),
@@ -313,7 +325,7 @@ def main() -> None:
         dist = choose_distribution(
             distributions_by_project[project],
             rocm_version=rocm_version,
-            python_tag=args.python_tag,
+            python_tag=python_tag,
         )
         print(f"prefetching {project}: {dist.filename}", file=sys.stderr)
         fetched = prefetch(dist.url)
@@ -330,7 +342,6 @@ def main() -> None:
         }
 
     output = Path(args.output)
-    sources = load_sources(output)
     sources["targets"][args.target] = target_sources
     sources["updated"] = target_sources["updated"]
     output.write_text(json.dumps(sources, indent=2) + "\n")


### PR DESCRIPTION
## Summary

- add a single TheRock Python selector in `pkgs/therock/python-config.nix`
- route TheRock wheel, amdsmi, vLLM, Ray bench, and `torch-rocm` aliases through that selector
- derive wheel install paths and `rocgdb-pyX.Y` cleanup from the selected interpreter instead of hardcoding 3.12 at each call site
- make the wheel updater default to the current checked-in Python tag instead of carrying its own `cp312` default
- remove the misleading `torch-rocm` source override path; for the TheRock wheel provider, `torch-rocm` is explicitly the pinned wheel bundle

## Validation

- `nix flake check --no-build --all-systems --accept-flake-config`
- `nix build --no-link --accept-flake-config .#therock-python-wheels .#torch-rocm .#therock-amdsmi`
- `nix build --no-link --accept-flake-config .#vllm-rocm`
- `nix run nixpkgs#nixfmt-tree -- --tree-root . --walk filesystem --fail-on-change .`
- `nix run nixpkgs#deadnix -- --fail .`
- `nix run nixpkgs#statix -- check .`
- `python3 -m py_compile pkgs/therock/scripts/update-python-wheels.py`
- confirmed `vllm-rocm` and `torch-rocm` both resolve to Python `3.12.13`
