### PR TITLE
multikernel: package Linux 7.0-mk2 and add NixOS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ TheRock-published Python wheels.
 | `strix-halo-vllm-pair-bench-gfx1151` | two-host vLLM transport-matrix bench driver |
 | `therock-rocm`, `therock-python`, `torch-rocm` | TheRock binary SDK + wheels |
 | `amdtop` | btop/nvitop-style TUI for AMD CPU, GPU and XDNA NPU telemetry |
+| `linux-multikernel`, `kerf-multikernel` | pinned Linux 7.0-mk2 host/spawn kernel and lifecycle manager |
+| `multikernel-demo-initrd` | tiny interactive spawn initramfs for bare-metal isolation demos |
 | `xrt`, `xrt-amdxdna`, `tokenizers-cpp`, `strix-halo-mes-firmware`, `ec-su-axb35-monitor` | hardware support bits |
 | `live-iso` | USB-flashable strix-halo live system |
 | Darwin: `llama-cpp`, `llama-cpp-master`, `llama-cpp-master-rdma`, `mlx`, `mlx-metal`, `ds4`, `jaccl` | cross-platform / Metal |
@@ -194,6 +196,12 @@ the tag in `lib/providers.nix`.
 - `nixosModules.fastflowlm` — FastFlowLM OpenAI-compatible server (XDNA2)
 - `nixosModules.benchmark-runner` / `benchmark-executor` — local + remote bench infra
 - `nixosModules.ec-su-axb35`, `ryzenadj`, `tuning` — Strix Halo hardware modules
+- `nixosModules.multikernel` — declarative bare-metal kernel pools and spawn instances
+
+The multikernel package builds the complete upstream `v7.0-mk2` tree, not a
+patch stack replayed onto the current nixpkgs kernel. See
+[docs/multikernel.md](docs/multikernel.md) for the module, local-source override,
+hardware bring-up, rollback, and panic-isolation demonstration.
 
 Example RDMA RPC server instance:
 

--- a/docs/multikernel-strix-4.md
+++ b/docs/multikernel-strix-4.md
@@ -1,0 +1,33 @@
+# Strix Halo hardware validation
+
+`strix-4` completed the bare-metal multikernel lifecycle on 2026-08-27. The
+host PXE-booted Linux `7.0.0-mk2`; its boot ID remained
+`b8114cee-4294-4d50-88de-c38828906fa3` throughout every runtime operation.
+
+The host created an 8 GiB pool from physical APIC IDs 24 through 31 and booted
+two independent kernels from the packaged ELF `vmlinux` and static demo
+initramfs:
+
+| Instance | APIC IDs | RAM | First boot ID |
+| --- | --- | --- | --- |
+| blue | 24-27 | 2 GiB | `dcfbdc80-3176-424d-8180-8afd57abaa94` |
+| red | 28-31 | 2 GiB | `2dfade39-88a5-43f7-8d0b-c98fb82ffbb5` |
+
+Both spawn kernels reported four online CPUs, Linux `7.0.0-mk2`, a private
+PID 1, and about 2 GiB of memory. Blue was then deliberately crashed through
+`/proc/sysrq-trigger`. Its console reported:
+
+```text
+Kernel panic - not syncing: sysrq triggered crash
+Multikernel instance 1 shutting down
+Instance 'blue' is no longer active (status: loaded).
+```
+
+The host remained reachable with its original boot ID. Red remained `active`
+with its original boot ID and continued its heartbeat. Blue was respawned from
+the loaded kernel image and came back with the new boot ID
+`55f6d76c-2b2c-481c-9901-c237f8b55ff4`.
+
+Finally both instances were stopped, unloaded and deleted. Kerf returned APIC
+IDs 24 through 31 and the complete 8 GiB pool; the host again reported CPUs
+`0-31` online without rebooting.

