### PR TITLE
sglang: package ROCm build for Strix Halo

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -711,6 +711,7 @@
             "llama-cpp-rocm"
             "llama-cpp-vulkan"
             "mlx-rocm"
+            "sglang-rocm"
             "strix-halo-mes-firmware"
             "therock-amdsmi"
             "therock-python"
@@ -883,6 +884,7 @@
             mlx-lm-server =
               ap self.packages.${system}.mlx-lm "mlx_lm.server"
                 "Run the MLX LM HTTP server on ROCm";
+            sglang-rocm = ap pkgs.sglang-rocm "sglang" "Run SGLang with ROCm";
 
             live-iso-vm =
               let

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -288,6 +288,12 @@ let
       torch-rocm = final."torch-rocm-${suffix}";
     }
     // lib.optionalAttrs (supportsTherockRocm && supportsTherockPython) {
+      sglang-rocm = prev.callPackage ../pkgs/sglang {
+        inherit (final) python312Packages;
+        rocmSdk = final."therock-rocm-${suffix}";
+        inherit (rocmTarget) packageSuffix;
+        hsaOverrideGfxVersion = rocmTarget.hsaOverride or null;
+      };
       vllm-rocm = final."vllm-rocm-therock-${suffix}";
     }
   );

--- a/overlays/therock-python.nix
+++ b/overlays/therock-python.nix
@@ -22,6 +22,31 @@ final: prev: {
       if lib.versions.majorMinor pyprev.python.version == pythonConfig.pythonVersion then
         let
           wheels = final."therock-python-wheels-${s}";
+          rocmSdk = final."therock-rocm-${s}";
+          rocmSource = final."therock-rocm-source-${s}";
+          therockRocmPackages =
+            let
+              sdk = rocmSdk;
+            in
+            {
+              clr = sdk;
+              hipblas = sdk;
+              hipblas-common = sdk;
+              hipblaslt = sdk;
+              hipcub = sdk;
+              hipfft = sdk;
+              hipsolver = sdk;
+              hipsparse = sdk;
+              rocblas = sdk;
+              rocprim = sdk;
+              rocsolver = sdk;
+              rocsparse = sdk;
+              rocthrust = sdk;
+              hipcc = sdk;
+              composable_kernel = {
+                src = "${rocmSource}/rocm-libraries/projects/composablekernel";
+              };
+            };
         in
         {
           amdsmi = final."therock-amdsmi-${s}";
@@ -50,7 +75,58 @@ final: prev: {
           depyf = disablePythonChecks pyprev.depyf;
           llguidance = disablePythonChecks pyprev.llguidance;
           pydevd = disablePythonChecks pyprev.pydevd;
-          "mistral-common" = disablePythonChecks pyprev."mistral-common";
+          amd-aiter = _pyfinal.callPackage ../pkgs/amd-aiter {
+            amd-aiter = pyprev.amd-aiter.override {
+              rocmPackages = therockRocmPackages;
+              inherit (_pyfinal) torch;
+            };
+          };
+          timm = pyprev.timm.overridePythonAttrs (old: {
+            nativeCheckInputs = (old.nativeCheckInputs or [ ]) ++ [
+              final.openssl
+            ];
+            disabledTestPaths = (old.disabledTestPaths or [ ]) ++ [
+              "tests/test_optim.py"
+            ];
+          });
+          "mistral-common" = (disablePythonChecks pyprev."mistral-common").overridePythonAttrs (old: {
+            pythonRelaxDeps = (old.pythonRelaxDeps or [ ]) ++ [
+              "numpy"
+            ];
+          });
+          "torch-memory-saver" =
+            (pyprev."torch-memory-saver".override {
+              inherit (_pyfinal) torch;
+            }).overridePythonAttrs
+              (old: {
+                postPatch = (old.postPatch or "") + ''
+                  substituteInPlace setup.py \
+                    --replace-fail \
+                      'self.compiler.set_executable("compiler_so", "hipcc")' \
+                      'self.compiler.set_executable("compiler_so", "${rocmSdk}/bin/therock-hip-clang++")' \
+                    --replace-fail \
+                      'self.compiler.set_executable("compiler_cxx", "hipcc")' \
+                      'self.compiler.set_executable("compiler_cxx", "${rocmSdk}/bin/therock-hip-clang++")' \
+                    --replace-fail \
+                      'self.compiler.set_executable("linker_so", "hipcc --shared")' \
+                      'self.compiler.set_executable("linker_so", "${rocmSdk}/bin/therock-hip-clang++ --shared")'
+                '';
+                env = {
+                  HIP_PLATFORM = "amd";
+                  NIX_CFLAGS_COMPILE = "-D__HIP_PLATFORM_AMD__";
+                  ROCM_HOME = "${rocmSdk}";
+                  ROCM_PATH = "${rocmSdk}";
+                };
+                nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+                  rocmSdk
+                ];
+                buildInputs = (old.buildInputs or [ ]) ++ [
+                  rocmSdk
+                ];
+                meta = (old.meta or { }) // {
+                  broken = false;
+                };
+              });
         }
       else
         { }

--- a/pkgs/amd-aiter/default.nix
+++ b/pkgs/amd-aiter/default.nix
@@ -1,0 +1,48 @@
+{
+  amd-aiter,
+  lib,
+  ...
+}:
+
+# Slim override of nixpkgs' ROCm/aiter packaging. Keep the upstream
+# derivation and only add local gfx1151 fixes plus runtime CK layout
+# compatibility for AITER's JIT code.
+amd-aiter.overridePythonAttrs (old: {
+  patches =
+    (old.patches or [ ])
+    ++ (
+      let
+        patchDir = ./patches;
+        entries = builtins.attrNames (builtins.readDir patchDir);
+        patches = builtins.filter (n: lib.hasSuffix ".patch" n) entries;
+      in
+      map (p: patchDir + "/${p}") patches
+    );
+
+  postInstall = (old.postInstall or "") + ''
+    # AITER's JIT code still looks for the pre-ROCm-7 Composable Kernel
+    # layout directly under 3rdparty/composable_kernel. TheRock sources use
+    # the projects/composablekernel layout, so add compatibility links.
+    for site in "$out"/lib/python*/site-packages; do
+      ck="$site/aiter_meta/3rdparty/composable_kernel"
+      ck_project="$ck/projects/composablekernel"
+      if [[ -d "$ck_project" ]]; then
+        ln -sfn "$ck_project/include" "$ck/include"
+        ln -sfn "$ck_project/library" "$ck/library"
+        ln -sfn "$ck_project/example" "$ck/example"
+      fi
+    done
+  '';
+
+  passthru = (old.passthru or { }) // {
+    tests = lib.mapAttrs (
+      _: drv:
+      drv.overrideAttrs (oldDrv: {
+        env = (oldDrv.env or { }) // {
+          GPU_ARCHS = "gfx1151";
+          PYTORCH_ROCM_ARCH = "gfx1151";
+        };
+      })
+    ) (old.passthru.tests or { });
+  };
+})

