### PR TITLE
Add SpacemiT K3 AI packages

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -178,6 +178,23 @@
         "type": "github"
       }
     },
+    "llama-cpp-spacemit": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783141934,
+        "narHash": "sha256-Z8APQR0Xp9/zm+izIW0ICY8NhD5RQbZC/G49z3j9bJE=",
+        "owner": "spacemit-com",
+        "repo": "llama.cpp",
+        "rev": "86d4ff230bdfef62de1cc4987783a8d29af66d49",
+        "type": "github"
+      },
+      "original": {
+        "owner": "spacemit-com",
+        "ref": "v0.1.5",
+        "repo": "llama.cpp",
+        "type": "github"
+      }
+    },
     "mlx-src": {
       "flake": false,
       "locked": {
@@ -243,9 +260,11 @@
         "ec-su-axb35": "ec-su-axb35",
         "fastflowlm": "fastflowlm",
         "llama-cpp-master": "llama-cpp-master",
+        "llama-cpp-spacemit": "llama-cpp-spacemit",
         "mlx-src": "mlx-src",
         "nix-ai-tools": "nix-ai-tools",
         "nixpkgs": "nixpkgs",
+        "spine-triton": "spine-triton",
         "therock-src-7-13-gfx1151-base-half-011b45bd": "therock-src-7-13-gfx1151-base-half-011b45bd",
         "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84": "therock-src-7-13-gfx1151-base-rocm-cmake-ec512d84",
         "therock-src-7-13-gfx1151-compiler-amd-llvm-1e702164": "therock-src-7-13-gfx1151-compiler-amd-llvm-1e702164",
@@ -305,6 +324,25 @@
         "vllm-src": "vllm-src",
         "xdna-driver-src": "xdna-driver-src",
         "xrt-src": "xrt-src"
+      }
+    },
+    "spine-triton": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1780563047,
+        "narHash": "sha256-z7t6hb+rQXqjDt0OwdcWkeDXosi4Vw+LsSQ9IYL1Zqw=",
+        "ref": "refs/tags/0.5.5",
+        "rev": "c62b11c5ea994ed6f7ce1d5ac881f14fc5e4aba4",
+        "revCount": 444,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/spacemit-com/spine-triton.git"
+      },
+      "original": {
+        "ref": "refs/tags/0.5.5",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/spacemit-com/spine-triton.git"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,16 @@
       flake = false;
     };
 
+    llama-cpp-spacemit = {
+      url = "github:spacemit-com/llama.cpp/v0.1.5";
+      flake = false;
+    };
+
+    spine-triton = {
+      url = "git+https://github.com/spacemit-com/spine-triton.git?ref=refs/tags/0.5.5&submodules=1";
+      flake = false;
+    };
+
     fastflowlm = {
       url = "github:FastFlowLM/FastFlowLM";
       flake = false;
@@ -387,6 +397,9 @@
       };
 
       thunderboltIbverbsOverlay = inputs.thunderbolt-ibverbs.overlays.default;
+      spacemitK3Overlay = import ./overlays/spacemit-k3.nix {
+        inherit inputs inputVersion;
+      };
 
       # Re-export thunderbolt-ibverbs flake packages under the names
       # downstream callers expect. The upstream package set uses
@@ -600,6 +613,7 @@
         python = self.lib.mkPythonOverlay {
           provider = "nixpkgs";
         };
+        spacemitK3 = spacemitK3Overlay;
       };
 
       # NixOS modules