--- a/docs/multikernel.md
+++ b/docs/multikernel.md
@@ -1,0 +1,163 @@
+# Bare-metal multikernel Linux
+
+This flake packages Multikernel Technologies' first public release as four
+reproducible pieces:
+
+- `linux-multikernel`: exact upstream `v7.0-mk2`, commit
+  `3bdd35b64413da0b4e089ce931bfc2e8b031cbf7`;
+- `kerf-multikernel`: Kerf `v0.2.0`, the resource and lifecycle manager;
+- `kerf-init`: a static PID 1 for spawn initramfs images;
+- `multikernel-demo-initrd`: a static BusyBox root with an interactive MKTTY
+  console and independent-kernel heartbeat.
+
+`v7.0-mk2` has an in-tree runtime contiguous allocator. The `lazy_cma` module
+shown by older upstream instructions is neither needed nor loaded here.
+
+## NixOS module
+
+Import the overlay (normally through `nixosModules.default`) and the dedicated
+module. Keep automatic preparation disabled until the machine's APIC topology
+and recovery path have been checked.
+
+```nix
+{
+  imports = [
+    inputs.nix-strix-halo.nixosModules.default
+    inputs.nix-strix-halo.nixosModules.multikernel
+  ];
+
+  boot.multikernel = {
+    enable = true;
+
+    # These are physical APIC IDs, not blindly copied Linux CPU numbers.
+    # The example contains both SMT threads of four complete cores.
+    pool = {
+      cpus = "24-31";
+      memory = "8GB";
+      prepareAtBoot = false;
+    };
+
+    instances = {
+      blue = {
+        id = 1;
+        cpus = "24-27";
+        memory = "2GB";
+      };
+      red = {
+        id = 2;
+        cpus = "28-31";
+        memory = "2GB";
+      };
+    };
+  };
+}
+```
+
+The module selects `linuxPackages_multikernel`, makes Kerf and
+`multikernelctl` available, and creates one inert systemd preparation unit per
+instance. `prepareAtBoot` and `startAtBoot` both default to false.
+
+## Bring-up
+
+Confirm the host is running the packaged kernel and that Secure Boot lockdown
+is not blocking unsigned kexec images:
+
+```console
+$ uname -r
+7.0.0-mk2
+$ zgrep -E 'MULTIKERNEL|MKTTY|KEXEC_HANDOVER' /proc/config.gz
+$ sudo multikernelctl show
+```
+
+Prepare and start each spawn explicitly:
+
+```console
+$ sudo multikernelctl prepare blue
+$ sudo multikernelctl start blue
+$ sudo multikernelctl prepare red
+$ sudo multikernelctl start red
+$ sudo multikernelctl show
+$ sudo multikernelctl console blue
+```
+
+Detach from a Kerf console with `Ctrl+]` followed by `.`. A spawn prints its
+kernel release, boot ID, online logical CPUs, physical APIC IDs, memory size, PID identity, and a
+heartbeat. The shell and applets are entirely inside the initramfs; no disk,
+NFS root, DAXFS image, or PCI device is required.
+
+## Panic-isolation demonstration
+
+With both `blue` and `red` active, attach to `blue` and deliberately panic it:
+
+```console
+[blue root@multikernel]# echo c > /proc/sysrq-trigger
+```
+
+SSH to the host and the `red` console should remain alive. Record their boot
+IDs and heartbeats. A panic normally returns the failed instance to `loaded`,
+so respawn its already-loaded pristine kernel image directly:
+
+```console
+$ sudo multikernelctl start blue
+$ sudo multikernelctl console blue
+```
+
+If a wedged kernel remains `active` instead, use
+`sudo multikernelctl force-stop blue` before restarting it.
+
+This is a fault-isolation demonstration, not a hostile-guest security claim.
+Spawn kernels cooperate with the host and are not protected by a hypervisor or
+second-level page tables. Do not run untrusted kernels.
+
+## Teardown and rollback
+
+Cleanly stop and return one instance's resources:
+
+```console
+$ sudo multikernelctl stop blue
+$ sudo multikernelctl unload blue
+$ sudo multikernelctl delete blue
+```
+
+After all instances have been deleted, return the complete pool to the host:
+
+```console
+$ sudo multikernelctl reset-pool
+```
+
+For a netboot host, keep the previous PXE artifact GC-rooted and record its
+served symlink before the first reboot. Reverting the server's per-host symlink
+and rebooting is the recovery path; runtime pool operations never need to
+rewrite firmware or a bootloader.
+
+## Local kernel development
+
+The public package defaults to a pinned GitHub source and content hash so
+remote builders and binary caches see the same derivation. A local checkout can
+replace only the source while preserving the package recipe:
+
+```nix
+linux-multikernel = prev.linux-multikernel.override {
+  source = /mnt/Home/src/mklinux-7.0-mk2;
+};
+linuxPackages_multikernel = final.linuxPackagesFor final.linux-multikernel;
+```
+
+Nix flakes include only Git-tracked local-source changes. Stage new kernel files
+before evaluating a flake that references the checkout.
+
+## Sharp edges
+
+- Upstream supports x86-64 in this release; Strix Halo is an empirical target,
+  not an upstream-tested platform.
+- Host and spawn kernels must come from the same source/layout. The module uses
+  one package for both by default.
+- The optional multikernel-vsock transport is disabled: mk2 ships a stale
+  `stream_allow` callback signature that does not compile against its own 7.0
+  VSOCK API. The CPU, memory, kexec, MKTTY, and DAXFS paths are unaffected.
+- Pool memory allocation is best-effort against live memory and can fail after
+  fragmentation. Prepare it early, but only after the configuration is proven.
+- Use complete physical cores. Splitting SMT siblings across independent
+  kernels defeats isolation and is not a sensible performance experiment.
+- Start without PCI devices. Add exclusive device assignment only after CPU,
+  memory, console, kill, respawn, and pool-return paths all pass.

--- a/flake.nix
+++ b/flake.nix
@@ -290,6 +290,7 @@
       };
 
       thunderboltIbverbsOverlay = inputs.thunderbolt-ibverbs.overlays.default;
+      multikernelOverlay = import ./overlays/multikernel.nix;
       spacemitK3Overlay = import ./overlays/spacemit-k3.nix {
         inherit inputs inputVersion;
       };