--- a/pkgs/amd-aiter/patches/0001-gfx1151-vec-convert-rdna-fallbacks.patch
+++ b/pkgs/amd-aiter/patches/0001-gfx1151-vec-convert-rdna-fallbacks.patch
@@ -1,0 +1,74 @@
+--- a/csrc/include/ck_tile/vec_convert.h
++++ b/csrc/include/ck_tile/vec_convert.h
+@@ -37,37 +37,69 @@ struct numeric_traits<fp8_t>
+     // maximum finite value
+     CK_TILE_HOST_DEVICE static constexpr fp32_t max() { return 6.0f; }
+ };
++
++// RDNA 3/3.5 lacks the CDNA packed FP32/FP8 conversion instructions used
++// below. Keep CDNA on the fast asm path and provide scalar fallbacks for
++// gfx11xx/gfx115x so AITER JIT modules compile on Strix Halo.
++#if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
++    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) || \
++    defined(__gfx1152__) || defined(__gfx1153__)
++#define CK_TILE_RDNA3_NO_PK_FP8 1
++#endif
+ CK_TILE_DEVICE fp32x2_v amd_assembly_pk_mul_f32(fp32x2_v a, fp32x2_t b)
+ {
+     fp32x2_v c;
++#if defined(CK_TILE_RDNA3_NO_PK_FP8)
++    c[0] = a[0] * b[0];
++    c[1] = a[1] * b[1];
++#else
+     asm volatile("v_pk_mul_f32 %0, %1, %2" : "=v"(c) : "v"(a), "v"(b));
++#endif
+     return c;
+ }
+ CK_TILE_DEVICE fp8x2_v amd_assembly_cvt_pk_fp8_f32(fp32_t a, fp32_t b)
+ {
+-    int16x2_t c;
+     static constexpr bool is_e4m3_fnuz =
+         (numeric_traits<fp8_t>::f8_interpret == fp8_interpretation::E4M3_FNUZ);
+     static constexpr float d = is_e4m3_fnuz ? 240.0f : 448.0f;
+     static constexpr float e = is_e4m3_fnuz ? -240.0f : -448.0f;
++#if defined(CK_TILE_RDNA3_NO_PK_FP8)
++    a = __builtin_fminf(__builtin_fmaxf(a, e), d);
++    b = __builtin_fminf(__builtin_fmaxf(b, e), d);
++    fp8x2_v result;
++    result[0] = type_convert<fp8_t>(a);
++    result[1] = type_convert<fp8_t>(b);
++    return result;
++#else
++    int16x2_t c;
+     asm volatile("v_med3_f32 %1, %1, %3, %4\n"
+                  "v_med3_f32 %2, %2, %3, %4\n"
+                  "v_cvt_pk_fp8_f32 %0, %1, %2"
+                  : "=v"(c)
+                  : "v"(a), "v"(b), "v"(d), "v"(e));
+     return bit_cast<fp8x2_v>(c[0]);
++#endif
+ }
+ CK_TILE_DEVICE fp8x2_v amd_assembly_cvt_pk_bf8_f32(fp32_t a, fp32_t b)
+ {
+-    int16x2_t c;
+     static constexpr float d = 57344.0f;
+     static constexpr float e = -57344.0f;
++#if defined(CK_TILE_RDNA3_NO_PK_FP8)
++    a = __builtin_fminf(__builtin_fmaxf(a, e), d);
++    b = __builtin_fminf(__builtin_fmaxf(b, e), d);
++    fp8x2_v result;
++    result[0] = type_convert<fp8_t>(a);
++    result[1] = type_convert<fp8_t>(b);
++    return result;
++#else
++    int16x2_t c;
+     asm volatile("v_med3_f32 %1, %1, %3, %4\n"
+                  "v_med3_f32 %2, %2, %3, %4\n"
+                  "v_cvt_pk_bf8_f32 %0, %1, %2"
+                  : "=v"(c)
+                  : "v"(a), "v"(b), "v"(d), "v"(e));
+     return bit_cast<fp8x2_v>(c[0]);
++#endif
+ }
+ CK_TILE_DEVICE fp4x2_t amd_assembly_cvt_scalef32_pk_fp4_f32(fp32_t a, fp32_t b, fp32_t scale)
+ {

--- a/pkgs/amd-aiter/patches/0002-gfx1151-hip-reduce-rdna-fallbacks.patch
+++ b/pkgs/amd-aiter/patches/0002-gfx1151-hip-reduce-rdna-fallbacks.patch
@@ -1,0 +1,74 @@
+--- a/csrc/include/hip_reduce.h
++++ b/csrc/include/hip_reduce.h
+@@ -3,6 +3,15 @@
+ #include "hip_compat.h"
+ #include <rocprim/rocprim.hpp>
+ 
++// RDNA 3/3.5 lacks CDNA DPP row_bcast instructions. Use rocPRIM's swizzle
++// path for gfx11xx/gfx115x and keep the existing DPP code on CDNA.
++#if defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1102__) || \
++    defined(__gfx1103__) || defined(__gfx1150__) || defined(__gfx1151__) || \
++    defined(__gfx1152__) || defined(__gfx1153__)
++#define AITER_RDNA_NO_DPP_BCAST 1
++#endif
++
++
+ template <typename T, typename F>
+ __device__ constexpr T wave_reduce_ds(T local, F reduce_op)
+ {
+@@ -112,14 +121,28 @@ __device__ constexpr T wave_reduce(T local, F reduce_op)
+ 
+     if constexpr(WarpSize > 16)
+     {
++#if defined(AITER_RDNA_NO_DPP_BCAST)
++        // RDNA wave32: row_bcast:15 is unavailable. This swizzle mirrors
++        // lane 0..15 into lane 16..31 after the row-local reduction.
++        local = reduce_op(rocprim::detail::warp_swizzle<T, 0x1e0>(local), local);
++#else
+         // row_bcast:15
+         local = reduce_op(rocprim::detail::warp_move_dpp<T, 0x142>(local), local);
++#endif
+     }
+ 
+     if constexpr(WarpSize > 32)
+     {
++#if defined(AITER_RDNA_NO_DPP_BCAST)
++        // RDNA is wave32-only. A 64-wide reduction on gfx11xx means the caller
++        // selected a CDNA-only kernel shape, so fail at compile time instead of
++        // emitting illegal DPP row_bcast instructions.
++        static_assert(WarpSize <= 32,
++                      "WarpSize > 32 is not supported on RDNA (wave32 only)");
++#else
+         // row_bcast:31
+         local = reduce_op(rocprim::detail::warp_move_dpp<T, 0x143>(local), local);
++#endif
+     }
+ 
+     if constexpr(threadBroadcast && WarpSize > 4)
+@@ -166,13 +189,18 @@ __device__ constexpr T multithread_reduce(T data, F reduce_op, int thread_num)
+         data = reduce_op(rocprim::detail::warp_move_dpp<T, 0x4e>(data), data);
+         data = reduce_op(rocprim::detail::warp_move_dpp<T, 0x124>(data), data);
+         data = reduce_op(rocprim::detail::warp_move_dpp<T, 0x128>(data), data);
++#if defined(AITER_RDNA_NO_DPP_BCAST)
++        data = reduce_op(rocprim::detail::warp_swizzle<T, 0x1e0>(data), data);
++#else
+         data = reduce_op(rocprim::detail::warp_move_dpp<T, 0x142, 0xa>(data), data);
++#endif
+         if constexpr(threadBroadcast)
+         {
+             data = rocprim::warp_shuffle(data, thread_num - 1, thread_num);
+             // data = thread_broadcast<T, 32, WarpSize>(data, thread_num - 1);
+         }
+     }
++#if !defined(AITER_RDNA_NO_DPP_BCAST)
+     else if(thread_num == 64)
+     {
+         data = reduce_op(rocprim::detail::warp_move_dpp<T, 0xb1>(data), data);
+@@ -187,6 +215,7 @@ __device__ constexpr T multithread_reduce(T data, F reduce_op, int thread_num)
+             // data = thread_broadcast<T, 64, WarpSize>(data, thread_num - 1);
+         }
+     }
++#endif
+ 
+     return data;
+ }

