### PR TITLE
rocm: add Radeon Pro V620 gfx1030 builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,8 +175,10 @@ nix build .#legacyPackages.x86_64-linux.gfx1030.vllm-rocm # Radeon Pro V620
 Only targets with matching TheRock binary/Python source pins expose
 TheRock-shaped packages such as `therock-rocm`, `ds4-rocm`, `mlx-rocm`, and
 `vllm-rocm`. At the moment those pins exist for `gfx1030` (Radeon Pro V620) and
-`gfx1151`; `llama-cpp-rocm`
-is available for every target listed in `pkgs/therock/targets.nix`.
+`gfx1151`. Package availability may be narrower where an architecture lacks a
+required feature: `ds4-rocm` requires rocWMMA and is not exposed for `gfx1030`.
+`llama-cpp-rocm` is available for every target listed in
+`pkgs/therock/targets.nix`.
 
 For non-default providers compose your own overlays with `lib.mkRocmOverlay`,
 `lib.mkPythonOverlay`, and `lib.mkPkgsOverlay`. Add a new target by

--- a/README.md
+++ b/README.md
@@ -169,11 +169,13 @@ Per-target packages (default providers) are available under
 
 ```bash
 nix build .#legacyPackages.x86_64-linux.gfx1103.llama-cpp-rocm
+nix build .#legacyPackages.x86_64-linux.gfx1030.vllm-rocm # Radeon Pro V620
 ```
 
 Only targets with matching TheRock binary/Python source pins expose
 TheRock-shaped packages such as `therock-rocm`, `ds4-rocm`, `mlx-rocm`, and
-`vllm-rocm`. At the moment those pins exist for `gfx1151`; `llama-cpp-rocm`
+`vllm-rocm`. At the moment those pins exist for `gfx1030` (Radeon Pro V620) and
+`gfx1151`; `llama-cpp-rocm`
 is available for every target listed in `pkgs/therock/targets.nix`.
 
 For non-default providers compose your own overlays with `lib.mkRocmOverlay`,

--- a/flake.nix
+++ b/flake.nix
@@ -921,6 +921,7 @@
               assert !(self.packages.${system} ? vllm-rocm-therock-gfx1151);
               assert !(self.legacyPackages.${system}.gfx1103 ? ds4-rocm);
               assert !(self.legacyPackages.${system}.gfx1103 ? vllm-rocm);