@@ -351,6 +352,7 @@
         [
           thunderboltIbverbsOverlay
           thunderboltRenamesOverlay
+          multikernelOverlay
           (import ./overlays/rocm.nix {
             inherit lib therockPythonConfig;
             provider = rocmProvider;
@@ -506,6 +508,7 @@
         python = self.lib.mkPythonOverlay {
           provider = "nixpkgs";
         };
+        multikernel = multikernelOverlay;
         spacemitK3 = spacemitK3Overlay;
       };
 
@@ -526,6 +529,7 @@
         fastflowlm = import ./modules/fastflowlm.nix;
         smu-exporter = import ./modules/smu-exporter.nix;
         npu-exporter = import ./modules/npu-exporter.nix;
+        multikernel = import ./modules/multikernel.nix;
         ryzenadj = import ./modules/ryzenadj.nix;
         tuning = import ./modules/tuning.nix;
         thunderbolt-ibverbs = inputs.thunderbolt-ibverbs.nixosModules.default;
@@ -622,6 +626,8 @@
             "ec-su-axb35"
             "ec-su-axb35-monitor"
             "fastflowlm"
+            "kerf-init"
+            "kerf-multikernel"
             "llama-cpp-master-rocm"
             "llama-cpp-master-vulkan"
             "llama-cpp-rocm"
@@ -629,7 +635,9 @@
             "llvm-aie"
             "mlir-aie"
             "mlir-aie-env"
+            "linux-multikernel"
             "mlx-rocm"
+            "multikernel-demo-initrd"
             "sglang-rocm"
             "strix-halo-mes-firmware"
             "therock-amdsmi"
@@ -1053,6 +1061,121 @@
               vllmPackage = fakeVllmEnv;
               packageSuffix = "ci";
             };
+
+            multikernelEval = lib.nixosSystem {
+              inherit system;
+              modules = [
+                self.nixosModules.multikernel
+                {
+                  nixpkgs.pkgs = pkgs;
+                  system.stateVersion = "26.05";
+                  boot.loader.grub.enable = false;
+                  fileSystems."/" = {
+                    device = "/dev/null";
+                    fsType = "ext4";
+                  };
+                  boot.multikernel = {
+                    enable = true;
+                    pool = {
+                      cpus = "12-15,28-31";
+                      memory = "8GB";
+                    };
+                    instances.blue = {
+                      id = 1;
+                      cpus = "12-13,28-29";
+                      memory = "2GB";
+                    };
+                  };
+                }
+              ];
+            };
+
+            multikernelModule =
+              let
+                plain = builtins.unsafeDiscardStringContext;
+                poolScript = plain multikernelEval.config.systemd.services.multikernel-pool.script;
+                instanceScript = plain multikernelEval.config.systemd.services.multikernel-instance-blue.script;
+                controller = lib.findFirst (
+                  package: lib.getName package == "multikernelctl"
+                ) null multikernelEval.config.environment.systemPackages;
+              in
+              pkgs.runCommandLocal "ci-multikernel-module"
+                {
+                  nativeBuildInputs = [ pkgs.gnugrep ];
+                  meta.maintainers = with lib.maintainers; [ georgewhewell ];
+                }
+                ''
+                  cat > pool.sh <<'EOF'
+                  ${poolScript}
+                  EOF
+                  cat > instance.sh <<'EOF'
+                  ${instanceScript}
+                  EOF
+                  grep -F -- "--cpus=12-15,28-31" pool.sh
+                  grep -F -- "--memory=8GB" pool.sh
+                  grep -F -- "kerf create blue" instance.sh
+                  grep -F -- "--id=1" instance.sh
+                  grep -F -- "console=mktty0" instance.sh
+                  grep -F -- "multikernel.demo.name=blue" instance.sh
+                  grep -F -- 'systemctl stop "multikernel-instance-$instance.service"' ${controller}/bin/multikernelctl
+                  grep -F -- 'systemctl stop multikernel-pool.service' ${controller}/bin/multikernelctl
+                  touch "$out"
+                '';
+
+            multikernelKernelConfig =
+              pkgs.runCommandLocal "ci-multikernel-kernel-config"
+                {
+                  nativeBuildInputs = [ pkgs.gnugrep ];
+                  meta.maintainers = with lib.maintainers; [ georgewhewell ];
+                }
+                ''
+                  config=${pkgs.linux-multikernel.configfile}
+                  for symbol in \
+                    KEXEC_FILE KEXEC_HANDOVER KEXEC_HANDOVER_ENABLE_DEFAULT \
+                    MULTIKERNEL MKTTY SMP HOTPLUG_CPU MEMORY_HOTPLUG \
+                    MEMORY_HOTREMOVE DAXFS VSOCKETS; do
+                    grep -qx "CONFIG_$symbol=y" "$config"
+                  done
+                  grep -qx '# CONFIG_DEFERRED_STRUCT_PAGE_INIT is not set' "$config"
+                  grep -qx '# CONFIG_MULTIKERNEL_VSOCKETS is not set' "$config"
+                  cp "$config" "$out"
+                '';
+
+            multikernelInitrd =
+              pkgs.runCommandLocal "ci-multikernel-demo-initrd"
+                {
+                  nativeBuildInputs = [
+                    pkgs.cpio
+                    pkgs.gnugrep
+                    pkgs.zstd
+                  ];
+                  meta.maintainers = with lib.maintainers; [ georgewhewell ];
+                }
+                ''
+                  mkdir unpack
+                  cd unpack
+                  zstd -dc ${pkgs.multikernel-demo-initrd}/initrd | cpio -id
+                  find . -printf '%P\n' | sort > "$out"
+                  grep -qx init "$out"
+                  grep -qx bin/sh "$out"
+                  grep -qx bin/busybox "$out"
+                  grep -qx bin/multikernel-demo "$out"
+                  demo=$(find nix/store -maxdepth 1 -type f -name '*-multikernel-demo')
+                  grep -Fq '/sys/devices/system/cpu/online' "$demo"
+                  grep -Fq 'physical APIC' "$demo"
+                '';
+
+            multikernelKerf =
+              pkgs.runCommandLocal "ci-multikernel-kerf"
+                {
+                  nativeBuildInputs = [ pkgs.kerf-multikernel ];
+                  meta.maintainers = with lib.maintainers; [ georgewhewell ];
+                }
+                ''
+                  kerf --help > "$out"
+                  grep -q 'Multikernel Management System' "$out"
+                  kerf create --help | grep -q 'Use physical APIC'
+                '';
           in
           {
             deadnix = runSourceCheck "deadnix" [ pkgs.deadnix ] "deadnix --fail .";
@@ -1061,6 +1184,10 @@
               pkgs.nixfmt-tree
             ] "treefmt --tree-root . --walk filesystem --fail-on-change .";
             cuda-host-driver-runtime = cudaHostDriverRuntime;
+            multikernel-demo-initrd = multikernelInitrd;
+            multikernel-kerf = multikernelKerf;
+            multikernel-kernel-config = multikernelKernelConfig;
+            multikernel-module = multikernelModule;
             package-surface = packageSurface;
             vllm-pair-bench-dry-run =
               pkgs.runCommandLocal "ci-vllm-pair-bench-dry-run"

--- a/lib/hydra.nix
+++ b/lib/hydra.nix
@@ -101,10 +101,13 @@ let
           ds4-rocm
           ec-su-axb35-monitor
           fastflowlm
+          kerf-multikernel
           llama-cpp-rocm
           llama-cpp-vulkan
           llama-cpp-master
+          linux-multikernel
           mlx-rocm
+          multikernel-demo-initrd
           strix-halo-mes-firmware
           therock-rocm
           tokenizers-cpp

--- a/modules/multikernel.nix
+++ b/modules/multikernel.nix
@@ -1,0 +1,403 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.boot.multikernel;
+  inherit (lib)
+    mkEnableOption
+    mkIf
+    mkOption
+    types
+    ;
+
+  instanceType = types.submodule (
+    { name, ... }:
+    {
+      options = {
+        enable = mkEnableOption "the ${name} multikernel instance" // {
+          default = true;
+        };
+
+        id = mkOption {
+          type = types.nullOr (types.ints.between 1 511);
+          default = null;
+          description = "Stable multikernel instance ID; null lets Kerf allocate one.";
+        };
+
+        cpus = mkOption {
+          type = types.str;
+          example = "12-13,28-29";
+          description = "Physical APIC IDs assigned to this instance.";
+        };
+
+        memory = mkOption {
+          type = types.str;
+          example = "2GB";
+          description = "Contiguous memory allocated to this instance from the pool.";
+        };
+
+        devices = mkOption {
+          type = types.listOf types.str;
+          default = [ ];
+          description = "Kerf device aliases exclusively assigned to this instance.";
+        };
+
+        kernel = mkOption {
+          type = types.str;
+          default = cfg.spawnKernel;
+          defaultText = lib.literalExpression "config.boot.multikernel.spawnKernel";
+          description = "ELF vmlinux or x86 bzImage loaded into the instance.";
+        };
+
+        initrd = mkOption {
+          type = types.nullOr types.str;
+          default = cfg.spawnInitrd;
+          defaultText = lib.literalExpression "config.boot.multikernel.spawnInitrd";
+          description = "Optional initramfs passed to the spawn kernel.";
+        };
+
+        entrypoint = mkOption {
+          type = types.str;
+          default = "/bin/multikernel-demo";
+          description = "Spawn initramfs entrypoint, interpreted by kerf-init.";
+        };
+
+        kernelParams = mkOption {
+          type = types.listOf types.str;
+          default = [
+            "init=/init"
+            "console=mktty0"
+            "loglevel=6"
+            "panic=-1"
+            "pci=nobar"
+            "random.trust_cpu=on"
+            "sysrq_always_enabled=1"
+          ];
+          description = "Kernel command-line parameters for the spawn kernel.";
+        };
+
+        prepareAtBoot = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Create the instance and load its kernel during host boot.";
+        };
+
+        startAtBoot = mkOption {
+          type = types.bool;
+          default = false;
+          description = "Boot the prepared spawn kernel during host boot.";
+        };
+      };
+    }
+  );
+
+  enabledInstances = lib.filterAttrs (_: instance: instance.enable) cfg.instances;
+  instanceNames = builtins.attrNames enabledInstances;
+  kerf = lib.getExe cfg.package;
+
+  poolArgs = [
+    kerf
+    "init"
+    "--cpus=${cfg.pool.cpus}"
+    "--memory=${cfg.pool.memory}"
+  ]
+  ++ lib.optional (cfg.pool.devices != [ ]) "--devices=${lib.concatStringsSep "," cfg.pool.devices}";
+
+  instanceCmdline =
+    name: instance:
+    lib.concatStringsSep " " (
+      instance.kernelParams
+      ++ [
+        "multikernel.demo.name=${name}"
+        ''kerf.entrypoint="${instance.entrypoint}"''
+      ]
+    );
+
+  createArgs =
+    name: instance:
+    [
+      kerf
+      "create"
+      name
+      "--cpus=${instance.cpus}"
+      "--memory=${instance.memory}"
+    ]
+    ++ lib.optional (instance.id != null) "--id=${toString instance.id}"
+    ++ lib.optional (instance.devices != [ ]) "--devices=${lib.concatStringsSep "," instance.devices}";
+
+  loadArgs =
+    name: instance:
+    [
+      kerf
+      "load"
+      name
+      "--kernel=${instance.kernel}"
+      "--cmdline=${instanceCmdline name instance}"
+    ]
+    ++ lib.optional (instance.initrd != null) "--initrd=${instance.initrd}";
+
+  mkInstanceService = name: instance: {
+    description = "Prepare multikernel instance ${name}";
+    after = [ "multikernel-pool.service" ];
+    requires = [ "multikernel-pool.service" ];
+    wantedBy = lib.optional (instance.prepareAtBoot || instance.startAtBoot) "multi-user.target";
+    path = [ pkgs.coreutils ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      set -eu
+      instance_dir=/sys/fs/multikernel/instances/${name}
+
+      if [ ! -d "$instance_dir" ]; then
+        ${lib.escapeShellArgs (createArgs name instance)}
+      fi
+
+      status=$(cat "$instance_dir/status")
+      case "$status" in
+        ready)
+          ${lib.escapeShellArgs (loadArgs name instance)}
+          ;;
+        loaded|active)
+          ;;
+        *)
+          echo "multikernel instance ${name} has unexpected status: $status" >&2
+          exit 1
+          ;;
+      esac
+
+      ${lib.optionalString instance.startAtBoot ''
+        status=$(cat "$instance_dir/status")
+        if [ "$status" = loaded ]; then
+          ${lib.escapeShellArgs [
+            kerf
+            "exec"
+            name
+          ]}
+        fi
+      ''}
+    '';
+  };
+
+  instanceServices = lib.mapAttrs' (
+    name: instance: lib.nameValuePair "multikernel-instance-${name}" (mkInstanceService name instance)
+  ) enabledInstances;
+
+  knownNames =
+    if instanceNames == [ ] then
+      "__no_declarative_instances__"
+    else
+      lib.concatStringsSep "|" instanceNames;
+  multikernelctl = pkgs.writeShellApplication {
+    name = "multikernelctl";
+    runtimeInputs = [
+      cfg.package
+      pkgs.coreutils
+      pkgs.systemd
+    ];
+    text = ''
+      set -euo pipefail
+
+      command="''${1:-show}"
+      instance="''${2:-}"
+
+      require_instance() {
+        if [ -z "$instance" ]; then
+          echo "usage: multikernelctl $command <instance>" >&2
+          exit 2
+        fi
+        case "$instance" in
+          ${knownNames}) ;;
+          *)
+            echo "unknown declarative instance: $instance" >&2
+            echo "known instances: ${lib.concatStringsSep " " instanceNames}" >&2
+            exit 2
+            ;;
+        esac
+      }
+
+      case "$command" in
+        prepare)
+          require_instance
+          systemctl start "multikernel-instance-$instance.service"
+          ;;
+        start)
+          require_instance
+          systemctl start "multikernel-instance-$instance.service"
+          exec kerf exec "$instance"
+          ;;
+        console)
+          require_instance
+          exec kerf console "$instance"
+          ;;
+        stop)
+          require_instance
+          exec kerf kill "$instance"
+          ;;
+        force-stop)
+          require_instance
+          exec kerf kill --force "$instance"
+          ;;
+        unload)
+          require_instance
+          exec kerf unload "$instance"
+          ;;
+        delete)
+          require_instance
+          kerf delete "$instance"
+          systemctl stop "multikernel-instance-$instance.service"
+          ;;
+        show)
+          if [ -n "$instance" ]; then
+            exec kerf show "$instance"
+          else
+            exec kerf show
+          fi
+          ;;
+        reset-pool)
+          kerf init --cpus=none --memory=none
+          systemctl stop multikernel-pool.service
+          ;;
+        *)
+          echo "usage: multikernelctl {prepare|start|console|stop|force-stop|unload|delete|show|reset-pool} [instance]" >&2
+          exit 2
+          ;;
+      esac
+    '';
+  };
+in
+{
+  options.boot.multikernel = {
+    enable = mkEnableOption "bare-metal multikernel Linux";
+
+    selectHostKernel = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Select the packaged multikernel kernel as boot.kernelPackages.";
+    };
+
+    hostKernelPackages = mkOption {
+      type = types.raw;
+      default = pkgs.linuxPackages_multikernel;
+      defaultText = lib.literalExpression "pkgs.linuxPackages_multikernel";
+      description = "Linux package set used by the host kernel.";
+    };
+
+    package = mkOption {
+      type = types.package;
+      default = pkgs.kerf-multikernel;
+      defaultText = lib.literalExpression "pkgs.kerf-multikernel";
+      description = "Kerf multikernel lifecycle manager.";
+    };
+
+    spawnKernel = mkOption {
+      type = types.str;
+      default = "${cfg.hostKernelPackages.kernel.dev}/vmlinux";
+      defaultText = lib.literalExpression ''"${config.boot.multikernel.hostKernelPackages.kernel.dev}/vmlinux"'';
+      description = "Default kernel image loaded into spawn instances.";
+    };
+
+    spawnInitrd = mkOption {
+      type = types.nullOr types.str;
+      default = "${pkgs.multikernel-demo-initrd}/initrd";
+      defaultText = lib.literalExpression ''"${pkgs.multikernel-demo-initrd}/initrd"'';
+      description = "Default self-contained spawn initramfs.";
+    };
+
+    pool = {
+      cpus = mkOption {
+        type = types.str;
+        example = "12-15,28-31";
+        description = "Physical APIC IDs moved from the host into the multikernel pool.";
+      };
+
+      memory = mkOption {
+        type = types.str;
+        example = "8GB";
+        description = "Runtime contiguous-memory pool managed by the host kernel.";
+      };
+
+      devices = mkOption {
+        type = types.listOf types.str;
+        default = [ ];
+        description = "Kerf device aliases moved into the multikernel pool.";
+      };
+
+      prepareAtBoot = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Create the resource pool during host boot.";
+      };
+    };
+
+    instances = mkOption {
+      type = types.attrsOf instanceType;
+      default = { };
+      description = "Declarative spawn-kernel instances.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = builtins.match "[0-9,-]+" cfg.pool.cpus != null;
+        message = "boot.multikernel.pool.cpus must be a Kerf APIC-ID list such as 12-15,28-31";
+      }
+      {
+        assertion =
+          builtins.match "[0-9]+(KB|MB|GB|TB|KiB|MiB|GiB|TiB|B)?(@[0-9]+)?(,[0-9]+(KB|MB|GB|TB|KiB|MiB|GiB|TiB|B)?(@[0-9]+)?)*" cfg.pool.memory
+          != null;
+        message = "boot.multikernel.pool.memory must be a Kerf size such as 8GB";
+      }
+    ]
+    ++ lib.concatMap (
+      name:
+      let
+        instance = enabledInstances.${name};
+      in
+      [
+        {
+          assertion = builtins.match "[A-Za-z0-9_.-]+" name != null;
+          message = "multikernel instance names may contain only letters, digits, dot, underscore and dash";
+        }
+        {
+          assertion = builtins.match "[0-9,-]+" instance.cpus != null;
+          message = "boot.multikernel.instances.${name}.cpus must be an APIC-ID list";
+        }
+      ]
+    ) instanceNames;
+
+    boot.kernelPackages = mkIf cfg.selectHostKernel (lib.mkOverride 50 cfg.hostKernelPackages);
+    boot.kernel.sysctl."kernel.kexec_load_disabled" = 0;
+
+    environment.systemPackages = [
+      cfg.package
+      multikernelctl
+      pkgs.dtc
+    ];
+
+    systemd.services = {
+      multikernel-pool = {
+        description = "Prepare the bare-metal multikernel resource pool";
+        wantedBy = lib.optional cfg.pool.prepareAtBoot "multi-user.target";
+        before = map (name: "multikernel-instance-${name}.service") instanceNames;
+        path = [ pkgs.coreutils ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          set -eu
+          ${lib.escapeShellArgs poolArgs}
+          test -d /sys/fs/multikernel/instances
+        '';
+      };
+    }
+    // instanceServices;
+  };
+}