@@ -648,9 +662,10 @@
       packages = perSystem (
         pkgs:
         let
+          system = pkgs.stdenv.hostPlatform.system;
           s = defaultRocmTarget.packageSuffix;
-          aiTools = inputs.nix-ai-tools.packages.${pkgs.stdenv.hostPlatform.system};
-          cudaPkgs = cudaPkgsFor pkgs.stdenv.hostPlatform.system;
+          aiTools = inputs.nix-ai-tools.packages.${system};
+          cudaPkgs = cudaPkgsFor system;
           packageRuntimeEnv = import ./lib/runtime-env.nix { inherit lib; };
           inherit (packageRuntimeEnv) wrapRuntimeEnv;
           jacclPackage = pkgs.callPackage ./pkgs/jaccl (
@@ -739,6 +754,25 @@
             jaccl = jacclPackage;
           };
 
+          spacemitK3Packages = lib.optionalAttrs (system == "x86_64-linux") (
+            let
+              spacemitPkgs = import nixpkgs {
+                inherit system;
+                config.allowUnfree = true;
+                overlays = [ spacemitK3Overlay ];
+              };
+            in
+            {
+              inherit (spacemitPkgs)
+                llama-cpp-spacemit
+                spacemit-k3-runtime
+                spacemit-k3-spine-mlir
+                spacemit-k3-toolchain
+                spine-triton-source
+                ;
+            }
+          );
+
           # Two-host vLLM transport-matrix driver. The driver only needs the
           # vLLM closure to expose both `vllm` and `ray`, so join the default
           # ROCm vLLM package with ray rather than baking ray into vllm-rocm.
@@ -805,6 +839,7 @@
             };
         in
         genericPackages
+        // spacemitK3Packages
         // lib.optionalAttrs pkgs.stdenv.isLinux linuxPackages
         // lib.optionalAttrs pkgs.stdenv.isDarwin darwinPackages
       );

--- a/overlays/spacemit-k3.nix
+++ b/overlays/spacemit-k3.nix
@@ -1,0 +1,37 @@
+{
+  inputs,
+  inputVersion,
+}:
+
+final: _prev:
+
+let
+  buildPkgs = final.pkgsBuildBuild;
+  llamaVersion = inputVersion "0.1.5" inputs.llama-cpp-spacemit;
+  llamaCommit = inputs.llama-cpp-spacemit.shortRev or inputs.llama-cpp-spacemit.rev or "unknown";
+in
+{
+  spacemit-k3-toolchain = buildPkgs.callPackage ../pkgs/spacemit/toolchain { };
+
+  spacemit-k3-runtime = buildPkgs.callPackage ../pkgs/spacemit/runtime {
+    spacemitK3Toolchain = final.spacemit-k3-toolchain;
+  };
+
+  spacemit-k3-spine-mlir = buildPkgs.callPackage ../pkgs/spacemit/spine-mlir {
+    spacemitK3Toolchain = final.spacemit-k3-toolchain;
+  };
+
+  spine-triton-source = buildPkgs.callPackage ../pkgs/spacemit/spine-triton {
+    src = inputs.spine-triton;
+    version = inputVersion "0.5.5" inputs.spine-triton;
+    spineMlir = final.spacemit-k3-spine-mlir;
+  };
+
+  llama-cpp-spacemit = buildPkgs.callPackage ../pkgs/llama-cpp-spacemit {
+    src = inputs.llama-cpp-spacemit;
+    version = llamaVersion;
+    commit = llamaCommit;
+    spacemitK3Toolchain = final.spacemit-k3-toolchain;
+    spacemitK3Runtime = final.spacemit-k3-runtime;
+  };
+}