--- a/pkgs/amd-aiter/patches/0003-jit-stage-writable-cache-inputs.patch
+++ b/pkgs/amd-aiter/patches/0003-jit-stage-writable-cache-inputs.patch
@@ -1,0 +1,59 @@
+--- a/csrc/cpp_itfs/utils.py
++++ b/csrc/cpp_itfs/utils.py
+@@ -18,6 +18,37 @@ import inspect
+ import json
+ 
+ 
++def _make_writable(path):
++    if not os.path.exists(path):
++        return
++
++    def chmod_owner_writable(target):
++        os.chmod(target, os.stat(target).st_mode | 0o200)
++
++    if os.path.isdir(path):
++        for root, dirs, files in os.walk(path):
++            chmod_owner_writable(root)
++            for name in dirs:
++                chmod_owner_writable(os.path.join(root, name))
++            for name in files:
++                chmod_owner_writable(os.path.join(root, name))
++    else:
++        chmod_owner_writable(path)
++
++
++def _copy_writable(src, dst):
++    if os.path.isdir(dst):
++        dst = os.path.join(dst, os.path.basename(src))
++    shutil.copyfile(src, dst)
++    _make_writable(dst)
++    return dst
++
++
++def _copytree_writable(src, dst):
++    shutil.copytree(src, dst, dirs_exist_ok=True, copy_function=_copy_writable)
++    _make_writable(dst)
++
++
+ def get_git_commit_id_short():
+     """??? commit ID (?? 7 ???)"""
+     try:
+@@ -170,14 +201,14 @@ def compile_lib(src_file, folder, includes=None, sources=None, cxxflags=None):
+ 
+         for include in includes + [f"{CK_DIR}/include"]:
+             if os.path.isdir(include):
+-                shutil.copytree(include, include_dir, dirs_exist_ok=True)
++                _copytree_writable(include, include_dir)
+             else:
+-                shutil.copy(include, include_dir)
++                _copy_writable(include, include_dir)
+         for source in sources:
+             if os.path.isdir(source):
+-                shutil.copytree(source, sub_build_dir, dirs_exist_ok=True)
++                _copytree_writable(source, sub_build_dir)
+             else:
+-                shutil.copy(source, sub_build_dir)
++                _copy_writable(source, sub_build_dir)
+         with open(f"{sub_build_dir}/{folder}.cpp", "w") as f:
+             f.write(src_file)
+ 