+              assert !(self.legacyPackages.${system}.gfx1030 ? ds4-rocm);
               assert self.legacyPackages.${system}.gfx1030 ? vllm-rocm;
               pkgs.runCommandLocal "ci-package-surface"
                 {

--- a/flake.nix
+++ b/flake.nix
@@ -921,6 +921,7 @@
               assert !(self.packages.${system} ? vllm-rocm-therock-gfx1151);
               assert !(self.legacyPackages.${system}.gfx1103 ? ds4-rocm);
               assert !(self.legacyPackages.${system}.gfx1103 ? vllm-rocm);
+              assert self.legacyPackages.${system}.gfx1030 ? vllm-rocm;
               pkgs.runCommandLocal "ci-package-surface"
                 {
                   meta.maintainers = with lib.maintainers; [ georgewhewell ];
@@ -930,6 +931,7 @@
                   default llama-cpp-rocm: ${plain self.packages.${system}.llama-cpp-rocm.drvPath}
                   legacy gfx1151 llama-cpp-rocm: ${plain self.legacyPackages.${system}.gfx1151.llama-cpp-rocm.drvPath}
                   legacy gfx1103 llama-cpp-rocm: ${plain self.legacyPackages.${system}.gfx1103.llama-cpp-rocm.drvPath}
+                  legacy gfx1030 vllm-rocm: ${plain self.legacyPackages.${system}.gfx1030.vllm-rocm.drvPath}
                   default vllm-rocm: ${plain self.packages.${system}.vllm-rocm.drvPath}
                   EOF
                 '';

--- a/lib/hydra.nix
+++ b/lib/hydra.nix
@@ -130,7 +130,6 @@ let
         # smoke tests on gfx1151 until the Hydra fleet has V620 hardware.
         gfx1030-llama-cpp-rocm = gfx1030Packages.llama-cpp-rocm;
         gfx1030-llama-cpp-master-rocm = gfx1030Packages.llama-cpp-master-rocm;
-        gfx1030-mlx-rocm = gfx1030Packages.mlx-rocm;
         gfx1030-sglang-rocm = gfx1030Packages.sglang-rocm;
         gfx1030-therock-python = gfx1030Packages.therock-python;
         gfx1030-therock-python-wheels = gfx1030Packages.therock-python-wheels;

--- a/lib/hydra.nix
+++ b/lib/hydra.nix
@@ -128,7 +128,6 @@ let
 
         # V620 builders consume these binary gfx1030 artifacts. Keep runtime
         # smoke tests on gfx1151 until the Hydra fleet has V620 hardware.
-        gfx1030-ds4-rocm = gfx1030Packages.ds4-rocm;
         gfx1030-llama-cpp-rocm = gfx1030Packages.llama-cpp-rocm;
         gfx1030-llama-cpp-master-rocm = gfx1030Packages.llama-cpp-master-rocm;
         gfx1030-mlx-rocm = gfx1030Packages.mlx-rocm;

--- a/lib/hydra.nix
+++ b/lib/hydra.nix
@@ -45,6 +45,7 @@ let
       system = pkgs.stdenv.hostPlatform.system;
       isGateSystem = system == "x86_64-linux";
       x86Packages = self.packages.x86_64-linux;
+      gfx1030Packages = self.legacyPackages.x86_64-linux.gfx1030;
       x86Benchmarks = self.benchmarks.x86_64-linux;
       darwinPackages = self.packages.aarch64-darwin;
       darwinBenchmarks = self.benchmarks.aarch64-darwin;
@@ -124,6 +125,18 @@ let
         therock-rocm-from-source = fromSourcePkgs.therock-rocm;
         llama-cpp-rocm-from-source = fromSourcePkgs.llama-cpp-rocm;
         llama-cpp-rocm-nixpkgs = nixpkgsRocmPkgs.llama-cpp-rocm;
+
+        # V620 builders consume these binary gfx1030 artifacts. Keep runtime
+        # smoke tests on gfx1151 until the Hydra fleet has V620 hardware.
+        gfx1030-ds4-rocm = gfx1030Packages.ds4-rocm;
+        gfx1030-llama-cpp-rocm = gfx1030Packages.llama-cpp-rocm;
+        gfx1030-llama-cpp-master-rocm = gfx1030Packages.llama-cpp-master-rocm;
+        gfx1030-mlx-rocm = gfx1030Packages.mlx-rocm;
+        gfx1030-sglang-rocm = gfx1030Packages.sglang-rocm;
+        gfx1030-therock-python = gfx1030Packages.therock-python;
+        gfx1030-therock-python-wheels = gfx1030Packages.therock-python-wheels;
+        gfx1030-therock-rocm = gfx1030Packages.therock-rocm;
+        gfx1030-vllm-rocm = gfx1030Packages.vllm-rocm;
       };
 
       # Keep the PR gate hermetic: full DS4 model and Pi integration benchmarks

--- a/lib/rocm-targets.nix
+++ b/lib/rocm-targets.nix
@@ -9,6 +9,7 @@
       hsaOverride ? null,
       therockTarget ? packageSuffix,
       therockSourceTarget ? packageSuffix,
+      supportsRocWmma ? true,
       description ? packageSuffix,
     }:
     {
@@ -21,6 +22,7 @@
         hsaOverride
         therockTarget
         therockSourceTarget
+        supportsRocWmma
         description
         ;
     };

--- a/lib/rocm-targets.nix
+++ b/lib/rocm-targets.nix
@@ -8,6 +8,7 @@
       systemFeature ? runtimeArch,
       hsaOverride ? null,
       therockTarget ? packageSuffix,
+      therockSourceTarget ? packageSuffix,
       description ? packageSuffix,
     }:
     {
@@ -19,6 +20,7 @@
         systemFeature
         hsaOverride
         therockTarget
+        therockSourceTarget
         description
         ;
     };

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -187,6 +187,15 @@ let
       ];
     });
 
+  # llama.cpp otherwise prefers a host /opt/rocm when one is visible. Apart
+  # from making the build impure, that can mix a host HIP runtime with the
+  # target-narrowed nixpkgs ROCm libraries selected above.
+  withHermeticRocm =
+    drv:
+    drv.overrideAttrs (_: {
+      env.ROCM_PATH = final.rocmPackages.clr;
+    });
+
   # macOS 26 exposes Apple Thunderbolt RDMA through the SDK's infiniband
   # headers and umbrella librdma.dylib. This is only for Darwin builds; Linux
   # continues to use rdma-core-usb4 above.