--- a/overlays/multikernel.nix
+++ b/overlays/multikernel.nix
@@ -1,0 +1,22 @@
+final: prev:
+
+prev.lib.optionalAttrs prev.stdenv.isLinux (
+  let
+    rdtsc = final.python3Packages.callPackage ../pkgs/multikernel/rdtsc.nix { };
+    kerf = final.python3Packages.callPackage ../pkgs/multikernel/kerf.nix {
+      inherit rdtsc;
+    };
+    kerfInit = final.pkgsStatic.callPackage ../pkgs/multikernel/kerf-init.nix { };
+  in
+  {
+    linux-multikernel = final.callPackage ../pkgs/multikernel/linux.nix { };
+    linuxPackages_multikernel = final.linuxPackagesFor final.linux-multikernel;
+
+    kerf-multikernel = kerf;
+    kerf-init = kerfInit;
+    multikernel-demo-initrd = final.callPackage ../pkgs/multikernel/demo-initrd.nix {
+      kerf-init = kerfInit;
+      busybox = final.pkgsStatic.busybox;
+    };
+  }
+)

--- a/pkgs/multikernel/demo-initrd.nix
+++ b/pkgs/multikernel/demo-initrd.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  makeInitrd,
+  writeTextFile,
+  busybox,
+  kerf-init,
+}:
+
+let
+  demo = writeTextFile {
+    name = "multikernel-demo";
+    executable = true;
+    text = ''
+      #!/bin/sh
+      set -eu
+
+      bb=/bin/busybox
+      name="$($bb sed -n 's/.*multikernel.demo.name=\([^ ]*\).*/\1/p' /proc/cmdline)"
+      [ -n "$name" ] || name=spawn
+
+      online_cpus="$($bb cat /sys/devices/system/cpu/online)"
+      apic_ids="$($bb awk '
+        /^apicid[[:space:]]*:/ {
+          if (count++) printf ",";
+          printf "%s", $3;
+        }
+        END { print "" }
+      ' /proc/cpuinfo)"
+
+      echo
+      echo "=== NixOS multikernel spawn: $name ==="
+      echo "kernel: $($bb uname -r)"
+      echo "boot-id: $($bb cat /proc/sys/kernel/random/boot_id)"
+      echo "pid: $$ (PID 1 is kerf-init)"
+      echo "cpus: logical $online_cpus; physical APIC $apic_ids"
+      echo "memory: $($bb awk '/MemTotal/ { print $2 " kB" }' /proc/meminfo)"
+      echo "cmdline: $($bb cat /proc/cmdline)"
+      echo "This kernel owns its scheduler, memory map, PID space and failure domain."
+      echo "An interactive shell is ready; 'echo c > /proc/sysrq-trigger' crashes only this spawn."
+      echo
+
+      (
+        tick=0
+        while :; do
+          tick=$((tick + 1))
+          echo "[$name] heartbeat $tick from kernel $($bb uname -r), boot $($bb cat /proc/sys/kernel/random/boot_id)"
+          $bb sleep 5
+        done
+      ) &
+
+      export PATH=/bin
+      export PS1="[$name \\u@multikernel]# "
+      exec /bin/sh -i
+    '';
+  };
+in
+(makeInitrd {
+  name = "multikernel-demo-initrd";
+  compressor = "zstd";
+  compressorArgs = [ "-19" ];
+  contents = [
+    {
+      object = kerf-init;
+      symlink = "/init";
+      suffix = "/bin/kerf-init";
+    }
+    {
+      object = busybox;
+      symlink = "/bin/busybox";
+      suffix = "/bin/busybox";
+    }
+    {
+      object = demo;
+      symlink = "/bin/multikernel-demo";
+    }
+  ]
+  ++
+    map
+      (applet: {
+        object = busybox;
+        symlink = "/bin/${applet}";
+        suffix = "/bin/busybox";
+      })
+      [
+        "awk"
+        "cat"
+        "dmesg"
+        "grep"
+        "head"
+        "ls"
+        "mount"
+        "poweroff"
+        "ps"
+        "sed"
+        "sh"
+        "sleep"
+        "sync"
+        "uname"
+      ];
+}).overrideAttrs
+  (_: {
+    passthru.entrypoint = "/bin/multikernel-demo";
+    meta = {
+      description = "Self-contained initramfs for demonstrating independent multikernel spawn kernels";
+      license = lib.licenses.asl20;
+      platforms = [ "x86_64-linux" ];
+      maintainers = with lib.maintainers; [ georgewhewell ];
+    };
+  })