--- a/pkgs/amd-aiter/patches/0004-jit-template-use-rocm-env-and-gfx11-archs.patch
+++ b/pkgs/amd-aiter/patches/0004-jit-template-use-rocm-env-and-gfx11-archs.patch
@@ -1,0 +1,59 @@
+--- a/csrc/cpp_itfs/utils.py
++++ b/csrc/cpp_itfs/utils.py
+@@ -49,6 +49,23 @@
+     _make_writable(dst)
+ 
+ 
++def _rocm_tool(*parts):
++    root = os.environ.get("ROCM_HOME") or os.environ.get("ROCM_PATH") or "/opt/rocm"
++    return os.path.join(root, *parts)
++
++
++def _run_rocm_tool(*parts, args=()):
++    cmd = [_rocm_tool(*parts)] + list(args)
++    try:
++        return subprocess.run(cmd, capture_output=True, text=True, check=False).stdout
++    except FileNotFoundError:
++        fallback = [parts[-1]] + list(args)
++        try:
++            return subprocess.run(fallback, capture_output=True, text=True, check=False).stdout
++        except FileNotFoundError:
++            return ""
++
++
+ def get_git_commit_id_short():
+     """??? commit ID (?? 7 ???)"""
+     try:
+@@ -142,10 +159,11 @@
+ 
+ 
+ def get_hip_version():
+-    version = subprocess.run(
+-        "/opt/rocm/bin/hipconfig --version", shell=True, capture_output=True, text=True
+-    )
+-    return parse(version.stdout.split()[-1].rstrip("-").replace("-", "+"))
++    version = _run_rocm_tool("bin", "hipconfig", args=("--version",))
++    tokens = version.split()
++    if not tokens:
++        raise RuntimeError("hipconfig --version returned no output")
++    return parse(tokens[-1].rstrip("-").replace("-", "+"))
+ 
+ 
+ @lru_cache()
+@@ -168,6 +186,16 @@
+         "gfx940",
+         "gfx941",
+         "gfx942",
++        "gfx1100",
++        "gfx1101",
++        "gfx1102",
++        "gfx1103",
++        "gfx1150",
++        "gfx1151",
++        "gfx1152",
++        "gfx1153",
++        "gfx1200",
++        "gfx1201",
+         "gfx950",
+     ]
+ 