@@ -248,28 +257,19 @@ let
       };
 
       llama-cpp-rocm = bigParallel (
-        setPname "llama-cpp-rocm-${suffix}" (withRdmaRpc (localLlamaCpp rocmOverride))
+        setPname "llama-cpp-rocm-${suffix}" (withRdmaRpc (withHermeticRocm (localLlamaCpp rocmOverride)))
       );
       llama-cpp-vulkan = withRdmaRpc (localLlamaCpp vulkanOverride);
       llama-cpp-cuda = localLlamaCpp cudaOverride;
       llama-cpp-master-rocm = bigParallel (
-        setPname "llama-cpp-master-rocm-${suffix}" (withRdmaRpc (llamaCppMaster.override rocmOverride))
+        setPname "llama-cpp-master-rocm-${suffix}" (
+          withRdmaRpc (withHermeticRocm (llamaCppMaster.override rocmOverride))
+        )
       );
       llama-cpp-master-vulkan = withRdmaRpc (llamaCppMaster.override vulkanOverride);
       llama-cpp-master-cuda = llamaCppMaster.override cudaOverride;
     }
     // lib.optionalAttrs supportsTherockRocm {
-      ds4-rocm = bigParallel (
-        prev.callPackage ../pkgs/ds4-rocm {
-          src = inputs.ds4-hip;
-          rocmSdk = final."therock-rocm-${suffix}";
-          version = inputVersion "experimental" inputs.ds4-hip;
-          inherit (rocmTarget) packageSuffix;
-          offloadArch = firstBuildTarget;
-          hsaOverrideGfxVersion = rocmTarget.hsaOverride or null;
-        }
-      );
-
       mlx-rocm = bigParallel (
         final.python3Packages.callPackage ../pkgs/mlx/rocm.nix {
           mlx = final.python3Packages.mlx.override {
@@ -288,6 +288,18 @@ let
       # package set's target is fixed (which it is per pkgsFor invocation).
       therock-rocm = final."therock-rocm-${suffix}";
       therock-rocm-env = final."therock-rocm-${suffix}-env";
+    }
+    // lib.optionalAttrs (supportsTherockRocm && rocmTarget.supportsRocWmma) {
+      ds4-rocm = bigParallel (
+        prev.callPackage ../pkgs/ds4-rocm {
+          src = inputs.ds4-hip;
+          rocmSdk = final."therock-rocm-${suffix}";
+          version = inputVersion "experimental" inputs.ds4-hip;
+          inherit (rocmTarget) packageSuffix;
+          offloadArch = firstBuildTarget;
+          hsaOverrideGfxVersion = rocmTarget.hsaOverride or null;
+        }
+      );
     }
     // lib.optionalAttrs supportsTherockPython {
       therock-python = final."therock-python-${suffix}";

--- a/pkgs/therock/default.nix
+++ b/pkgs/therock/default.nix
@@ -33,23 +33,23 @@ let
   sourcePinsByTarget = therockRocmSourcePins.targets;
 
   sourceFor =
-    suffix:
-    if builtins.hasAttr suffix sourcePinsByTarget then
-      sourcePinsByTarget.${suffix}
+    rocmTarget:
+    if builtins.hasAttr rocmTarget.therockSourceTarget sourcePinsByTarget then
+      sourcePinsByTarget.${rocmTarget.therockSourceTarget}
     else
-      throw "missing TheRock source pin for ${suffix}";
+      throw "missing TheRock source pin for ${rocmTarget.packageSuffix}";
 
-  defaultSource = sourceFor target.packageSuffix;
+  defaultSource = sourceFor target;
 
   lockedSourceTreeFor =
-    suffix:
+    rocmTarget:
     let
-      sourceTree = therockRocmSourceTrees.${suffix};
+      sourceTree = therockRocmSourceTrees.${rocmTarget.therockSourceTarget};
     in
-    if !(builtins.hasAttr suffix therockRocmSourceTrees) then
-      throw "missing locked TheRock source tree inputs for ${suffix}"
+    if !(builtins.hasAttr rocmTarget.therockSourceTarget therockRocmSourceTrees) then
+      throw "missing locked TheRock source tree inputs for ${rocmTarget.packageSuffix}"
     else if !(builtins.isAttrs sourceTree && sourceTree ? root && sourceTree ? submodules) then
-      throw "invalid locked TheRock source tree inputs for ${suffix}"
+      throw "invalid locked TheRock source tree inputs for ${rocmTarget.packageSuffix}"
     else
       sourceTree;
 
@@ -151,7 +151,7 @@ let
     rocmTarget:
     let
       suffix = rocmTarget.packageSuffix;
-      source = sourceFor suffix;
+      source = sourceFor rocmTarget;
       cmakeConfig = {
         target = suffix;
         amdgpuTargets = rocmTarget.buildTargets;
@@ -160,7 +160,7 @@ let
       projectTargetUnexcludes = lib.optionalAttrs (builtins.elem suffix rocmTarget.buildTargets) {
         rocprofiler-compute = [ suffix ];
       };
-      sourceTreeInputs = lockedSourceTreeFor suffix;
+      sourceTreeInputs = lockedSourceTreeFor rocmTarget;
       compilerSourceTreeInputs = sourceTreeInputs // {
         submodules = builtins.filter (
           submodule: !(lib.hasPrefix "rocm-systems/projects/rocprofiler-" submodule.path)
@@ -263,7 +263,7 @@ let
     };
 
   therockFromSourceTargets = builtins.filter (
-    rocmTarget: builtins.hasAttr rocmTarget.packageSuffix sourcePinsByTarget
+    rocmTarget: builtins.hasAttr rocmTarget.therockSourceTarget sourcePinsByTarget
   ) rocmTargets;
 
   therockFromSourcePerArch = lib.foldl' lib.recursiveUpdate { } (

--- a/pkgs/therock/scripts/update-rocm.py
+++ b/pkgs/therock/scripts/update-rocm.py
@@ -20,6 +20,7 @@ from pathlib import Path
 BASE_URL = "https://rocm.nightlies.amd.com/tarball-multi-arch/"
 TARGET_SLUGS = {
     "gfx1010": "gfx101X-dgpu",
+    "gfx1030": "gfx103X-all",
     "gfx1036": "gfx103X-all",
     "gfx1103": "gfx110X-all",
     "gfx110X": "gfx110X-dgpu",
@@ -103,7 +104,12 @@ def main() -> None:
     targets = args.target or ["gfx1151"]
     index = "" if args.version else fetch_index()
 
-    sources = {"linux": {}}
+    output = Path(args.output)
+    try:
+        sources = json.loads(output.read_text())
+    except FileNotFoundError:
+        sources = {"linux": {}}
+    sources.setdefault("linux", {})
     for target in targets:
         version = args.version or find_version(index, target, args.series)
         slug = target_slug(target)
@@ -119,7 +125,7 @@ def main() -> None:
             "updated": datetime.now(timezone.utc).isoformat(),
         }
 
-    Path(args.output).write_text(json.dumps(sources, indent=2) + "\n")
+    output.write_text(json.dumps(sources, indent=2) + "\n")
 
 
 if __name__ == "__main__":

--- a/pkgs/therock/sources/python-wheels.json
+++ b/pkgs/therock/sources/python-wheels.json
@@ -152,7 +152,149 @@
         }
       },
       "updated": "2026-07-19T15:13:13.835729+00:00"