--- a/pkgs/multikernel/kerf-init.nix
+++ b/pkgs/multikernel/kerf-init.nix
@@ -1,0 +1,37 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+}:
+
+stdenv.mkDerivation {
+  pname = "kerf-init";
+  version = "0.2.0";
+
+  src = fetchFromGitHub {
+    owner = "multikernel";
+    repo = "kerf";
+    rev = "8b72b3e9b266f8d32e707e2c1743ad7afc50b1ec";
+    hash = "sha256-feP1fO7A6ARdth05Eo6PltzWkAC3UKdzZ1vtM0bg7hY=";
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin"
+    $CC -Wall -Wextra -Werror -O2 -static \
+      -o "$out/bin/kerf-init" src/init/init.c
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Minimal static PID 1 for multikernel spawn initramfs images";
+    homepage = "https://github.com/multikernel/kerf";
+    license = lib.licenses.asl20;
+    mainProgram = "kerf-init";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ georgewhewell ];
+  };
+}

--- a/pkgs/multikernel/kerf.nix
+++ b/pkgs/multikernel/kerf.nix
@@ -1,0 +1,49 @@
+{
+  lib,
+  buildPythonApplication,
+  fetchFromGitHub,
+  poetry-core,
+  click,
+  libfdt,
+  pyyaml,
+  pyudev,
+  rdtsc,
+  zstandard,
+}:
+
+buildPythonApplication rec {
+  pname = "kerf-multikernel";
+  version = "0.2.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "multikernel";
+    repo = "kerf";
+    rev = "8b72b3e9b266f8d32e707e2c1743ad7afc50b1ec";
+    hash = "sha256-feP1fO7A6ARdth05Eo6PltzWkAC3UKdzZ1vtM0bg7hY=";
+  };
+
+  build-system = [ poetry-core ];
+  dependencies = [
+    click
+    libfdt
+    pyyaml
+    pyudev
+    rdtsc
+    zstandard
+  ];
+
+  # Hardware lifecycle tests require a multikernel host. Unit coverage is
+  # exercised separately by the flake check with a writable fake sysfs tree.
+  doCheck = false;
+  pythonImportsCheck = [ "kerf" ];
+
+  meta = {
+    description = "Resource-safe lifecycle manager for Linux multikernel instances";
+    homepage = "https://github.com/multikernel/kerf";
+    license = lib.licenses.asl20;
+    mainProgram = "kerf";
+    platforms = [ "x86_64-linux" ];
+    maintainers = with lib.maintainers; [ georgewhewell ];
+  };
+}

