### PR TITLE
pkgs: add llm-inference-bench

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -622,6 +622,7 @@
             "llama-cpp-master-vulkan"
             "llama-cpp-rocm"
             "llama-cpp-vulkan"
+            "llm-inference-bench"
             "llvm-aie"
             "mlir-aie"
             "mlir-aie-env"

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -239,6 +239,7 @@ let
     in
     {
       amdgpu-smu-exporter = prev.callPackage ../pkgs/amdgpu-smu-exporter { };
+      llm-inference-bench = final.callPackage ../pkgs/llm-inference-bench { };
 
       ec-su-axb35 = ecPackages.kernelModule;
       ec-su-axb35-monitor = ecPackages.monitor;

--- a/pkgs/llm-inference-bench/default.nix
+++ b/pkgs/llm-inference-bench/default.nix
@@ -1,0 +1,77 @@
+{
+  fetchFromGitHub,
+  lib,
+  makeWrapper,
+  numactl,
+  python3,
+  stdenv,
+}:
+
+let
+  pythonEnv = python3.withPackages (ps: [
+    ps.httpx
+    ps.openai
+    ps.psutil
+    ps.requests
+    ps.rich
+  ]);
+in
+stdenv.mkDerivation {
+  pname = "llm-inference-bench";
+  version = "0.4.29";
+
+  src = fetchFromGitHub {
+    owner = "local-inference-lab";
+    repo = "llm-inference-bench";
+    rev = "86cf05c2f42f4d21b909b6e684424ca1aab89fd5";
+    hash = "sha256-wjUDTL5QFtL/o5ogSjLJmgObiPyrpj6rYm/SHVyAgFE=";
+  };
+
+  strictDeps = true;
+
+  nativeBuildInputs = [ makeWrapper ];
+  buildInputs = [ numactl ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    g++ -O3 -std=c++17 tools/amd_fabric/llm_amd_fabric.cpp \
+      -o llm_amd_fabric -lnuma -pthread
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    install -D -m 0755 llm_decode_bench.py \
+      "$out/share/llm-inference-bench/llm_decode_bench.py"
+    install -D -m 0755 llm_cjk_watchdog.py \
+      "$out/share/llm-inference-bench/llm_cjk_watchdog.py"
+    cp -r data "$out/share/llm-inference-bench/data"
+
+    install -D -m 0755 llm_amd_fabric \
+      "$out/share/llm-inference-bench/tools/amd_fabric/llm_amd_fabric"
+    mkdir -p "$out/bin"
+    ln -s ../share/llm-inference-bench/tools/amd_fabric/llm_amd_fabric \
+      "$out/bin/llm-amd-fabric"
+
+    makeWrapper ${pythonEnv}/bin/python "$out/bin/llm-decode-bench" \
+      --add-flags "$out/share/llm-inference-bench/llm_decode_bench.py"
+    makeWrapper ${pythonEnv}/bin/python "$out/bin/llm-cjk-watchdog" \
+      --add-flags "$out/share/llm-inference-bench/llm_cjk_watchdog.py"
+
+    runHook postInstall
+  '';
+
+  # tools/p2pmark is CUDA/NVIDIA-only and is intentionally not built for this
+  # ROCm/AMD-focused flake.
+
+  meta = {
+    description = "LLM inference benchmark and AMD NUMA/xGMI fabric diagnostic";
+    homepage = "https://github.com/local-inference-lab/llm-inference-bench";
+    license = lib.licenses.mit;
+    mainProgram = "llm-decode-bench";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary

- package llm-inference-bench 0.4.29 from the pinned upstream revision
- install wrapped llm-decode-bench and llm-cjk-watchdog Python entry points with rich, httpx, requests, psutil, and openai
- build and expose the AMD libnuma NUMA/xGMI diagnostic as llm-amd-fabric
- include the pinned benchmark datasets
- omit the CUDA/NVIDIA-only p2pmark build because this flake targets ROCm/AMD

## Testing

- `nix build --builders "" .#llm-inference-bench`
- `result/bin/llm-decode-bench --help`
- `result/bin/llm-cjk-watchdog --help`
- `result/bin/llm-amd-fabric --help`