+    },
+    "gfx1030": {
+      "target": "gfx1030",
+      "series": "7.15",
+      "rocmVersion": "7.15.0a20260719",
+      "pythonTag": "cp313",
+      "index": "https://rocm.nightlies.amd.com/whl-multi-arch/",
+      "packages": {
+        "rocm": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/rocm-7.15.0a20260719.tar.gz",
+          "hash": "sha256-4eucEU31gedyq+C9l4tmIK2r4Lvn/xFlKuuhOhyT1v0=",
+          "filename": "rocm-7.15.0a20260719.tar.gz",
+          "packageVersion": "7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "source",
+          "abiTag": "source",
+          "platformTag": "source",
+          "kind": "sdist"
+        },
+        "rocm-bootstrap": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/rocm_bootstrap-0.1.0-py3-none-any.whl",
+          "hash": "sha256-M+PU2tCGsfDga8BJphjKh01Pty91j/8AZ24j0qZEtlI=",
+          "filename": "rocm_bootstrap-0.1.0-py3-none-any.whl",
+          "packageVersion": "0.1.0",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "py3",
+          "abiTag": "none",
+          "platformTag": "any",
+          "kind": "wheel"
+        },
+        "torch": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/torch-2.11.0%2Brocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "hash": "sha256-zKkpXQzmm66lq6EzcDf8Css+iymGaOScmJ0KDlnml+E=",
+          "filename": "torch-2.11.0+rocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "packageVersion": "2.11.0+rocm7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "cp313",
+          "abiTag": "cp313",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "torchvision": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/torchvision-0.26.0%2Brocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "hash": "sha256-2cFXRf0ILI7SnNErlkdlJE7wsHqJynDUtMP9nB5JWhs=",
+          "filename": "torchvision-0.26.0+rocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "packageVersion": "0.26.0+rocm7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "cp313",
+          "abiTag": "cp313",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "torchaudio": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/torchaudio-2.11.0%2Brocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "hash": "sha256-yg+apaxrZGA5FTEp/s5uMd3Wz4a58KH5TJJG1Kq0AsE=",
+          "filename": "torchaudio-2.11.0+rocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "packageVersion": "2.11.0+rocm7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "cp313",
+          "abiTag": "cp313",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "triton": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/triton-3.7.1%2Bgit0263a6a6.rocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "hash": "sha256-lFlPDoZPsvhoBnzNuchlNFdi/NQ5SeUMMUtvtISqREU=",
+          "filename": "triton-3.7.1+git0263a6a6.rocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "packageVersion": "3.7.1+git0263a6a6.rocm7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "cp313",
+          "abiTag": "cp313",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "rocm-sdk-core": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_core-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "hash": "sha256-g/OhoE/nxLF1VMggeLvTyrI/nB/82XW4f65mwutlWdE=",
+          "filename": "rocm_sdk_core-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "packageVersion": "7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "py3",
+          "abiTag": "none",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "rocm-sdk-devel": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_devel-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "hash": "sha256-D5nBAdCQCh0jE5XexzQnZ7uHUQED1jq0iHRBCyw7SE4=",
+          "filename": "rocm_sdk_devel-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "packageVersion": "7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "py3",
+          "abiTag": "none",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "rocm-sdk-libraries": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_libraries-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "hash": "sha256-beBGkZQnSc1YkzIPappdAq2dTHg699ksAtKHHvS+JhE=",
+          "filename": "rocm_sdk_libraries-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "packageVersion": "7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "py3",
+          "abiTag": "none",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "amd-torch-device-gfx1030": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/amd_torch_device_gfx1030-2.11.0%2Brocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "hash": "sha256-SEJJTgoW0+T2bjeso/ydr21mKI0Esex/95t0bz0dnik=",
+          "filename": "amd_torch_device_gfx1030-2.11.0+rocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "packageVersion": "2.11.0+rocm7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "cp313",
+          "abiTag": "cp313",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "amd-torchvision-device-gfx1030": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/amd_torchvision_device_gfx1030-0.26.0%2Brocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "hash": "sha256-gGB8C5ULyS80JiYLvgJ1/DJvpr89KRwhurxd0VmIoRo=",
+          "filename": "amd_torchvision_device_gfx1030-0.26.0+rocm7.15.0a20260719-cp313-cp313-linux_x86_64.whl",
+          "packageVersion": "0.26.0+rocm7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "cp313",
+          "abiTag": "cp313",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        },
+        "rocm-sdk-device-gfx1030": {
+          "url": "https://rocm.nightlies.amd.com/whl-multi-arch/rocm_sdk_device_gfx1030-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "hash": "sha256-+ydkifkQRNL8i1GpX9htKBeQS+4Z3IQUV621v1P+/JE=",
+          "filename": "rocm_sdk_device_gfx1030-7.15.0a20260719-py3-none-linux_x86_64.whl",
+          "packageVersion": "7.15.0a20260719",
+          "rocmVersion": "7.15.0a20260719",
+          "pythonTag": "py3",
+          "abiTag": "none",
+          "platformTag": "linux_x86_64",
+          "kind": "wheel"
+        }
+      },
+      "updated": "2026-07-21T17:03:33.279321+00:00"
     }
   },