--- a/pkgs/multikernel/linux.nix
+++ b/pkgs/multikernel/linux.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  buildLinux,
+  fetchFromGitHub,
+  source ? fetchFromGitHub {
+    owner = "multikernel";
+    repo = "linux";
+    # Annotated tag v7.0-mk2, released 2026-08-25.
+    rev = "3bdd35b64413da0b4e089ce931bfc2e8b031cbf7";
+    hash = "sha256-tMCLOHzGon+i5jws7tzaHgR5D1/2ef9bQJYegG42r74=";
+  },
+  ...
+}@args:
+
+buildLinux (
+  args
+  // {
+    pname = "linux-multikernel";
+    version = "7.0-mk2";
+    modDirVersion = "7.0.0-mk2";
+
+    # Override with `linux-multikernel.override { source = /path/to/linux; }`
+    # for local kernel development while the public output stays reproducible.
+    src = source;
+
+    # This is a complete upstream-derived tree, not a patch against the
+    # nixpkgs kernel. Keep its exact source while reusing nixpkgs' generic
+    # x86_64 configuration and module packaging.
+    kernelPatches = [ ];
+    ignoreConfigErrors = false;
+
+    structuredExtraConfig = with lib.kernel; {
+      KEXEC = yes;
+      KEXEC_FILE = yes;
+      KEXEC_HANDOVER = yes;
+      KEXEC_HANDOVER_ENABLE_DEFAULT = yes;
+      MULTIKERNEL = yes;
+      MKTTY = yes;
+      SMP = yes;
+      HOTPLUG_CPU = yes;
+      MEMORY_HOTPLUG = yes;
+      MEMORY_HOTREMOVE = yes;
+
+      # Useful, but not required by the minimal initramfs demo: DAXFS can
+      # expose a shared root image.
+      DAXFS = yes;
+      VSOCKETS = yes;
+
+      # mk2's optional transport still implements the pre-7.0
+      # vsock_transport.stream_allow callback signature and does not compile
+      # in the release tree. Keep the core architecture buildable without a
+      # downstream source patch; the device-free MKTTY demo does not use it.
+      MULTIKERNEL_VSOCKETS = lib.mkForce no;
+
+      # Kexec HandOver excludes deferred struct-page initialization. The
+      # in-tree mk2 allocator selects CMA through KEXEC_HANDOVER and uses
+      # alloc_contig_range() to grow its pool at runtime.
+      DEFERRED_STRUCT_PAGE_INIT = lib.mkForce unset;
+
+      RELOCATABLE = yes;
+      BLK_DEV_INITRD = yes;
+      DEVTMPFS = yes;
+      DEVTMPFS_MOUNT = yes;
+    };
+
+    extraMeta = {
+      branch = "7.0-mk2";
+      description = "Linux 7.0 with Multikernel Technologies' bare-metal multi-kernel architecture";
+      homepage = "https://github.com/multikernel/linux";
+      license = lib.licenses.gpl2Only;
+      platforms = [ "x86_64-linux" ];
+      maintainers = with lib.maintainers; [ georgewhewell ];
+    };
+
+    passthru = {
+      multikernel = {
+        abi = 1;
+        release = "v7.0-mk2";
+        rev = "3bdd35b64413da0b4e089ce931bfc2e8b031cbf7";
+      };
+    };
+  }
+  // (args.argsOverride or { })
+)