--- a/pkgs/llama-cpp-spacemit/default.nix
+++ b/pkgs/llama-cpp-spacemit/default.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenvNoCC,
+  cmake,
+  gcc,
+  ninja,
+  patchelf,
+  src,
+  version,
+  commit,
+  spacemitK3Toolchain,
+  spacemitK3Runtime,
+}:
+
+let
+  runtimeRpath = lib.concatStringsSep ":" [
+    "$out/lib"
+    "${spacemitK3Runtime}/sysroot/lib"
+    "${spacemitK3Runtime}/riscv64-unknown-linux-gnu/lib"
+  ];
+in
+stdenvNoCC.mkDerivation {
+  pname = "llama-cpp-spacemit";
+  inherit src version;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    patchelf
+  ];
+
+  dontPatchELF = true;
+  dontStrip = true;
+
+  env.RISCV_ROOT_PATH = spacemitK3Toolchain;
+
+  cmakeFlags = [
+    (lib.cmakeFeature "CMAKE_AR" "${spacemitK3Toolchain}/bin/riscv64-unknown-linux-gnu-ar")
+    (lib.cmakeFeature "CMAKE_RANLIB" "${spacemitK3Toolchain}/bin/riscv64-unknown-linux-gnu-ranlib")
+    (lib.cmakeFeature "CMAKE_STRIP" "${spacemitK3Toolchain}/bin/riscv64-unknown-linux-gnu-strip")
+    (lib.cmakeFeature "CMAKE_TOOLCHAIN_FILE" "${src}/cmake/riscv64-spacemit-linux-gnu-gcc.cmake")
+    (lib.cmakeFeature "CMAKE_INSTALL_PREFIX" "${placeholder "out"}")
+    (lib.cmakeFeature "HOST_CXX_COMPILER" "${gcc}/bin/g++")
+    (lib.cmakeFeature "LLAMA_BUILD_COMMIT" commit)
+    (lib.cmakeFeature "LLAMA_BUILD_NUMBER" "0")
+    (lib.cmakeBool "BUILD_SHARED_LIBS" true)
+    (lib.cmakeBool "GGML_BLAS" false)
+    (lib.cmakeBool "GGML_CLBLAST" false)
+    (lib.cmakeBool "GGML_CPU_REPACK" false)
+    (lib.cmakeBool "GGML_CPU_RISCV64_SPACEMIT" true)
+    (lib.cmakeBool "GGML_CUDA" false)
+    (lib.cmakeBool "GGML_HIP" false)
+    (lib.cmakeBool "GGML_METAL" false)
+    (lib.cmakeBool "GGML_OPENMP" false)
+    (lib.cmakeBool "GGML_RPC" true)
+    (lib.cmakeBool "GGML_RVV" true)
+    (lib.cmakeBool "GGML_RV_ZBA" true)
+    (lib.cmakeBool "GGML_RV_ZFH" true)
+    (lib.cmakeBool "GGML_RV_ZICBOP" true)
+    (lib.cmakeBool "GGML_RV_ZIHINTPAUSE" true)
+    (lib.cmakeBool "GGML_RV_ZVFH" true)
+    (lib.cmakeBool "GGML_VULKAN" false)
+    (lib.cmakeBool "LLAMA_BUILD_EXAMPLES" false)
+    (lib.cmakeBool "LLAMA_BUILD_SERVER" true)
+    (lib.cmakeBool "LLAMA_BUILD_TESTS" false)
+    (lib.cmakeBool "LLAMA_BUILD_UI" false)
+    (lib.cmakeBool "LLAMA_CURL" false)
+    (lib.cmakeBool "LLAMA_OPENSSL" false)
+  ];
+
+  postInstall = ''
+    ln -sf "$out/bin/llama-cli" "$out/bin/llama"
+
+    if [ -e "$out/bin/rpc-server" ] && [ ! -e "$out/bin/llama-rpc-server" ]; then
+      ln -s rpc-server "$out/bin/llama-rpc-server"
+    fi
+
+    mkdir -p "$out/include"
+    cp "$src/include/llama.h" "$out/include/"
+  '';
+
+  postFixup = ''
+    while IFS= read -r -d "" elf; do
+      if old_rpath=$(patchelf --print-rpath "$elf" 2>/dev/null); then
+        patchelf --set-rpath "${runtimeRpath}''${old_rpath:+:$old_rpath}" "$elf" 2>/dev/null || true
+      fi
+      if patchelf --print-interpreter "$elf" >/dev/null 2>&1; then
+        patchelf --set-interpreter "${spacemitK3Runtime}/sysroot/lib/ld-linux-riscv64-lp64d.so.1" "$elf" 2>/dev/null || true
+      fi
+    done < <(find "$out" -type f \( -perm -0100 -o -name "*.so" -o -name "*.so.*" \) -print0)
+  '';
+
+  passthru = {
+    targetSystem = "riscv64-linux";
+    inherit spacemitK3Runtime spacemitK3Toolchain;
+  };
+
+  meta = {
+    description = "llama.cpp from SpacemiT's fork, built for K3/A100 IME2";
+    homepage = "https://github.com/spacemit-com/llama.cpp";
+    license = lib.licenses.mit;
+    mainProgram = "llama";
+    maintainers = with lib.maintainers; [ georgewhewell ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/spacemit/runtime/default.nix
+++ b/pkgs/spacemit/runtime/default.nix
@@ -1,0 +1,44 @@
+{
+  lib,
+  stdenvNoCC,
+  spacemitK3Toolchain,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "spacemit-k3-runtime";
+  inherit (spacemitK3Toolchain) version;
+
+  dontUnpack = true;
+  dontConfigure = true;
+  dontBuild = true;
+  dontFixup = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    copyRuntimeLibs() {
+      local src="$1"
+      local dst="$2"
+
+      [ -d "$src" ] || return
+      mkdir -p "$dst"
+
+      find "$src" -maxdepth 1 \( -type f -o -type l \) \
+        \( -name "*.so" -o -name "*.so.*" -o -name "ld-linux-*.so.*" \) \
+        -exec cp -P --target-directory="$dst" {} +
+    }
+
+    copyRuntimeLibs ${spacemitK3Toolchain}/sysroot/lib "$out/sysroot/lib"
+    copyRuntimeLibs ${spacemitK3Toolchain}/riscv64-unknown-linux-gnu/lib "$out/riscv64-unknown-linux-gnu/lib"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Runtime libraries from the SpacemiT K3 RISC-V toolchain";
+    homepage = "https://github.com/spacemit-com/toolchain";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ georgewhewell ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/spacemit/spine-mlir/default.nix
+++ b/pkgs/spacemit/spine-mlir/default.nix
@@ -1,0 +1,59 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  patchelf,
+  spacemitK3Toolchain,
+}:
+
+let
+  version = "0.5.4";
+  runtimeRpath = lib.concatStringsSep ":" [
+    "${spacemitK3Toolchain}/sysroot/lib"
+    "${spacemitK3Toolchain}/riscv64-unknown-linux-gnu/lib"
+  ];
+in
+stdenvNoCC.mkDerivation {
+  pname = "spacemit-k3-spine-mlir";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://github.com/spacemit-com/spine-mlir/releases/download/${version}/spine-mlir-riscv64-${version}.tar.gz";
+    hash = "sha256-ATaPcRWWddlzy3hFQBp6+7LPv9ftoGY2m8D5DKP4a0w=";
+  };
+
+  nativeBuildInputs = [ patchelf ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    release_dir=ci/workspace/AI/spine-mlir-build/build/riscv64/speir/Release/spine-mlir-riscv64-${version}
+    mkdir -p "$out"
+    cp -R "$release_dir"/. "$out/"
+    chmod -R u+w "$out"
+
+    while IFS= read -r -d "" elf; do
+      if old_rpath=$(patchelf --print-rpath "$elf" 2>/dev/null); then
+        patchelf --set-rpath "${runtimeRpath}''${old_rpath:+:$old_rpath}" "$elf" 2>/dev/null || true
+      fi
+      if patchelf --print-interpreter "$elf" >/dev/null 2>&1; then
+        patchelf --set-interpreter "${spacemitK3Toolchain}/sysroot/lib/ld-linux-riscv64-lp64d.so.1" "$elf" 2>/dev/null || true
+      fi
+    done < <(find "$out" -type f \( -perm -0100 -o -name "*.so" -o -name "*.so.*" \) -print0)
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SpacemiT Spine MLIR runtime tools for RISC-V";
+    homepage = "https://github.com/spacemit-com/spine-mlir";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ georgewhewell ];
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/spacemit/spine-triton/default.nix
+++ b/pkgs/spacemit/spine-triton/default.nix
@@ -1,0 +1,36 @@
+{
+  lib,
+  stdenvNoCC,
+  src,
+  version,
+  spineMlir,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "spine-triton-source";
+  inherit src version;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/share/spine-triton"
+    cp -R . "$out/share/spine-triton/source"
+
+    runHook postInstall
+  '';
+
+  passthru = {
+    inherit spineMlir;
+  };
+
+  meta = {
+    description = "Pinned SpacemiT Spine-Triton source tree";
+    homepage = "https://github.com/spacemit-com/spine-triton";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ georgewhewell ];
+    platforms = lib.platforms.linux;
+  };
+}

--- a/pkgs/spacemit/toolchain/default.nix
+++ b/pkgs/spacemit/toolchain/default.nix
@@ -1,0 +1,98 @@
+{
+  lib,
+  stdenvNoCC,
+  stdenv,
+  fetchurl,
+  file,
+  libffi,
+  libxml2,
+  ncurses,
+  patchelf,
+  zlib,
+  zstd,
+}:
+
+stdenvNoCC.mkDerivation {
+  pname = "spacemit-k3-toolchain";
+  version = "1.2.4";
+
+  src = fetchurl {
+    url = "https://github.com/spacemit-com/toolchain/releases/download/v1.2.4/spacemit-toolchain-linux-glibc-x86_64-v1.2.4.tar.xz";
+    hash = "sha256-+TtKFt6MfNahR83c+0kGeOiN81Vw4XizFkE4vij6BrY=";
+  };
+
+  nativeBuildInputs = [
+    file
+    patchelf
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+  dontPatchELF = true;
+  dontMoveLib64 = true;
+  dontPatchShebangs = true;
+  dontCheckForBrokenSymlinks = true;
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out"
+    cp -R ./* "$out/"
+    chmod -R u+w "$out"
+
+    for link in "$out"/bin/gp-*; do
+      [ -L "$link" ] || continue
+      target=$(readlink "$link")
+      prefixed="$out/bin/riscv64-unknown-linux-gnu-$target"
+      if [ ! -e "$out/bin/$target" ] && [ -e "$prefixed" ]; then
+        ln -sfn "riscv64-unknown-linux-gnu-$target" "$link"
+      fi
+    done
+
+    host_rpath="$out/lib:$out/lib64:${
+      lib.makeLibraryPath [
+        stdenv.cc.cc.lib
+        libffi
+        libxml2
+        ncurses
+        zlib
+        zstd
+      ]
+    }"
+    host_interpreter=${lib.escapeShellArg stdenv.cc.bintools.dynamicLinker}
+
+    patch_host_elf() {
+      local elf="$1"
+
+      if ! file "$elf" | grep -Fq "x86-64"; then
+        return
+      fi
+
+      if old_rpath=$(patchelf --print-rpath "$elf" 2>/dev/null); then
+        patchelf --set-rpath "''${old_rpath:+$old_rpath:}$host_rpath" "$elf" 2>/dev/null || true
+      fi
+
+      if patchelf --print-interpreter "$elf" >/dev/null 2>&1; then
+        patchelf --set-interpreter "$host_interpreter" "$elf" 2>/dev/null || true
+      fi
+    }
+
+    for dir in "$out/bin" "$out/lib" "$out/lib64" "$out/libexec" "$out/riscv64-unknown-linux-gnu/bin"; do
+      [ -d "$dir" ] || continue
+      while IFS= read -r -d "" elf; do
+        patch_host_elf "$elf"
+      done < <(find "$dir" -type f \( -perm -0100 -o -name "*.so" -o -name "*.so.*" \) -print0)
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "SpacemiT K3 RISC-V cross toolchain with IME instruction support";
+    homepage = "https://github.com/spacemit-com/toolchain";
+    license = lib.licenses.gpl3Plus;
+    maintainers = with lib.maintainers; [ georgewhewell ];
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary

Adds a focused SpacemiT K3 package surface for building and deploying AI tooling to K3/A100 RISC-V boards:

- `spacemit-k3-toolchain`: vendor x86_64-hosted RISC-V toolchain with IME instruction support
- `spacemit-k3-runtime`: target runtime library subset split out from the full toolchain
- `llama-cpp-spacemit`: SpacemiT's llama.cpp fork built for RISC-V K3/A100 IME2
- `spacemit-k3-spine-mlir`: packaged RISC-V Spine MLIR runtime tools
- `spine-triton-source`: pinned Spine-Triton source, fetched with submodules
- `overlays.spacemitK3`: composable overlay for downstream board configs

## Notes

`llama-cpp-spacemit` is cross-built using the full vendor toolchain, but its runtime interpreter and RPATH point at `spacemit-k3-runtime`, so target deployments do not pull in the full compiler closure.

## Verification

- `nix build .#packages.x86_64-linux.spacemit-k3-toolchain .#packages.x86_64-linux.spacemit-k3-runtime .#packages.x86_64-linux.spacemit-k3-spine-mlir .#packages.x86_64-linux.spine-triton-source .#packages.x86_64-linux.llama-cpp-spacemit`
- `nix build .#checks.x86_64-linux.nixfmt .#checks.x86_64-linux.deadnix .#checks.x86_64-linux.statix`
- `nix flake check --no-build`
- Verified `llama-cli` is a RISC-V ELF whose interpreter and RPATH use `spacemit-k3-runtime`.
- Verified `llama-cpp-spacemit` directly references `spacemit-k3-runtime`, not `spacemit-k3-toolchain`.
