### PR TITLE
amdtop: add AMD CPU/GPU/NPU TUI monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ TheRock-published Python wheels.
 | `fastflowlm` | XDNA2 NPU CLI (`flm`) |
 | `strix-halo-vllm-pair-bench-gfx1151` | two-host vLLM transport-matrix bench driver |
 | `therock-rocm`, `therock-python`, `torch-rocm` | TheRock binary SDK + wheels |
+| `amdtop` | btop/nvitop-style TUI for AMD CPU, GPU and XDNA NPU telemetry |
 | `xrt`, `xrt-amdxdna`, `tokenizers-cpp`, `strix-halo-mes-firmware`, `ec-su-axb35-monitor` | hardware support bits |
 | `live-iso` | USB-flashable strix-halo live system |
 | Darwin: `llama-cpp`, `llama-cpp-master`, `llama-cpp-master-rdma`, `mlx`, `mlx-metal`, `ds4`, `jaccl` | cross-platform / Metal |

--- a/flake.nix
+++ b/flake.nix
@@ -614,6 +614,7 @@
             names: lib.filter (name: builtins.hasAttr name pkgs && lib.isDerivation pkgs.${name}) names;
 
           linuxLocalPackageNames = [
+            "amdtop"
             "ds4-rocm"
             "ec-su-axb35"
             "ec-su-axb35-monitor"

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -240,6 +240,11 @@ let
     {
       amdgpu-smu-exporter = prev.callPackage ../pkgs/amdgpu-smu-exporter { };
 
+      # Interactive counterpart to the exporters: a btop-style TUI over the
+      # same amdgpu/XDNA telemetry, useful on a Strix Halo box where the APU
+      # and the NPU both matter.
+      amdtop = prev.callPackage ../pkgs/amdtop { };
+
       ec-su-axb35 = ecPackages.kernelModule;
       ec-su-axb35-monitor = ecPackages.monitor;
       strix-halo-mes-firmware = prev.callPackage ../pkgs/strix-halo-mes-firmware.nix { };

--- a/pkgs/amdtop/default.nix
+++ b/pkgs/amdtop/default.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+  libdrm,
+  versionCheckHook,
+  nix-update-script,
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "amdtop";
+  version = "0.2.6";
+
+  src = fetchFromGitHub {
+    owner = "lhl";
+    repo = "amdtop";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-B7/J7jZrJosNot6hnTJ568DxqG+ZRurBPoMDrO4diBk=";
+  };
+
+  cargoHash = "sha256-JXnZ9tYXZywcemN5fQRP8efyhnV+8WVxguk2JEugpj0=";
+
+  # libamdgpu_top reads GPU telemetry through libdrm_amdgpu_sys, which links
+  # against libdrm_amdgpu at build time rather than dlopen-ing it.
+  buildInputs = [ libdrm ];
+
+  strictDeps = true;
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Terminal system monitor for AMD GPUs, CPUs, and XDNA NPUs";
+    longDescription = ''
+      A btop/nvitop-style TUI that monitors CPUs, AMD GPUs (discrete cards and
+      APUs) via libamdgpu_top, and AMD XDNA NPUs exposed through the Linux
+      accel class. Reports per-core CPU history, VRAM/GTT pools, memory
+      bandwidth, per-process engine usage, and ships 41 bundled themes.
+    '';
+    homepage = "https://github.com/lhl/amdtop";
+    changelog = "https://github.com/lhl/amdtop/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "amdtop";
+    maintainers = with lib.maintainers; [ georgewhewell ];
+    platforms = lib.platforms.linux;
+  };
+})

--- a/pkgs/mlir-aie/default.nix
+++ b/pkgs/mlir-aie/default.nix
@@ -17,7 +17,7 @@
 }:
 
 let
-  python = python312Packages.python;
+  inherit (python312Packages) python;
 
   llvm-aie = python312Packages.buildPythonPackage rec {
     pname = "llvm-aie";
@@ -138,13 +138,13 @@ in
     ];
     nativeBuildInputs = [ makeWrapper ];
     postBuild = ''