--- a/pkgs/multikernel/rdtsc.nix
+++ b/pkgs/multikernel/rdtsc.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  setuptools,
+}:
+
+buildPythonPackage rec {
+  pname = "rdtsc";
+  version = "0.2.1";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-mTqP6ArQDjzKl2/qoKT+mJeOleATq11miu7XiQveTos=";
+  };
+
+  postPatch = ''
+    substituteInPlace src/rdtsc/__init__.py \
+      --replace-fail "import pkg_resources" "from importlib import resources" \
+      --replace-fail "pkg_resources.resource_filename('rdtsc', sofile)" 'str(resources.files("rdtsc").joinpath(sofile))'
+  '';
+
+  build-system = [ setuptools ];
+  pythonImportsCheck = [ "rdtsc" ];
+
+  meta = {
+    description = "Small Python wrapper around the x86 RDTSC instruction";
+    homepage = "https://github.com/Roguelazer/rdtsc";
+    license = lib.licenses.isc;
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
## Summary

- package the exact upstream Linux `v7.0-mk2` and Kerf `v0.2.0` releases
- add a reusable overlay and NixOS module for host pools plus declarative spawn instances
- add `multikernelctl` lifecycle operations and a static MKTTY demo initramfs
- expose packages, module, Hydra jobs, documentation, and focused flake checks
- allow the kernel source to be overridden with a local checkout while retaining a pinned public default

## Hardware validation

Tested end to end on the Strix Halo `strix-4` bare-metal PXE host:

- host booted Linux `7.0.0-mk2`
- created an 8 GiB pool from physical APIC IDs 24 through 31
- ran blue on APIC 24-27 and red on APIC 28-31, each with 2 GiB
- deliberately panicked blue through `/proc/sysrq-trigger`
- confirmed the host and red retained their boot IDs and red kept heartbeating
- respawned blue from its already-loaded kernel image with a new boot ID
- stopped, unloaded, and deleted both instances
- returned all eight APIC IDs and the complete memory pool without rebooting

The exact observations are recorded in `docs/multikernel-strix-4.md`.

## Checks

- `linux-multikernel`, `kerf-multikernel`, and `multikernel-demo-initrd` build
- `multikernel-module`
- `multikernel-kernel-config`
- `multikernel-demo-initrd`
- `multikernel-kerf`
- `nixfmt`
- `deadnix`
- `statix`

## Known limitation

`CONFIG_MULTIKERNEL_VSOCKETS` is disabled because the mk2 release contains a stale `stream_allow` callback signature that does not compile against its own Linux 7.0 VSOCK API. CPU and memory transfer, kexec handover, MKTTY, and DAXFS remain enabled. The demonstrated path uses CPU, memory, kexec, and MKTTY.

Multikernel instances are cooperative bare-metal kernels, not hostile-guest security boundaries.