-  "updated": "2026-07-19T15:13:13.835729+00:00"
+  "updated": "2026-07-21T17:03:33.279321+00:00"
 }

--- a/pkgs/therock/sources/rocm.json
+++ b/pkgs/therock/sources/rocm.json
@@ -6,6 +6,13 @@
       "version": "7.15.0a20260719",
       "filename": "therock-dist-linux-gfx1151-7.15.0a20260719.tar.gz",
       "updated": "2026-07-19T15:05:53.258172+00:00"
+    },
+    "gfx1030": {
+      "url": "https://rocm.nightlies.amd.com/tarball-multi-arch/therock-dist-linux-gfx103X-all-7.15.0a20260719.tar.gz",
+      "hash": "sha256-XqhekKNqQaIgCx5/3/fgZdRvE4wVIkeiBrV1uebKn9E=",
+      "version": "7.15.0a20260719",
+      "filename": "therock-dist-linux-gfx103X-all-7.15.0a20260719.tar.gz",
+      "updated": "2026-07-21T17:01:40.257051+00:00"
     }
   }
 }

--- a/pkgs/therock/targets.nix
+++ b/pkgs/therock/targets.nix
@@ -9,6 +9,14 @@ let
       description = "gfx1010 ROCm target";
     };
 
+    gfx1030 = mkRocmTarget {
+      packageSuffix = "gfx1030";
+      therockTarget = "gfx103X-all";
+      # The source checkout is architecture-independent; share its lock graph.
+      therockSourceTarget = "gfx1151";
+      description = "Radeon Pro V620 (gfx1030) ROCm target";
+    };
+
     gfx1036 = mkRocmTarget {
       packageSuffix = "gfx1036";
       runtimeArch = "gfx1036";
@@ -50,6 +58,7 @@ in
   defaultRocmGpuTargets = defaultRocmTarget.rocmGpuTargets;
   rocmTargets = [
     rocmTargetsBySuffix.gfx1010
+    rocmTargetsBySuffix.gfx1030
     rocmTargetsBySuffix.gfx1036
     rocmTargetsBySuffix.gfx1103
     rocmTargetsBySuffix.gfx1151

--- a/pkgs/therock/targets.nix
+++ b/pkgs/therock/targets.nix
@@ -6,6 +6,7 @@ let
       packageSuffix = "gfx1010";
       runtimeArch = "gfx1010";
       therockTarget = "gfx101X-dgpu";
+      supportsRocWmma = false;
       description = "gfx1010 ROCm target";
     };
 
@@ -14,6 +15,7 @@ let
       therockTarget = "gfx103X-all";
       # The source checkout is architecture-independent; share its lock graph.
       therockSourceTarget = "gfx1151";
+      supportsRocWmma = false;
       description = "Radeon Pro V620 (gfx1030) ROCm target";
     };
 