-      mkdir -p "$out/nix-support"
-      cat > "$out/nix-support/setup-hook" <<EOF
-export PEANO_INSTALL_DIR=${llvm-aie}/${python.sitePackages}/llvm-aie
-export MLIR_AIE_INSTALL_DIR=${mlir-aie}/${python.sitePackages}/mlir_aie
-export XILINX_XRT=${xrt.xdna}
-export PATH=${llvm-aie}/${python.sitePackages}/llvm-aie/bin:${mlir-aie}/bin:\$PATH
-EOF
+            mkdir -p "$out/nix-support"
+            cat > "$out/nix-support/setup-hook" <<EOF
+      export PEANO_INSTALL_DIR=${llvm-aie}/${python.sitePackages}/llvm-aie
+      export MLIR_AIE_INSTALL_DIR=${mlir-aie}/${python.sitePackages}/mlir_aie
+      export XILINX_XRT=${xrt.xdna}
+      export PATH=${llvm-aie}/${python.sitePackages}/llvm-aie/bin:${mlir-aie}/bin:\$PATH
+      EOF
     '';
     meta = {
       description = "Combined MLIR-AIE and Peano environment for AMD Ryzen AI NPU development";


### PR DESCRIPTION
Adds [`amdtop`](https://github.com/lhl/amdtop) v0.2.6 — a btop/nvitop-style terminal monitor for AMD systems, built on the published `libamdgpu_top` crate. It is the interactive counterpart to the exporters this flake already ships: per-core CPU history, APU GTT/VRAM pools and memory-controller bandwidth, XDNA NPU utilization from `/sys/class/accel`, and a per-process VRAM/GTT/engine table.

## Packaging notes

- `rustPlatform.buildRustPackage` from the upstream `v0.2.6` tag (`fetchFromGitHub`, `tag = "v${finalAttrs.version}"`, finalAttrs-style so `nix-update` only has to bump `version`).
- `libdrm` in `buildInputs`: `libdrm_amdgpu_sys` links `libdrm_amdgpu` at build time rather than dlopen-ing it, so it must be in the runtime closure — verified with `ldd` and `nix path-info -r`.
- `strictDeps = true`; upstream's 60 unit + 3 CLI tests run in the check phase; `versionCheckHook` validates the installed binary; `passthru.updateScript = nix-update-script { }`.
- Full `meta`: description, longDescription, homepage, changelog, `license = asl20`, maintainer, `mainProgram`, `platforms.linux`.
- Wired into `overlays/pkgs.nix` (so `pkgs.amdtop` works through `overlays.default`) and `linuxLocalPackageNames`, which exposes it as `packages.x86_64-linux.amdtop` and puts it in Hydra. Added a README row.

Not in nixpkgs yet (nixpkgs has the sibling `amdgpu_top`, not `amdtop`); this derivation is written to nixpkgs conventions so it can be upstreamed as-is.

## Also: green the source checks

`ci-nixfmt` and `ci-statix` have both been failing on `master` since `pkgs/mlir-aie/default.nix` landed. Second commit fixes both — the formatter's own reindentation of the `setup-hook` heredoc, and `inherit (python312Packages) python;`.

Nothing rebuilds: Nix strips the common leading whitespace of an indented string, so the emitted `setup-hook` is byte-identical, and both `mlir-aie-env` and `mlir-aie` evaluate to the same store derivations before and after the change (`4k620z7jhcc8s3iffcpkyh06dpvzmyxs-mlir-aie-env-1.3.4.drv`, `zqgjn8dwdlkrv80d6mk18g8vdvj7iyj7-python3.12-mlir-aie-1.3.4.drv`).

## Verification

- `nix build .#amdtop -L` — builds, all 63 tests pass, `versionCheckPhase` finds 0.2.6.
- `nix run .#amdtop -- --version` → `amdtop 0.2.6`.
- Ran the TUI on a live box under a sized pty: CPU grid, GPU band, and the process table render with real telemetry.
- `nix build .#checks.x86_64-linux.{nixfmt,statix,deadnix,package-surface}` — all pass on this branch.