--- a/pkgs/sglang/default.nix
+++ b/pkgs/sglang/default.nix
@@ -1,0 +1,323 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  gnumake,
+  makeWrapper,
+  patchelf,
+  symlinkJoin,
+  python312Packages,
+  rocmSdk,
+  packageSuffix ? "rocm",
+  hsaOverrideGfxVersion ? null,
+}:
+
+let
+  pythonSitePackages = python312Packages.python.sitePackages;
+  rocmSitePackages = python312Packages.torch.passthru.sitePackages or null;
+  gpuArch = if lib.hasPrefix "gfx" packageSuffix then packageSuffix else null;
+  rocmSdkForJit = symlinkJoin {
+    name = "${rocmSdk.name or "rocm-sdk"}-sglang-jit";
+    paths = [ rocmSdk ];
+    postBuild = ''
+      rm -f "$out/bin/hipcc"
+      printf '%s\n' \
+        '#!${stdenv.shell}' \
+        'needs_xhip=0' \
+        'for arg in "$@"; do' \
+        '  case "$arg" in' \
+        '    *.cu|*.hip|*.cpp|*.cc|*.cxx) needs_xhip=1 ;;' \
+        '  esac' \
+        'done' \
+        'if [ "$needs_xhip" = 1 ]; then' \
+        '  exec ${rocmSdk}/bin/therock-hip-clang++ -x hip "$@"' \
+        'fi' \
+        'exec ${rocmSdk}/bin/therock-hip-clang++ "$@"' \
+        > "$out/bin/hipcc"
+      chmod 755 "$out/bin/hipcc"
+    '';
+  };
+  tvmFfiLibDir = "${python312Packages.apache-tvm-ffi}/${pythonSitePackages}/tvm_ffi/lib";
+  outlines-core_0_1_26 = python312Packages.buildPythonPackage rec {
+    pname = "outlines-core";
+    version = "0.1.26";
+    format = "wheel";
+
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/e2/1d/a36292b6198986bd9c3ff8c24355deb82ed5475403379ee40b5b5473e2e3/outlines_core-${version}-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+      hash = "sha256-6GobtGrcXL9t/Xp/5BBeDipMbgQXMqBTEmtBxSGh8iM=";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+    ];
+
+    buildInputs = [
+      stdenv.cc.cc.lib
+    ];
+
+    dependencies = with python312Packages; [
+      interegular
+      jsonschema
+    ];
+
+    pythonImportsCheck = [ "outlines_core" ];
+  };
+  outlines_0_1_11 = python312Packages.buildPythonPackage rec {
+    pname = "outlines";
+    version = "0.1.11";
+    format = "wheel";
+
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/13/b4/99ea4a122bef60e3fd6402d19665aff1f928e0daf8fac3044d0b73f72003/outlines-${version}-py3-none-any.whl";
+      hash = "sha256-9aXyJC7ZgC06q3qSeJv0AI1zTFdr6SWMwKKX9pASRyc=";
+    };
+
+    dependencies = with python312Packages; [
+      airportsdata
+      cloudpickle
+      diskcache
+      interegular
+      jinja2
+      jsonschema
+      lark
+      nest-asyncio
+      numpy
+      outlines-core_0_1_26
+      pycountry
+      pydantic
+      referencing
+      requests
+      torch
+      tqdm
+      typing-extensions
+    ];
+
+    pythonImportsCheck = [ "outlines" ];
+  };
+  torchaoNoChecks = python312Packages.torchao.overridePythonAttrs (old: {
+    doCheck = false;
+    nativeCheckInputs = [ ];
+    pythonImportsCheck = old.pythonImportsCheck or [ "torchao" ];
+  });
+  xgrammar_0_2_1 = python312Packages.buildPythonPackage rec {
+    pname = "xgrammar";
+    version = "0.2.1";
+    format = "wheel";
+
+    src = fetchurl {
+      url = "https://files.pythonhosted.org/packages/96/4b/327b3cf702b685a2be28d15490faa4beeac00c4fbcf9bb2d7db0fda32931/xgrammar-${version}-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl";
+      hash = "sha256-y8YBTcHJL8MXsUUZEhyBY/41/ZNBeeWkXYP3gP8jGCY=";
+    };
+
+    nativeBuildInputs = [
+      autoPatchelfHook
+      patchelf
+    ];
+
+    buildInputs = [
+      python312Packages.apache-tvm-ffi
+      stdenv.cc.cc.lib
+    ];
+
+    autoPatchelfIgnoreMissingDeps = [
+      "libtvm_ffi.so"
+    ];
+
+    dependencies = with python312Packages; [
+      apache-tvm-ffi
+      numpy
+      pydantic
+      torch
+      transformers
+      triton
+      typing-extensions
+    ];
+
+    pythonImportsCheck = [ "xgrammar" ];
+
+    postFixup = ''
+      patchelf --add-rpath ${lib.escapeShellArg tvmFfiLibDir} \
+        "$out/${pythonSitePackages}/xgrammar/libxgrammar_bindings.so"
+    '';
+  };
+in
+assert lib.assertMsg (
+  rocmSitePackages != null
+) "sglang-rocm requires the TheRock torch wheel package with passthru.sitePackages";
+python312Packages.buildPythonApplication rec {
+  pname = "sglang-rocm-${packageSuffix}";
+  version = "0.5.14";
+  format = "wheel";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/1a/f8/49727c6252937cd8b97aade22c7c0c6be86ea53b4a7f64eebb8cbf8accdd/sglang-${version}-cp312-cp312-manylinux_2_34_x86_64.whl";
+    hash = "sha256-RXOqx3QEW6kmurL376qtexIOT4RpXM8nxZ0nb4Vt7Kg=";
+  };
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    stdenv.cc.cc.lib
+  ];
+
+  dontUseNinjaBuild = true;
+
+  dependencies = with python312Packages; [
+    aiohttp
+    amd-aiter
+    anthropic
+    apache-tvm-ffi
+    blobfile
+    build
+    compressed-tensors
+    datasets
+    distro
+    easydict
+    einops
+    fastapi
+    gguf
+    interegular
+    ipython
+    kernels
+    llguidance
+    python312Packages."mistral-common"
+    modelscope
+    msgspec
+    ninja
+    numpy
+    nvidia-ml-py
+    openai
+    openai-harmony
+    orjson
+    outlines_0_1_11
+    packaging
+    partial-json-parser
+    pillow
+    prometheus-client
+    psutil
+    pybase64
+    pydantic
+    python-multipart
+    pyzmq
+    requests
+    scipy
+    sentencepiece
+    setproctitle
+    smg-grpc-servicer
+    soundfile
+    tiktoken
+    timm
+    torch
+    torch-memory-saver
+    torchaoNoChecks
+    torchaudio
+    torchvision
+    tqdm
+    transformers
+    uvicorn
+    uvloop
+    watchfiles
+    xgrammar_0_2_1
+  ];
+
+  pythonRemoveDeps = [
+    "cuda-python"
+    "flash-attn-4"
+    "flashinfer-cubin"
+    "flashinfer-python"
+    "flashinfer_cubin"
+    "flashinfer_python"
+    "nvidia-cutlass-dsl"
+    "nvidia-mathdx"
+    "py-spy"
+    "quack-kernels"
+    "sgl-deep-gemm"
+    "sglang-kernel"
+    "tilelang"
+    "torchcodec"
+    "tokenspeed-mla"
+    "tokenspeed_mla"
+  ];
+
+  pythonRelaxDeps = [
+    "apache-tvm-ffi"
+    "blobfile"
+    "kernels"
+    "llguidance"
+    "openai"
+    "openai-harmony"
+    "outlines"
+    "timm"
+    "torch"
+    "torchaudio"
+    "torchcodec"
+    "transformers"
+    "xgrammar"
+  ];
+
+  postInstall = ''
+    for patch_file in ${./patches}/*.patch; do
+      patch -p1 -d "$out/${pythonSitePackages}" < "$patch_file"
+    done
+  '';
+
+  postFixup = ''
+    wrapPythonPrograms
+
+    rocm_site=${lib.escapeShellArg rocmSitePackages}
+    rocm_lib_path="$(find "$rocm_site" -type d \( -name lib -o -name lib64 \) -print | paste -sd:)"
+
+    wrap_args=(
+      --set HIP_PLATFORM amd
+      --set ROCM_HOME ${lib.escapeShellArg rocmSdkForJit}
+      --set ROCM_PATH ${lib.escapeShellArg rocmSdkForJit}
+      --set HIP_PATH ${lib.escapeShellArg rocmSdkForJit}
+      --set CC ${lib.escapeShellArg "${stdenv.cc}/bin/cc"}
+      --set CXX ${lib.escapeShellArg "${rocmSdkForJit}/bin/therock-hip-clang++"}
+      --run 'if [ -z "''${AITER_JIT_DIR:-}" ]; then export AITER_JIT_DIR="''${XDG_CACHE_HOME:-$HOME/.cache}/aiter/sglang-${version}-${packageSuffix}-py312/jit"; fi'
+      --run 'if [ -z "''${AITER_ROOT_DIR:-}" ]; then export AITER_ROOT_DIR="''${XDG_CACHE_HOME:-$HOME/.cache}/aiter/sglang-${version}-${packageSuffix}-py312/root"; fi'
+      --prefix PATH : ${
+        lib.escapeShellArg (
+          lib.makeBinPath [
+            rocmSdkForJit
+            gnumake
+            python312Packages.ninja
+          ]
+        )
+      }
+      --prefix LD_LIBRARY_PATH : "$rocm_lib_path"
+    )
+    ${lib.optionalString (gpuArch != null) ''
+      wrap_args+=(
+        --set GPU_ARCHS ${lib.escapeShellArg gpuArch}
+        --set PYTORCH_ROCM_ARCH ${lib.escapeShellArg gpuArch}
+      )
+    ''}
+    ${lib.optionalString (hsaOverrideGfxVersion != null) ''
+      wrap_args+=(--set HSA_OVERRIDE_GFX_VERSION ${lib.escapeShellArg hsaOverrideGfxVersion})
+    ''}
+
+    for bin in "$out/bin/sglang" "$out/bin/killall_sglang"; do
+      [ -x "$bin" ] || continue
+      wrapProgram "$bin" "''${wrap_args[@]}"
+    done
+  '';
+
+  pythonImportsCheck = [
+    "sglang"
+  ];
+
+  meta = {
+    description = "SGLang serving framework packaged against the TheRock ROCm Python stack";
+    homepage = "https://github.com/sgl-project/sglang";
+    license = lib.licenses.asl20;
+    mainProgram = "sglang";
+    maintainers = with lib.maintainers; [ georgewhewell ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/sglang/patches/0001-rocm-hisparse-optional-sgl-kernel.patch
+++ b/pkgs/sglang/patches/0001-rocm-hisparse-optional-sgl-kernel.patch
@@ -1,0 +1,316 @@
+diff --git a/sglang/srt/mem_cache/hisparse_memory_pool.py b/sglang/srt/mem_cache/hisparse_memory_pool.py
+index 2d78f2e4..a5f91030 100644
+--- a/sglang/srt/mem_cache/hisparse_memory_pool.py
++++ b/sglang/srt/mem_cache/hisparse_memory_pool.py
+@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
+ _is_cuda = is_cuda()
+ _is_hip = is_hip()
+ if _is_cuda or _is_hip:
+-    from sgl_kernel.kvcacheio import transfer_kv_all_layer_mla
++    try:
++        from sgl_kernel.kvcacheio import transfer_kv_all_layer_mla
++    except ImportError:
++        transfer_kv_all_layer_mla = None
+ else:
+ 
+     def transfer_kv_all_layer_mla(*args, **kwargs):
+@@ -106,6 +109,11 @@ class HiSparseDSATokenToKVPool(DSATokenToKVPool):
+         return super().get_mla_kv_buffer(layer, loc, dst_dtype)
+ 
+     def transfer_values_on_device(self, dst_indices, src_indices):
++        if transfer_kv_all_layer_mla is None:
++            raise RuntimeError(
++                "HiSparse device KV transfer requires sgl_kernel.kvcacheio, "
++                "but sgl_kernel is not available in this ROCm build."
++            )
+         transfer_kv_all_layer_mla(
+             src_layers=self.data_ptrs,
+             dst_layers=self.data_ptrs,
+diff --git a/sglang/srt/mem_cache/memory_pool_host.py b/sglang/srt/mem_cache/memory_pool_host.py
+index aa301c0a..3588e5c2 100644
+--- a/sglang/srt/mem_cache/memory_pool_host.py
++++ b/sglang/srt/mem_cache/memory_pool_host.py
+@@ -49,21 +49,43 @@ _is_npu = is_npu()
+ _is_xpu = is_xpu()
+ _is_mps = is_mps()
+ if _is_cuda or _is_hip:
+-    from sgl_kernel.kvcacheio import (
+-        transfer_kv_all_layer,
+-        transfer_kv_all_layer_direct_lf_pf,
+-        transfer_kv_all_layer_lf_pf,
+-        transfer_kv_all_layer_lf_ph,
+-        transfer_kv_all_layer_mla,
+-        transfer_kv_all_layer_mla_lf_pf,
+-        transfer_kv_direct,
+-        transfer_kv_per_layer,
+-        transfer_kv_per_layer_direct_pf_lf,
+-        transfer_kv_per_layer_mla,
+-        transfer_kv_per_layer_mla_pf_lf,
+-        transfer_kv_per_layer_pf_lf,
+-        transfer_kv_per_layer_ph_lf,
+-    )
++    try:
++        from sgl_kernel.kvcacheio import (
++            transfer_kv_all_layer,
++            transfer_kv_all_layer_direct_lf_pf,
++            transfer_kv_all_layer_lf_pf,
++            transfer_kv_all_layer_lf_ph,
++            transfer_kv_all_layer_mla,
++            transfer_kv_all_layer_mla_lf_pf,
++            transfer_kv_direct,
++            transfer_kv_per_layer,
++            transfer_kv_per_layer_direct_pf_lf,
++            transfer_kv_per_layer_mla,
++            transfer_kv_per_layer_mla_pf_lf,
++            transfer_kv_per_layer_pf_lf,
++            transfer_kv_per_layer_ph_lf,
++        )
++    except ImportError:
++
++        def _missing_sgl_kernel_kvcacheio(*args, **kwargs):
++            raise RuntimeError(
++                "Host KV cache transfer requires sgl_kernel.kvcacheio, but "
++                "sglang-kernel is not available in this ROCm build."
++            )
++
++        transfer_kv_all_layer = _missing_sgl_kernel_kvcacheio
++        transfer_kv_all_layer_direct_lf_pf = _missing_sgl_kernel_kvcacheio
++        transfer_kv_all_layer_lf_pf = _missing_sgl_kernel_kvcacheio
++        transfer_kv_all_layer_lf_ph = _missing_sgl_kernel_kvcacheio
++        transfer_kv_all_layer_mla = _missing_sgl_kernel_kvcacheio
++        transfer_kv_all_layer_mla_lf_pf = _missing_sgl_kernel_kvcacheio
++        transfer_kv_direct = _missing_sgl_kernel_kvcacheio
++        transfer_kv_per_layer = _missing_sgl_kernel_kvcacheio
++        transfer_kv_per_layer_direct_pf_lf = _missing_sgl_kernel_kvcacheio
++        transfer_kv_per_layer_mla = _missing_sgl_kernel_kvcacheio
++        transfer_kv_per_layer_mla_pf_lf = _missing_sgl_kernel_kvcacheio
++        transfer_kv_per_layer_pf_lf = _missing_sgl_kernel_kvcacheio
++        transfer_kv_per_layer_ph_lf = _missing_sgl_kernel_kvcacheio
+ if _is_npu:
+     from sgl_kernel_npu.kvcacheio import TransferDirection, transfer_kv_dim_exchange
+ 
+diff --git a/sglang/srt/layers/activation.py b/sglang/srt/layers/activation.py
+index 292be3c..064bfbc 100644
+--- a/sglang/srt/layers/activation.py
++++ b/sglang/srt/layers/activation.py
+@@ -67,7 +67,10 @@ if _is_cuda:
+ elif _is_xpu:
+     from sgl_kernel import gelu_and_mul, gelu_tanh_and_mul, silu_and_mul
+ elif _is_hip:
+-    from sgl_kernel import gelu_and_mul, gelu_quick, gelu_tanh_and_mul, silu_and_mul
++    try:
++        from sgl_kernel import gelu_and_mul, gelu_quick, gelu_tanh_and_mul, silu_and_mul
++    except ImportError:
++        gelu_and_mul = gelu_quick = gelu_tanh_and_mul = silu_and_mul = None
+ elif _is_musa:
+     from sglang.srt.utils.patch_torch import register_fake_if_exists
+ 
+@@ -106,6 +109,9 @@ class SiluAndMul(MultiPlatformOp):
+         silu_and_mul(x, out)
+         return out
+ 
++    def forward_hip(self, x: torch.Tensor) -> torch.Tensor:
++        return self.forward_native(x)
++
+     def forward_aiter(self, x: torch.Tensor, limit: float = 0.0) -> torch.Tensor:
+         d = x.shape[-1] // 2
+         output_shape = x.shape[:-1] + (d,)
+@@ -173,6 +179,9 @@ class GeluAndMul(MultiPlatformOp):
+     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+         return self._forward_impl(x)
+ 
++    def forward_hip(self, x: torch.Tensor) -> torch.Tensor:
++        return self.forward_native(x)
++
+     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+         return self._forward_impl(x)
+ 
+@@ -211,6 +220,9 @@ class ReLU2(MultiPlatformOp):
+     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
+         return relu2(x)
+ 
++    def forward_hip(self, x: torch.Tensor) -> torch.Tensor:
++        return self.forward_native(x)
++
+ 
+ class QuickGELU(MultiPlatformOp):
+     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
+@@ -220,6 +232,8 @@ class QuickGELU(MultiPlatformOp):
+         return self.forward_native(x)
+ 
+     def forward_hip(self, x: torch.Tensor) -> torch.Tensor:
++        if gelu_quick is None:
++            return self.forward_native(x)
+         out = torch.empty(x.shape, dtype=x.dtype, device=x.device)
+         gelu_quick(x, out)
+         return out
+diff --git a/sglang/srt/layers/attention/flashattention_backend.py b/sglang/srt/layers/attention/flashattention_backend.py
+index 0a50f0d..f5eac4d 100644
+--- a/sglang/srt/layers/attention/flashattention_backend.py
++++ b/sglang/srt/layers/attention/flashattention_backend.py
+@@ -31,7 +31,15 @@ if TYPE_CHECKING:
+     from sglang.srt.layers.radix_attention import RadixAttention
+     from sglang.srt.model_executor.model_runner import ModelRunner
+ 
+-from sgl_kernel import merge_state_v2
++try:
++    from sgl_kernel import merge_state_v2
++except ImportError:
++
++    def merge_state_v2(*args, **kwargs):
++        raise RuntimeError(
++            "flashattention merge_state_v2 requires sglang-kernel, but "
++            "sglang-kernel is not available in this ROCm build."
++        )
+ 
+ from sglang.jit_kernel.flash_attention import (
+     flash_attn_varlen_func,
+diff --git a/sglang/srt/layers/attention/merge_state.py b/sglang/srt/layers/attention/merge_state.py
+index 245418a..df855e4 100644
+--- a/sglang/srt/layers/attention/merge_state.py
++++ b/sglang/srt/layers/attention/merge_state.py
+@@ -1,7 +1,10 @@
+ from typing import Optional, Tuple
+ 
+ import torch
+-from sgl_kernel import merge_state_v2
++try:
++    from sgl_kernel import merge_state_v2
++except ImportError:
++    merge_state_v2 = None
+ 
+ from sglang.srt.layers.attention.triton_ops.merge_state import merge_state_triton
+ from sglang.srt.utils import is_cuda
+@@ -33,6 +36,7 @@ def merge_state(
+ ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+     if (
+         _is_cuda
++        and merge_state_v2 is not None
+         and _supported_dtypes(prefix_output)
+         and _supported_headdim(prefix_output)
+     ):
+diff --git a/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py b/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+index b92654f..f671609 100644
+--- a/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
++++ b/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+@@ -59,7 +59,17 @@ if _is_cuda:
+ elif _is_cpu and _is_cpu_amx_available:
+     pass
+ elif _is_hip:
+-    from sgl_kernel import gelu_and_mul, silu_and_mul
++    try:
++        from sgl_kernel import gelu_and_mul, silu_and_mul
++    except ImportError:
++
++        def silu_and_mul(input: torch.Tensor, output: torch.Tensor) -> None:
++            d = input.shape[-1] // 2
++            output.copy_(F.silu(input[..., :d]) * input[..., d:])
++
++        def gelu_and_mul(input: torch.Tensor, output: torch.Tensor) -> None:
++            d = input.shape[-1] // 2
++            output.copy_(F.gelu(input[..., :d], approximate="tanh") * input[..., d:])
+ 
+     if _use_aiter:
+         try:
+diff --git a/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py b/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+index 5d6f456..669afbe 100644
+--- a/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
++++ b/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+@@ -16,7 +16,10 @@ _is_xpu = is_xpu()
+ _is_musa = is_musa()
+ 
+ if _is_cuda or _is_hip or _is_xpu or _is_musa:
+-    from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
++    try:
++        from sgl_kernel import moe_align_block_size as sgl_moe_align_block_size
++    except ImportError:
++        sgl_moe_align_block_size = None
+ 
+ 
+ def moe_align_block_size(
+@@ -83,7 +86,7 @@ def moe_align_block_size(
+         from sglang.srt.lora.trtllm_lora_temp.environ import lora_envs
+ 
+         use_jit_align = lora_envs.SGLANG_OPT_USE_JIT_KERNEL_MOE_ALIGN.get()
+-    if use_jit_align:
++    if use_jit_align or sgl_moe_align_block_size is None:
+         from sglang.jit_kernel.moe_align import (
+             moe_align_block_size as jit_moe_align_block_size,
+         )
+diff --git a/sglang/srt/layers/moe/topk.py b/sglang/srt/layers/moe/topk.py
+index 4f504e2..9211c60 100644
+--- a/sglang/srt/layers/moe/topk.py
++++ b/sglang/srt/layers/moe/topk.py
+@@ -174,12 +174,20 @@ if _is_cuda:
+         pass
+ 
+ if _is_cuda or _is_hip or _is_xpu:
+-    from sgl_kernel import topk_softmax
++    try:
++        from sgl_kernel import topk_softmax
++    except ImportError:
++
++        def topk_softmax(*args, **kwargs):
++            raise RuntimeError(
++                "MoE top-k requires sgl_kernel.topk_softmax, but sglang-kernel "
++                "is not available in this ROCm build."
++            )
+ 
+     try:
+         from sgl_kernel import topk_sigmoid
+     except ImportError:
+-        pass
++        topk_sigmoid = None
+ if _use_aiter:
+     try:
+         from aiter import biased_grouped_topk as aiter_biased_grouped_topk
+diff --git a/sglang/srt/layers/rotary_embedding/base.py b/sglang/srt/layers/rotary_embedding/base.py
+index 945e3f8..eab26c1 100644
+--- a/sglang/srt/layers/rotary_embedding/base.py
++++ b/sglang/srt/layers/rotary_embedding/base.py
+@@ -111,7 +111,7 @@ class RotaryEmbedding(MultiPlatformOp):
+             if _is_cuda:
+                 from sglang.jit_kernel.rope import rotary_embedding
+             elif _is_hip:
+-                from sgl_kernel import rotary_embedding
++                rotary_embedding = None
+             else:
+                 from vllm._custom_ops import rotary_embedding
+ 
+@@ -434,6 +434,20 @@ class RotaryEmbedding(MultiPlatformOp):
+                 )
+         return query, key
+ 
++    def forward_hip(
++        self,
++        positions: torch.Tensor,
++        query: torch.Tensor,
++        key: torch.Tensor,
++        offsets: Optional[torch.Tensor] = None,
++        fused_set_kv_buffer_arg: Optional[Union[FusedSetKVBufferArg, dict]] = None,
++    ) -> Tuple[torch.Tensor, torch.Tensor]:
++        if fused_set_kv_buffer_arg is not None:
++            return self.forward_cuda(
++                positions, query, key, offsets, fused_set_kv_buffer_arg
++            )
++        return self.forward_native(positions, query, key, offsets)
++
+     def extra_repr(self) -> str:
+         s = f"head_size={self.head_size}, rotary_dim={self.rotary_dim}"
+         s += f", max_position_embeddings={self.max_position_embeddings}"
+diff --git a/sglang/srt/speculative/spec_utils.py b/sglang/srt/speculative/spec_utils.py
+index 312f366..c3936ae 100644
+--- a/sglang/srt/speculative/spec_utils.py
++++ b/sglang/srt/speculative/spec_utils.py
+@@ -64,7 +64,10 @@ if TYPE_CHECKING:
+ if _is_cuda:
+     from sgl_kernel import fast_topk
+ elif _is_hip:
+-    from sgl_kernel import fast_topk
++    try:
++        from sgl_kernel import fast_topk
++    except ImportError:
++        from sglang.srt.utils.common import fast_topk
+ else:
+     from sglang.srt.utils.common import fast_topk
+ 

--- a/pkgs/sglang/patches/0002-rocm-default-triton-and-xgrammar-fallback.patch
+++ b/pkgs/sglang/patches/0002-rocm-default-triton-and-xgrammar-fallback.patch
@@ -1,0 +1,56 @@
+diff --git a/sglang/srt/constrained/xgrammar_backend.py b/sglang/srt/constrained/xgrammar_backend.py
+index 67f701b..e3d6a01 100644
+--- a/sglang/srt/constrained/xgrammar_backend.py
++++ b/sglang/srt/constrained/xgrammar_backend.py
+@@ -41,7 +41,12 @@ _is_hip = is_hip()
+ 
+ if _is_hip:
+-    from sgl_kernel import apply_token_bitmask_inplace_cuda
++    try:
++        from sgl_kernel import apply_token_bitmask_inplace_cuda
++    except ImportError:
++        from sglang.srt.constrained.triton_ops.bitmask_ops import (
++            apply_token_bitmask_inplace_triton as apply_token_bitmask_inplace_cuda,
++        )
+ else:
+     from sglang.srt.constrained.triton_ops.bitmask_ops import (
+         apply_token_bitmask_inplace_triton,
+     )
+diff --git a/sglang/srt/server_args.py b/sglang/srt/server_args.py
+index b1ffdec..573ecb4 100644
+--- a/sglang/srt/server_args.py
++++ b/sglang/srt/server_args.py
+@@ -4445,7 +4445,10 @@ class ServerArgs:
+             ):
+                 return "trtllm_mha"
+             elif is_hip():
+-                return "aiter"
++                rocm_arch = os.environ.get("PYTORCH_ROCM_ARCH") or os.environ.get("GPU_ARCHS", "")
++                if rocm_arch.startswith(("gfx11", "gfx12")):
++                    return "triton"
++                return "aiter"
+             elif is_mps():
+                 return "torch_native"
+             else:
+@@ -4459,13 +4462,15 @@ class ServerArgs:
+             elif is_sm100_supported():
+                 return "flashinfer"
+             elif is_hip():
+-                head_num = model_config.get_num_kv_heads(self.tp_size)
+-                # TODO current aiter only support head number 16 or 128 head number
+-                if head_num == 128 or head_num == 16:
+-                    return "aiter"
+-                else:
+-                    return "triton"
++                rocm_arch = os.environ.get("PYTORCH_ROCM_ARCH") or os.environ.get("GPU_ARCHS", "")
++                if rocm_arch.startswith(("gfx11", "gfx12")):
++                    return "triton"
++                head_num = model_config.get_num_kv_heads(self.tp_size)
++                # TODO current aiter only support head number 16 or 128 head number
++                if head_num == 128 or head_num == 16:
++                    return "aiter"
++                return "triton"
+             elif is_mps():
+                 return "torch_native"
+             else:
+                 return "triton"


### PR DESCRIPTION
Summary:
- add a ROCm SGLang package for the TheRock Python stack
- add the local AITER override/patches needed for gfx1151 JIT compatibility
- default SGLang attention to Triton only on RDNA/gfx11-gfx12; keep AITER as the ROCm default elsewhere
- isolate AITER JIT/root caches per SGLang package version and add ninja to the runtime wrapper PATH
- let xgrammar fall back without sglang-kernel

Tested:
- nix fmt
- statix check .
- nix build .#legacyPackages.x86_64-linux.gfx1151.sglang-rocm
- Qwen3-0.6B smoke on strix-2 via /v1/models and /v1/completions

AITER attention status on gfx1151:
- full AITER decode hits AITER pa_ragged.cuh UNREACHABLE_CODE in the upstream RDNA path
- forcing the paged-attention guard open still fails to compile: __builtin_amdgcn_mfma_f32_16x16x16bf16_1k needs target feature mai-insts