@@ -23,6 +25,7 @@ let
       buildTargets = [ "gfx1030" ];
       hsaOverride = "10.3.0";
       therockTarget = "gfx103X-all";
+      supportsRocWmma = false;
       description = "gfx1036 ROCm target built as gfx1030";
     };
 


### PR DESCRIPTION
## Summary

- add Radeon Pro V620 as a first-class `gfx1030` ROCm target
- pin the matching TheRock `gfx103X-all` SDK and `gfx1030` PyTorch device wheels
- expose vLLM, SGLang, MLX, and llama.cpp through the per-target package set
- model rocWMMA support as a target capability; DS4 is intentionally not exposed for `gfx1030` because rocWMMA rejects that architecture
- make llama.cpp ROCm builds hermetic so a host `/opt/rocm` cannot contaminate their link
- include the seven supported binary `gfx1030` inference jobs in the Hydra `ci.build` aggregate
- leave `gfx1030-mlx-rocm` out of the Hydra gate because its Composable Kernel dependency has no XDL/WMMA implementation for gfx1030
- reuse the architecture-independent pinned TheRock source graph and make the ROCm updater preserve existing targets

## Validation

- built `legacyPackages.x86_64-linux.gfx1030.therock-rocm`
- built `legacyPackages.x86_64-linux.gfx1030.therock-python-wheels`
- built `legacyPackages.x86_64-linux.gfx1030.vllm-rocm`
- built both `gfx1030.llama-cpp-rocm` and `gfx1030.llama-cpp-master-rocm` on `strix-1`, with `/opt/rocm` visible
- ran `llama-bench --list-devices`; it loaded the ROCm backend and identified the V620 as `gfx1030`
- compiled and ran a HIP kernel on the V620 with the pinned TheRock SDK
- verified vLLM uses `PYTORCH_ROCM_ARCH=gfx1030` and `CMAKE_HIP_ARCHITECTURES=gfx1030`
- evaluated gfx1030 SGLang and MLX derivations
- ran `nix flake check --no-build`
- built formatting, deadnix, statix, and package-surface checks
- verified the Hydra build aggregate no longer reaches gfx1030 MLX or Composable Kernel derivations

Hydra smoke jobs remain on gfx1151 because the Hydra fleet does not yet have a V620 runner. V620 hardware validation was performed separately on `strix-1`.