### PR TITLE
sglang: serve Qwen3.8-Flash-Next on four V620s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /result-*
 /out-*/
 /gcroots/
+/.bench-artifacts/
+/torch_compile_debug/

--- a/docs/evidence/qwen38-flash-next-v620-20260828.md
+++ b/docs/evidence/qwen38-flash-next-v620-20260828.md
@@ -1,0 +1,102 @@
+# Qwen3.8-Flash-Next V620 qualification evidence
+
+Date: 2026-08-28
+
+Host: `strix-2`
+
+Hardware: four AMD Radeon Pro V620 cards, TP4, HIP devices `0,1,2,3`; the
+Strix Halo iGPU was excluded.
+
+Model: `/mnt/trex-models-fabric/Qwen3.8-Flash-Next-W4A16-G32`, read-only
+publication of the 131-shard, 173.558 GiB expert-only W4A16-G32 checkpoint.
+
+Package:
+`/nix/store/m5k617a9fx8w5rv66nnnkznhyb334px2-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552`
+
+Unit: `codex-qwen38-flash-next-tp4-v26.service`
+
+Raw log on the campaign host:
+`.bench-artifacts/serve/serve-20260828-220237.log`
+
+## Load and readiness
+
+The server loaded all 131 shards, skipped 333 language-model-excluded visual
+weights on every rank, allocated a 4,096-token cache, and reported:
+
+```text
+[2026-08-28 22:05:49 TP0] max_total_num_tokens=4096, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=1, context_len=4096, available_gpu_mem=8.50 GB
+[2026-08-28 22:05:49] The server is fired up and ready to roll!
+```
+
+## External completions
+
+The first request disabled thinking, used greedy decoding, and asked for an
+exact response. The OpenAI-compatible endpoint returned HTTP 200 in 7.522666
+seconds:
+
+```json
+{"content":"V620 FLASH WORKS","prompt_tokens":23,"completion_tokens":8,"reasoning_tokens":0}
+```
+
+The immediately following request had a 48-token prompt and asked for roughly
+120 words explaining mixture-of-experts routing. It returned HTTP 200 in
+10.789894 seconds with 146 completion tokens. The response began:
+
+```text
+Mixture-of-Experts (MoE) models decouple total parameter count from computational cost by employing a sparse gating mechanism.
+```
+
+The server recorded the padded 64-token QSA prefill tile and warm decode:
+
+```text
+[2026-08-28 22:06:26 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, input throughput (token/s): 9.43
+[2026-08-28 22:06:31 TP0] Decode batch, #running-req: 1, #full token: 128, gen throughput (token/s): 14.01
+[2026-08-28 22:06:34 TP0] Decode batch, #running-req: 1, #full token: 192, gen throughput (token/s): 14.13
+```
+
+## Failure reproduced and closed
+
+The preceding v24 run returned a valid short completion, then the longer
+prompt reproduced the gfx1030 QSA prefill failure:
+
+```text
+triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 67584, Hardware limit: 65536. Reducing block sizes or `num_stages` may help.
+```
+
+v26 used one Triton software-pipeline stage for ROCm QSA prefill while retaining
+the upstream tile and warp count. Both the short completion and the formerly
+failing longer prefill passed after that change. v24's successful short request
+had already forced the HIP JIT build of the patched MoE alignment kernel, and
+v26 executed the same patched path; no `sgl_kernel`, AITER, or NVIDIA-only
+backend entered the serving path.
+
+## Build gates
+
+The exact reviewed revision passed:
+
+```text
+nix build .#legacyPackages.x86_64-linux.gfx1030.sglang-qwen38-flash-next-rocm
+/nix/store/m5k617a9fx8w5rv66nnnkznhyb334px2-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552
+
+nix build .#sglang-qwen38-flash-next-rocm
+/nix/store/2baakfxc4ri7qqqi3v290h01y5gdyq8q-sglang-rocm-gfx1151-0.5.17.dev0+qwen4exp.73a2552
+
+nix build .#legacyPackages.x86_64-linux.gfx1030.vllm-rocm
+/nix/store/lshnzk3143w5fdlggwm1gkbjhafrkgb2-python3.13-vllm-0.25.1
+
+nix build .#vllm-rocm
+/nix/store/1mmff759x0yixyqjc9i84zikqk4b9nii-python3.13-vllm-0.25.1
+
+qwen38-flash-next-runtime-smoke
+{"aiter":"0","moe_topk":"torch_native","sgl_kernel_loaded":false,"status":"ok"}
+
+nix build .#hydraJobs.x86_64-linux.ci.source
+/nix/store/w5vp68qz5rvdqpmwjdzpyv0v5x3gl6mi-nix-strix-halo-ci-source
+
+nix build .#hydraJobs.x86_64-linux.ci.checks
+/nix/store/h1vmxqng7gf16hjm011hl5fgrqp8ld7j-nix-strix-halo-ci-checks
+```
+
+`nix flake check --accept-flake-config --no-build` also passed. The final
+stacked branch's ROCm source-provider aggregate includes vLLM, SGLang, MLX,
+DS4, and both llama.cpp tracks.

--- a/docs/evidence/qwen38-flash-next-v620-20260828.md
+++ b/docs/evidence/qwen38-flash-next-v620-20260828.md
@@ -11,12 +11,12 @@ Model: `/mnt/trex-models-fabric/Qwen3.8-Flash-Next-W4A16-G32`, read-only
 publication of the 131-shard, 173.558 GiB expert-only W4A16-G32 checkpoint.
 
 Package:
-`/nix/store/m5k617a9fx8w5rv66nnnkznhyb334px2-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552`
+`/nix/store/816iqv6ikd913gzbkqz1gy605rszfz7m-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552`
 
-Unit: `codex-qwen38-flash-next-tp4-v26.service`
+Unit: `codex-qwen38-flash-next-tp4-v29.service`
 
 Raw log on the campaign host:
-`.bench-artifacts/serve/serve-20260828-220237.log`
+`.bench-artifacts/serve/serve-20260828-222635.log`
 
 ## Load and readiness
 
@@ -24,34 +24,43 @@ The server loaded all 131 shards, skipped 333 language-model-excluded visual
 weights on every rank, allocated a 4,096-token cache, and reported:
 
 ```text
-[2026-08-28 22:05:49 TP0] max_total_num_tokens=4096, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=1, context_len=4096, available_gpu_mem=8.50 GB
-[2026-08-28 22:05:49] The server is fired up and ready to roll!
+[2026-08-28 22:29:43 TP0] max_total_num_tokens=4096, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=1, context_len=4096, available_gpu_mem=8.50 GB
+[2026-08-28 22:29:44] The server is fired up and ready to roll!
 ```
+
+The packaged launcher resolved its own immutable closure. Its logged arguments
+showed `disable_overlap_schedule=True`; CUDA graphs were also disabled. The
+launcher set `SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION=false`, so `/health`
+observed readiness without injecting a model request.
 
 ## External completions
 
 The first request disabled thinking, used greedy decoding, and asked for an
-exact response. The OpenAI-compatible endpoint returned HTTP 200 in 7.522666
-seconds:
+exact response. The OpenAI-compatible endpoint returned HTTP 200 in 5.271655
+seconds from the final packaged closure:
 
 ```json
 {"content":"V620 FLASH WORKS","prompt_tokens":23,"completion_tokens":8,"reasoning_tokens":0}
 ```
 
-The immediately following request had a 48-token prompt and asked for roughly
+The immediately following request had a 59-token prompt and asked for roughly
 120 words explaining mixture-of-experts routing. It returned HTTP 200 in
-10.789894 seconds with 146 completion tokens. The response began:
+11.075127 seconds with 140 completion tokens. The response began:
 
 ```text
-Mixture-of-Experts (MoE) models decouple total parameter count from computational cost by employing a sparse gating mechanism.
+A Mixture-of-Experts (MoE) model scales capacity by replacing dense feed-forward layers with multiple specialized expert networks.
 ```
+
+A third arithmetic control returned exact content `14` for 420 tokens over 30
+seconds: HTTP 200, 36 prompt tokens, three completion tokens, and 0.378691
+seconds. Passive health returned HTTP 200 in 1.4--1.6 ms after every request.
 
 The server recorded the padded 64-token QSA prefill tile and warm decode:
 
 ```text
-[2026-08-28 22:06:26 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, input throughput (token/s): 9.43
-[2026-08-28 22:06:31 TP0] Decode batch, #running-req: 1, #full token: 128, gen throughput (token/s): 14.01
-[2026-08-28 22:06:34 TP0] Decode batch, #running-req: 1, #full token: 192, gen throughput (token/s): 14.13
+[2026-08-28 22:30:08 TP0] Prefill batch, #new-seq: 1, #new-token: 64, #cached-token: 0, input throughput (token/s): 56.23
+[2026-08-28 22:30:14 TP0] Decode batch, #running-req: 1, #full token: 192, gen throughput (token/s): 12.54
+[2026-08-28 22:30:17 TP0] Decode batch, #running-req: 1, #full token: 192, gen throughput (token/s): 13.93
 ```
 
 ## Failure reproduced and closed
@@ -64,10 +73,20 @@ triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 
 ```
 
 v26 used one Triton software-pipeline stage for ROCm QSA prefill while retaining
-the upstream tile and warp count. Both the short completion and the formerly
-failing longer prefill passed after that change. v24's successful short request
-had already forced the HIP JIT build of the patched MoE alignment kernel, and
-v26 executed the same patched path; no `sgl_kernel`, AITER, or NVIDIA-only
+the upstream tile and warp count. Both requests returned valid output, but an
+asynchronous `at::native::vectorized_gather_kernel` hardware exception then
+faulted all four ranks. The traceback showed SGLang's overlap event loop and QSA
+gathers from shared ring buffers; SGLang enables its default write-after-read
+barrier from `is_cuda()`, which is false for HIP in this branch.
+
+v27 disabled scheduler overlap. The campaign's readiness poll then exposed a
+second edge: upstream `/health` defaults to generating one token from raw input
+ID `[0]`, and that non-chat QSA probe faulted. The final launcher therefore
+keeps overlap disabled and makes `/health` passive. v28 passed seven sequential
+chat completions in total, including a post-idle exact `STILL STABLE`
+completion, with passive health between the preceding requests. v29 repeated
+the acceptance set from the exact packaged closure and returned exact `STILL
+PACKAGED` after its own idle interval. No `sgl_kernel`, AITER, or NVIDIA-only
 backend entered the serving path.
 
 ## Build gates
@@ -76,10 +95,10 @@ The exact reviewed revision passed:
 
 ```text
 nix build .#legacyPackages.x86_64-linux.gfx1030.sglang-qwen38-flash-next-rocm
-/nix/store/m5k617a9fx8w5rv66nnnkznhyb334px2-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552
+/nix/store/816iqv6ikd913gzbkqz1gy605rszfz7m-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552
 
 nix build .#sglang-qwen38-flash-next-rocm
-/nix/store/2baakfxc4ri7qqqi3v290h01y5gdyq8q-sglang-rocm-gfx1151-0.5.17.dev0+qwen4exp.73a2552
+/nix/store/n67vv71dw7axn9vvlypnncn1843w2c28-sglang-rocm-gfx1151-0.5.17.dev0+qwen4exp.73a2552
 
 nix build .#legacyPackages.x86_64-linux.gfx1030.vllm-rocm
 /nix/store/lshnzk3143w5fdlggwm1gkbjhafrkgb2-python3.13-vllm-0.25.1
@@ -94,7 +113,7 @@ nix build .#hydraJobs.x86_64-linux.ci.source
 /nix/store/w5vp68qz5rvdqpmwjdzpyv0v5x3gl6mi-nix-strix-halo-ci-source
 
 nix build .#hydraJobs.x86_64-linux.ci.checks
-/nix/store/h1vmxqng7gf16hjm011hl5fgrqp8ld7j-nix-strix-halo-ci-checks
+/nix/store/mlqrvn96dsj5x81zh0df85aih5dkw4bv-nix-strix-halo-ci-checks
 ```
 
 `nix flake check --accept-flake-config --no-build` also passed. The final

--- a/docs/qwen38-flash-next-v620-campaign.md
+++ b/docs/qwen38-flash-next-v620-campaign.md
@@ -32,9 +32,10 @@ As of 2026-08-28:
   FP8 host embedding storage at load time, reducing its payload from
   102,466,171,160 bytes to about half that size. Gathered PLE values are
   converted back to the model dtype before computation;
-- live serving qualification is in progress. Constructor or load completion is
-  not a serving result; the gate remains an externally observed generated-token
-  response.
+- live serving is qualified on four V620s with the ROCm 10 stack:
+  an externally observed short completion returned HTTP 200, and a second
+  48-token prompt generated 146 coherent tokens at 14.01--14.13 tok/s warm
+  decode. Constructor or load completion alone is not counted as a result.
 
 The hardware recovery gate remains explicit: firmware **PCI Hot-Plug -> PCI
 Buses Padding = 5**, remove independent PEX-board power until its LEDs are dark,
@@ -109,10 +110,12 @@ FP16 range audit.
 
 ## Immutable inputs and reproduction
 
-The campaign worktree is `/mnt/Home/src/nix-strix-halo-qwen38-flash-next` on
-`feat/qwen38-flash-next-v620`, forked from the final corrected Qwen3.8 V620
-campaign at `4a6ae1a4`. The main `npu-exporter` worktree and the dirty
-`nixos-config` worktree are deliberately untouched.
+The clean PR worktree is
+`/mnt/Home/src/nix-strix-halo-qwen38-flash-next-clean` on
+`feat/qwen38-flash-next-v620-clean`, stacked on the ROCm 10 source-provider PR
+#165 at `2329fc1b` (itself based on the merged stable update at `e24b2efc`).
+The historical campaign worktree remains separate. The main `npu-exporter`
+worktree and the dirty `nixos-config` worktree are deliberately untouched.
 
 Pinned inputs:
 
@@ -401,3 +404,38 @@ page cache after loading. It does not enable MXFP4, FP8 compute, AITER,
 FlashInfer, TileLang, CuTe, or speculation by accident. The model pathname above
 records the campaign mount; a persistent deployment may use another read-only
 mount only after passing the same inventory and fabric-counter gates.
+
+### Live qualification evidence
+
+The first complete ROCm 10 qualification used TP4 unit
+`codex-qwen38-flash-next-tp4-v26.service`, exact closure
+`/nix/store/m5k617a9fx8w5rv66nnnkznhyb334px2-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552`,
+and log
+`.bench-artifacts/serve/serve-20260828-220237.log` on strix-2. A compact,
+tracked extract is available in
+[`qwen38-flash-next-v620-20260828.md`](evidence/qwen38-flash-next-v620-20260828.md).
+The immutable checkpoint was published read-only at
+`/mnt/trex-models-fabric/Qwen3.8-Flash-Next-W4A16-G32`.
+
+The first external request returned HTTP 200 in 7.523 seconds with 23 prompt
+tokens, eight completion tokens, and the exact response:
+
+```text
+V620 FLASH WORKS
+```
+
+The immediately following warm request exercised the previously failing
+64-token Triton prefill tile. It returned HTTP 200 in 10.790 seconds with 48
+prompt tokens and 146 completion tokens. SGLang reported 9.43 input tok/s and
+14.01--14.13 generation tok/s. The answer correctly described sparse expert
+routing, top-k selection, and the separation between total parameter capacity
+and per-token compute.
+
+An earlier v24 run had already produced real tokens, then exposed a precise
+gfx1030 launch failure on the longer prompt: QSA's upstream two-stage prefill
+configuration requested 67,584 bytes of LDS against the V620's 65,536-byte
+limit. The qualified closure retains the upstream tile and warp count but uses
+one software-pipeline stage on ROCm. Both the short decode and longer prefill
+were repeated after that fix. At qualification time, v26 was left live at
+`http://strix-2:30800/v1`; endpoint lifetime is operational state rather than
+part of this immutable evidence record.

--- a/docs/qwen38-flash-next-v620-campaign.md
+++ b/docs/qwen38-flash-next-v620-campaign.md
@@ -33,9 +33,15 @@ As of 2026-08-28:
   102,466,171,160 bytes to about half that size. Gathered PLE values are
   converted back to the model dtype before computation;
 - live serving is qualified on four V620s with the ROCm 10 stack:
-  an externally observed short completion returned HTTP 200, and a second
-  48-token prompt generated 146 coherent tokens at 14.01--14.13 tok/s warm
-  decode. Constructor or load completion alone is not counted as a result.
+  the exact packaged closure returned the requested short completion and a
+  59-token prompt generated 140 coherent tokens at up to 13.93 tok/s warm
+  decode. Six earlier stateful requests plus a post-idle request passed with
+  the same safety settings. Constructor or load completion alone is not counted
+  as a result;
+- the qualified launcher disables scheduler overlap because this experimental
+  QSA path mutates shared ring buffers without SGLang's CUDA-only default WAR
+  barrier, and it makes `/health` passive rather than generating from raw token
+  ID zero.
 
 The hardware recovery gate remains explicit: firmware **PCI Hot-Plug -> PCI
 Buses Padding = 5**, remove independent PEX-board power until its LEDs are dark,
@@ -386,38 +392,41 @@ Where an older per-experiment note disagrees with those indexes, the index wins.
 
 ## First qualified launch
 
-Resolve the closure, select the published W4 snapshot, and start eagerly:
+Build the package, select the published W4 snapshot, and start eagerly. The
+packaged launcher resolves its own immutable closure:
 
 ```console
-export SGLANG_QWEN38_FLASH_NEXT_CLOSURE="$(readlink -f \
-  .bench-artifacts/closures/sglang-qwen4-exp-gfx1030-pr-73a2552)"
+closure="$(nix build --no-link --print-out-paths \
+  .#legacyPackages.x86_64-linux.gfx1030.sglang-qwen38-flash-next-rocm)"
 export MODEL=/mnt/trex-models-fabric/Qwen3.8-Flash-Next-W4A16-G32
 export CUDA_GRAPH=0
-bash scripts/qwen38-flash-next-serve.sh
+"$closure/bin/qwen38-flash-next-serve.sh"
 ```
 
 The launcher forces TP4, FP16, FP32 SSM state, FP16 GDN convolution state,
 language-model-only loading, PLE host offload, Triton attention/linear
 attention/MoE, Torch dense GEMM, durable caches, and V620-only visibility. It
-also disables the unavailable custom all-reduce extension and drops checkpoint
-page cache after loading. It does not enable MXFP4, FP8 compute, AITER,
-FlashInfer, TileLang, CuTe, or speculation by accident. The model pathname above
-records the campaign mount; a persistent deployment may use another read-only
-mount only after passing the same inventory and fabric-counter gates.
+also disables the unavailable custom all-reduce extension, scheduler overlap,
+and model-generating health checks, then drops checkpoint page cache after
+loading. It does not enable MXFP4, FP8 compute, AITER, FlashInfer, TileLang,
+CuTe, or speculation by accident. `OVERLAP_SCHEDULE=1` is an unqualified
+experiment that enables SGLang's coarse HIP WAR barrier. The model pathname
+above records the campaign mount; a persistent deployment may use another
+read-only mount only after passing the same inventory and fabric-counter gates.
 
 ### Live qualification evidence
 
-The first complete ROCm 10 qualification used TP4 unit
-`codex-qwen38-flash-next-tp4-v26.service`, exact closure
-`/nix/store/m5k617a9fx8w5rv66nnnkznhyb334px2-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552`,
+The final ROCm 10 qualification used TP4 unit
+`codex-qwen38-flash-next-tp4-v29.service`, exact packaged closure
+`/nix/store/816iqv6ikd913gzbkqz1gy605rszfz7m-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552`,
 and log
-`.bench-artifacts/serve/serve-20260828-220237.log` on strix-2. A compact,
+`.bench-artifacts/serve/serve-20260828-222635.log` on strix-2. A compact,
 tracked extract is available in
 [`qwen38-flash-next-v620-20260828.md`](evidence/qwen38-flash-next-v620-20260828.md).
 The immutable checkpoint was published read-only at
 `/mnt/trex-models-fabric/Qwen3.8-Flash-Next-W4A16-G32`.
 
-The first external request returned HTTP 200 in 7.523 seconds with 23 prompt
+The first external request returned HTTP 200 in 5.272 seconds with 23 prompt
 tokens, eight completion tokens, and the exact response:
 
 ```text
@@ -425,9 +434,9 @@ V620 FLASH WORKS
 ```
 
 The immediately following warm request exercised the previously failing
-64-token Triton prefill tile. It returned HTTP 200 in 10.790 seconds with 48
-prompt tokens and 146 completion tokens. SGLang reported 9.43 input tok/s and
-14.01--14.13 generation tok/s. The answer correctly described sparse expert
+64-token Triton prefill tile. It returned HTTP 200 in 11.075 seconds with 59
+prompt tokens and 140 completion tokens. SGLang reported 56.23 input tok/s and
+up to 13.93 generation tok/s. The answer correctly described sparse expert
 routing, top-k selection, and the separation between total parameter capacity
 and per-token compute.
 
@@ -436,6 +445,16 @@ gfx1030 launch failure on the longer prompt: QSA's upstream two-stage prefill
 configuration requested 67,584 bytes of LDS against the V620's 65,536-byte
 limit. The qualified closure retains the upstream tile and warp count but uses
 one software-pipeline stage on ROCm. Both the short decode and longer prefill
-were repeated after that fix. At qualification time, v26 was left live at
-`http://strix-2:30800/v1`; endpoint lifetime is operational state rather than
-part of this immutable evidence record.
+were repeated after that fix.
+
+The first two v26 responses were not accepted as final qualification: all four
+ranks subsequently reported an asynchronous PyTorch gather hardware exception
+while SGLang was using its overlap event loop. A v27 serial-scheduler run then
+showed that the default `/health` endpoint itself performs a raw one-token model
+probe. The qualified launcher closes both hazards by disabling overlap and
+making `/health` passive. v28 passed seven requests in total, including a
+post-idle exact response, with passive health checks between the preceding
+requests. v29 repeated the acceptance set from the packaged closure and
+returned exact `STILL PACKAGED` after its own idle interval. At qualification
+time, v29 was left live at `http://strix-2:30800/v1`; endpoint lifetime is
+operational state rather than part of this immutable evidence record.

--- a/docs/qwen38-flash-next-v620-campaign.md
+++ b/docs/qwen38-flash-next-v620-campaign.md
@@ -1,0 +1,403 @@
+# Qwen3.8-Flash-Next on 4x V620
+
+## Decision and current status
+
+The production target is **expert-only INT4 W4A16, symmetric group 32, FP16
+activations, FP32 GDN state/accumulation where required, TP4, and PLE host
+offload**. BF16 is the immutable quality oracle. Official FP8 is a quality
+control, not a four-card serving format. Native MXFP4/NVFP4 is not available on
+gfx1030 and must not be emulated in the production path.
+
+As of 2026-08-28:
+
+- the exact 131-shard BF16 revision is complete and inventory-clean on trex at
+  `/mnt/optane/models/Qwen3.8-Flash-Next-BF16`;
+- the G32 conversion is complete: 131 shards, 173.558 GiB logical size, 73,728
+  routed expert projections, aggregate reconstruction RMSE `0.09651483`, and a
+  closed-world compressed-tensors manifest that leaves every non-routed tensor
+  unquantized;
+- the source-built SGLang Qwen4-Exp support closure is pinned to PR head
+  `73a255206f916366c8d26d4022f82ddfb0ab558d`;
+- a two-pass HIP Triton kernel replaces QSA decode's NVIDIA-only FA2/FA4 path;
+- gfx1030 import gates prevent unused AITER MXFP4/Quark paths from being
+  selected merely because PyTorch exposes HIP through `torch.cuda`;
+- the real Qwen4-Exp model import, including the in-tree Triton MoE runner and
+  generic runner's EAGLE import fan-out, is `sgl_kernel`-free on HIP;
+- the expert-only compressed-tensors producer and cautious TP4 launcher exist;
+- all four V620s and the PEX switch are recovered on strix-2, while the Strix
+  iGPU remains excluded from the heterogeneous process;
+- TP4 construction selects `CompressedTensorsWNA16TritonMoE`, and a real
+  checkpoint load stays within both the four 32 GiB cards and 128 GiB host RAM;
+- PLE remains BF16 in the immutable checkpoint but is explicitly downcast into
+  FP8 host embedding storage at load time, reducing its payload from
+  102,466,171,160 bytes to about half that size. Gathered PLE values are
+  converted back to the model dtype before computation;
+- live serving qualification is in progress. Constructor or load completion is
+  not a serving result; the gate remains an externally observed generated-token
+  response.
+
+The hardware recovery gate remains explicit: firmware **PCI Hot-Plug -> PCI
+Buses Padding = 5**, remove independent PEX-board power until its LEDs are dark,
+restore board power, then boot the host. Do not use a live PCI rescan; that has
+caused HIP faults on this fleet. Before serving, `lspci` must show all four
+V620s and the switch topology, and the selected model path must be a read-only
+mount containing the verified checkpoint.
+
+Upstream references:
+
+- [Qwen3.8-Flash-Next BF16](https://huggingface.co/Qwen/Qwen3.8-Flash-Next)
+- [Qwen3.8-Flash-Next FP8](https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8)
+- [official Qwen repository](https://github.com/QwenLM/Qwen3.8-Flash-Next)
+- [SGLang support PR #36497](https://github.com/sgl-project/sglang/pull/36497)
+- [SGLang model cookbook](https://docs.sglang.io/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next)
+
+## Cluster campaign triage
+
+The 2026-08-28 campaign treats the hardware as two useful but distinct pools:
+four gfx1030 V620s on strix-2, and one gfx1151 Strix Halo iGPU on each of
+strix-1 and strix-2. Their memory does not become one transparent 256 GiB
+address space. A heterogeneous or cross-host design must earn its keep through
+an explicit SGLang transport; it cannot be justified by adding the capacity
+numbers together.
+
+| track | observed control | campaign decision |
+|---|---|---|
+| Qwen3.8-27B dense | TP4 V620 decode: 20.674 tok/s B1, 129.00 B8, 146.31 B16, 262.83 B32 | regression and thermal control |
+| DeepSeek V4 Flash | prior TP2 decode: 10.99-11.51 tok/s prose and 14.62-16.50 tok/s code | strongest existing SGLang control; requalify without dead strix-3 |
+| GLM-5.2 | one-node heterogeneous correctness exists; gfx1030 attention and production multi-host transport remain limiting | transport/correctness work, not the first serving target |
+| Qwen3.8-Flash-Next | 125B total / 6B active hybrid model; expert-only G32 is resident only with PLE host compression and low-peak layout conversion | highest-value four-V620 experiment |
+
+The sequence is therefore dense Qwen control, bounded DeepSeek TP2 control,
+then Flash-Next TP4 on the four V620s. The two Halos remain available for
+controls and future disaggregated work, but are not mixed into this TP group.
+TP4 across four hosts is not tested while strix-3 is dead.
+
+## Why this precision ladder
+
+The V620 is RDNA2/gfx1030. It has fast native packed FP16 and INT4/INT8 dot
+operations. It does not have native BF16, FP8, MXFP4, MFMA, or WMMA. A format
+name in a checkpoint is not a hardware capability.
+
+| candidate | checkpoint size | TP4 after BF16/FP8 PLE offload | decision |
+|---|---:|---:|---|
+| BF16 | 335.29 GiB | about 59.98 GiB/card | immutable oracle; cannot reside |
+| official FP8 | 172.76 GiB | about 31.27 GiB/card | exceeds the cards' usable ~29.98 GiB before KV/workspace |
+| official NVFP4 | smaller | Blackwell-only kernels | reject on gfx1030 |
+| SGLang MXFP4 | smaller | gfx95 AITER path only | reject on gfx1030 |
+| routed experts W4A16-G32 | 173.558 GiB full checkpoint; about 68 GB packed routed-expert payload | about 22 GiB/card observed during load, PLE excluded | primary candidate |
+| routed experts W4A16-G64 | estimated 59.77 GiB expert payload | about 18.67 GiB/card total, PLE excluded | quality/latency control |
+| routed experts W4A16-G128 | estimated 58.01 GiB expert payload | about 18.23 GiB/card total, PLE excluded | residency control only |
+
+The W4 estimates follow directly from 48 layers, 512 routed experts per layer,
+and three `640 x 2560` projections per expert: 120,795,955,200 routed-expert
+parameters. G32 stores 4-bit values plus one FP16 scale per 32 values. The
+estimate is conservative because the coding service uses
+`--language-model-only` and never loads the vision tower.
+
+The full G32 checkpoint is much larger than the packed expert payload because
+PLE alone is 102,466,171,160 bytes in the immutable BF16 source. Four ranks
+therefore cannot each retain BF16 PLE in the host. `ple_embedding_dtype` is an
+explicit runtime storage decision, not a claim that the source checkpoint was
+rewritten or that the V620 has native FP8 arithmetic.
+
+G32 is the quality-first starting point. The campaign may promote an
+activation-aware G32 checkpoint over round-to-nearest G32, but it may not
+silently widen quantization to routers, the shared expert, PLE, GDN, QSA,
+hyperconnections, norms, embeddings, `lm_head`, or MTP. Those tensors remain in
+their source precision on disk and load as native FP16 after a complete BF16 to
+FP16 range audit.
+
+## Immutable inputs and reproduction
+
+The campaign worktree is `/mnt/Home/src/nix-strix-halo-qwen38-flash-next` on
+`feat/qwen38-flash-next-v620`, forked from the final corrected Qwen3.8 V620
+campaign at `4a6ae1a4`. The main `npu-exporter` worktree and the dirty
+`nixos-config` worktree are deliberately untouched.
+
+Pinned inputs:
+
+| input | revision |
+|---|---|
+| Qwen BF16 | `f5d08274bafd880402bd16f5e3e6c514136ec06c` |
+| SGLang support | `73a255206f916366c8d26d4022f82ddfb0ab558d` |
+| SGLang source hash | `sha256-7idPvXJCurLcQXcpppOuZjvoy/mEYIWB85ItBCQK/pI=` |
+| Transformers | `5.12.1` wheel, used by the SGLang-local Qwen4-Exp config |
+
+Build and resolve the exact closure:
+
+```console
+nix build .#legacyPackages.x86_64-linux.gfx1030.sglang-qwen38-flash-next-rocm \
+  --out-link .bench-artifacts/closures/sglang-qwen4-exp-gfx1030-pr-73a2552
+closure=$(readlink -f .bench-artifacts/closures/sglang-qwen4-exp-gfx1030-pr-73a2552)
+```
+
+`sglang version` must report both
+`0.5.17.dev0+qwen4exp.73a2552` and git revision `73a2552`.
+
+Before device work, run the converter's fused-layout self-test and the offline
+gfx1030 QSA compiler gate. The admitted score/value kernels use 166/193 VGPRs
+and zero bytes of private scratch; the rejected one-pass design spilled as much
+as 4,272 bytes.
+
+```console
+smoke=$(mktemp -d -p .bench-artifacts qwen-w4-smoke.XXXXXX)
+SGLANG_USE_AITER=0 \
+  "$closure/bin/qwen38-flash-next-runtime-smoke"
+"$closure/bin/qwen38-flash-next-quantize-experts" \
+  --self-test-dir "$smoke" --group-size 32
+"$closure/bin/qwen38-flash-next-qsa-aot" \
+  --output "$smoke/qsa-gfx1030-aot.json"
+```
+
+The runtime smoke gate imports the actual Qwen4-Exp module through its
+activation, MoE, model-runner, and EAGLE dependencies and fails if
+`sgl_kernel` enters the process. `sglang serve --help` is not a substitute: it
+does not import the model implementation.
+
+Resume and verify the BF16 staging download with
+[`qwen38-flash-next-stage-bf16.sh`](../scripts/qwen38-flash-next-stage-bf16.sh).
+The verifier reads every safetensors header, checks the index-to-shard mapping,
+and refuses a partial 131-shard checkpoint.
+
+For the multi-hour transfer, run it as a restartable user service rather than
+leaving it attached to an agent shell:
+
+```console
+systemd-run --user \
+  --unit=qwen38-flash-next-bf16-download.service \
+  --working-directory=/mnt/Home/src/nix-strix-halo-qwen38-flash-next \
+  --property=RuntimeMaxSec=infinity \
+  --property=Restart=on-failure \
+  --property=RestartSec=15s \
+  --collect \
+  bash scripts/qwen38-flash-next-stage-bf16.sh
+```
+
+The SPDK namespace root is intentionally root-owned. The stage script requires
+the pre-provisioned model directory and cache directory themselves to be
+writable; it does not require permission to create arbitrary top-level model
+names. A successful unit proceeds directly from the pinned download to the
+complete inventory and writes `.campaign-revision` only after verification.
+
+After the BF16 gate passes, create the first resident checkpoint with the
+quantizer installed in the exact SGLang closure:
+
+```console
+closure=$(readlink -f .bench-artifacts/closures/sglang-qwen4-exp-gfx1030-pr-73a2552)
+"$closure/bin/qwen38-flash-next-quantize-experts" \
+  --source /mnt/optane/models/Qwen3.8-Flash-Next-BF16 \
+  --output /mnt/optane/models/Qwen3.8-Flash-Next-W4A16-G32 \
+  --group-size 32
+```
+
+The official source stores each language layer as two fused 3-D tensors,
+`experts.gate_up_proj` and `experts.down_proj`. The conversion is resumable per
+shard and immutable per plan. It requires exactly `48 * 2 = 96` fused language
+expert tensors, slices all 512 experts, and emits exactly
+`48 * 512 * 3 = 73,728` per-expert packed projections in the naming convention
+SGLang maps to W13/W2. MTP's two fused expert tensors remain bit-identical and
+unquantized. The converter records aggregate reconstruction error and produces
+a new internally consistent safetensors index.
+
+Do not publish `/mnt/optane/models` read-write. The first campaign publication
+uses trex's read-only NFS export. Linux NFSv4 recognizes trex's management and
+fabric addresses as one server, so merely mounting `192.168.25.8` can silently
+reuse the existing `192.168.23.8` transport. Verify both the RPC transport's
+source/destination addresses and interface byte counters; the pathname and
+mount source string are not proof. The 2026-08-28 campaign migrated the shared
+RPC transports to `192.168.25.102 -> 192.168.25.8` and measured a cold 3.47 GB
+shard read entirely on `cx5fabric0` (3.51 GB fabric RX versus 164 KB management
+RX). Persist that export and routing in the fleet configuration before treating
+it as production.
+
+## Admission gates
+
+No optimization advances without its gate artifact under `.bench-artifacts`.
+
+### G0: hardware and topology
+
+- Four V620s appear as the only devices in `HIP_VISIBLE_DEVICES=0,1,2,3`.
+- The Strix iGPU is excluded.
+- PEX P2P/IPC and RCCL all-reduce pass before SGLang starts.
+- The selected model path is a read-only publication containing the verified
+  checkpoint, and interface counters prove that loading uses the intended
+  fabric rather than the management LAN.
+- Board clocks, junction temperature, fan state, and throttling counters are
+  recorded before and after each run.
+
+### G1: checkpoint fidelity and consumption
+
+- All 131 BF16 shards and all index entries pass header/offset/size validation.
+- Every BF16 value in every tensor is scanned before runtime FP16 conversion;
+  overflow is a hard failure and flush-to-zero counts are reported by tensor.
+- The quantized index contains exactly three packed tensors for each routed
+  projection and unchanged names for every non-routed tensor.
+- SGLang startup emits a parameter-consumption manifest. Missing, silently
+  dropped, multiply consumed, or unexpected tensors are hard failures. This is
+  mandatory because the DS4 0.5.14 loader silently dropped MTP tensors.
+
+### G2: numerical correctness
+
+- W4 pack/unpack round-trips its INT4 values exactly.
+- Dequantized tensor error is measured with the FP16 scale actually stored in
+  the checkpoint, not an FP32 pre-rounding scale.
+- QSA HIP eager decode is compared against its FP32 reference over random and
+  adversarial index layouts, including paged logical-to-physical mapping.
+- Both QSA passes must lower for `hip/gfx1030` with zero private scratch before
+  device testing; offline lowering is not a numerical or performance claim.
+- Eager and graph modes produce identical greedy tokens for at least 1,600
+  tokens across code, prose, long-prefix, tool-call, and multi-request cases.
+- Radix-cache cold and warm outputs match. Speculative mode must match greedy
+  target tokens before any speed result is admitted.
+- Tool parsing must produce populated `tool_calls`; token-0/`!` loops are a
+  hard failure, not a parser cosmetic.
+
+### G3: quality
+
+Use the BF16 checkpoint or an externally provisioned BF16 oracle for the
+quality baseline; the 188 GiB trex host cannot hold the 335 GiB oracle. Freeze
+prompts and reference outputs before comparing G32/G64/G128.
+
+The quality suite must include:
+
+- held-out code completion and repository-edit tasks;
+- function/tool calling with parallel and sequential calls;
+- long-context retrieval at 8K, 32K, 64K, and 128K;
+- preserved-thinking and non-preserved-thinking conversations;
+- perplexity or teacher-forced NLL on code and prose corpora;
+- the two-subagent coding acceptance fixture described below.
+
+Choose by quality first among variants that meet residency. G64/G128 exist to
+measure the quality-memory curve, not to justify avoidable degradation. If RTN
+G32 misses the frozen threshold, collect expert-input activation statistics on
+the resident model and produce an activation-aware G32 checkpoint; do not
+quantize additional tensor classes to make an easier kernel.
+
+### G4: performance
+
+Start from eager correctness, then admit one change at a time:
+
+1. CUDA graphs after graph/eager parity.
+2. Radix/prefix caching with `cached_tokens` evidence.
+3. QSA Triton decode against the HIP reference.
+4. GDN prefill and decode tiles tuned separately.
+5. W4 MoE tiles for actual Flash-Next shapes and batch regimes.
+6. NGRAM `k={2,4,8}` and native MTP/EAGLE, separately by workload.
+7. Scheduler/concurrency and memory fraction.
+
+Measure:
+
+| axis | required points |
+|---|---|
+| decode latency | batch 1; contexts 1K, 8K, 32K, 64K |
+| aggregate decode | concurrency 1, 2, 4, 8, 16, 32 |
+| TTFT | 1K, 8K, 31K, 64K, 128K, cold and exact-prefix warm |
+| cache | exact hit, one-token divergence, unique nonce miss, explicit flush |
+| speculation | code edit, code generation, tool JSON, prose, long-context |
+| stability | cold and sustained 30-minute runs with thermal telemetry |
+
+Trust server-reported generation throughput for aggregate results. Blocking
+Python client threads understated the old server by up to 4x. Every client
+prompt gets a nonce unless a cache hit is the independent variable. Warm timing
+starts no earlier than the third run. Variants run ABAB with fresh prompts and
+min-of-N reporting. Buffers for bandwidth/kernel work rotate over more than 128
+MiB so the result is DRAM, not Infinity Cache.
+
+Use the async benchmark client from the exact closure; it emits append-only,
+fsynced JSONL with cold/warm cache evidence and ABAB block labels:
+
+```console
+"$closure/bin/qwen38-flash-next-bench" \
+  --out .bench-artifacts/perf/prefix.jsonl \
+  --variant A --block-index 0 --trials 3 --samples 4 \
+  --concurrency 4 --prefix-tokens 16384 --max-new-tokens 128
+```
+
+## Coding-agent acceptance
+
+The target endpoint is OpenAI-compatible at
+`http://127.0.0.1:30800/v1`, served model `qwen3.8-flash-next`, with
+`qwen3_coder` tool parsing and `qwen3` reasoning parsing. Preserve thinking by
+default because it improves conversational continuity and makes stable prefixes
+reusable; test the opt-out explicitly.
+
+Port the production fixture from
+`/mnt/Home/src/nix-strix-halo-ds4-agent-prod/docs/production/ds4-agent.md` to
+both OpenCode/OMP and Pi. A passing run must:
+
+1. launch two distinct subagents with non-identical investigations;
+2. read the required repository files before editing;
+3. reproduce the intentionally failing boundary test;
+4. make the single minimal correction;
+5. run the focused and full tests;
+6. inspect the final diff and status;
+7. leave structured JSONL proving tool-call identity, order, inputs, outputs,
+   and completion.
+
+Prose claiming that work happened is not evidence. Duplicate subagents, empty
+tool results, edits before investigation, or a correct final file without the
+required process all fail. Run the fixture at concurrency 1 and with multiple
+simultaneous parent agents; fast B1 decode alone is not a good subagent service.
+
+Pi uses the same local Chat Completions endpoint through the repository's
+durable-runtime wrapper. Match its advertised limits to the qualified server;
+the Pi/OMP subagent extension remains an independently tested client component.
+
+```console
+export OPENAI_BASE_URL=http://127.0.0.1:30800/v1
+export OPENAI_API_KEY=qwen-local-no-auth
+export OPENAI_MODEL=qwen3.8-flash-next
+export PI_CONTEXT_WINDOW=32768
+export PI_MAX_TOKENS=8192
+export PI_REASONING=true
+export PI_WRAP_RUNTIME_DIR=/mnt/Home/src/.runtime/qwen38-flash-next-pi
+nix run .#pi-wrap
+```
+
+## Lessons carried forward
+
+- The old Qwen frontier was 20.674 tok/s B1, 33.832s cold 31K TTFT, and
+  0.464s warm 30K TTFT. Prefix reuse was the largest user-visible win: 74x.
+- NGRAM averaged 1.35x but ranged from 2.02x for a code edit to 0.92x for prose.
+  It remains workload-controlled.
+- CUDA graphs can erase standalone dispatch/fusion gains; measure end to end.
+- M<=8 GEMV and larger-M GEMM need different kernels. Do not inherit the old
+  dense model's hard-coded shapes into this MoE.
+- A 1.74x DS4 MoE kernel gain became only 3.1% end to end. Component wins need
+  server evidence.
+- Autotune keys include sequence length and every shape dimension. Record the
+  runtime-selected config, not merely the intended config.
+- Exact resolved Nix store paths and `/proc/<pid>/environ` are the truth.
+- Hugging Face Xet can buffer tens of gigabytes and finalize several shards in
+  one burst. Diagnose a stalled download from shard finalization together with
+  Xet controller progress, cgroup memory, PID I/O/CPU, sockets, and link errors;
+  a flat `du` sample alone is not evidence of a dead transfer.
+- The old V620s spent 90-95% of sustained work throttled near 106-107 C;
+  sustained TTFT regressed 11.9% and decode 7.9%. Thermal telemetry and ABAB
+  ordering are correctness requirements for performance claims.
+
+The prior corrected evidence remains in
+`/mnt/Home/src/nix-strix-halo-qwen38/.bench-artifacts/CAMPAIGN-INDEX.md` and
+`/mnt/Home/src/nix-strix-halo-ds4-focus/.bench-artifacts/DS4-CAMPAIGN-INDEX.md`.
+Where an older per-experiment note disagrees with those indexes, the index wins.
+
+## First qualified launch
+
+Resolve the closure, select the published W4 snapshot, and start eagerly:
+
+```console
+export SGLANG_QWEN38_FLASH_NEXT_CLOSURE="$(readlink -f \
+  .bench-artifacts/closures/sglang-qwen4-exp-gfx1030-pr-73a2552)"
+export MODEL=/mnt/trex-models-fabric/Qwen3.8-Flash-Next-W4A16-G32
+export CUDA_GRAPH=0
+bash scripts/qwen38-flash-next-serve.sh
+```
+
+The launcher forces TP4, FP16, FP32 SSM state, FP16 GDN convolution state,
+language-model-only loading, PLE host offload, Triton attention/linear
+attention/MoE, Torch dense GEMM, durable caches, and V620-only visibility. It
+also disables the unavailable custom all-reduce extension and drops checkpoint
+page cache after loading. It does not enable MXFP4, FP8 compute, AITER,
+FlashInfer, TileLang, CuTe, or speculation by accident. The model pathname above
+records the campaign mount; a persistent deployment may use another read-only
+mount only after passing the same inventory and fabric-counter gates.

--- a/flake.nix
+++ b/flake.nix
@@ -638,6 +638,7 @@
             "linux-multikernel"
             "mlx-rocm"
             "multikernel-demo-initrd"
+            "sglang-qwen38-flash-next-rocm"
             "sglang-rocm"
             "strix-halo-mes-firmware"
             "therock-amdsmi"

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -258,6 +258,11 @@ let
       ecPackages = prev.callPackage ../pkgs/ec-su-axb35.nix {
         ec-su-axb35-src = inputs.ec-su-axb35;
       };
+      qwen4PythonPackages = final.${therockPythonConfig.packagesAttr}.overrideScope (
+        pyFinal: _pyPrev: {
+          transformers = pyFinal.callPackage ../pkgs/transformers-5_12_1.nix { };
+        }
+      );
     in
     {
       amdgpu-smu-exporter = prev.callPackage ../pkgs/amdgpu-smu-exporter { };
@@ -350,6 +355,34 @@ let
         rocmSdk = final."therock-rocm-${suffix}";
         inherit (rocmTarget) packageSuffix;
         hsaOverrideGfxVersion = rocmTarget.hsaOverride or null;
+      };
+      sglang-qwen38-flash-next-rocm = prev.callPackage ../pkgs/sglang {
+        pythonPackages = qwen4PythonPackages;
+        rocmSdk = final."therock-rocm-${suffix}";
+        inherit (rocmTarget) packageSuffix;
+        hsaOverrideGfxVersion = rocmTarget.hsaOverride or null;
+        sglangVersion = "0.5.17.dev0+qwen4exp.73a2552";
+        sglangGitCommit = "73a255206f916366c8d26d4022f82ddfb0ab558d";
+        sglangSource = final.fetchFromGitHub {
+          owner = "sgl-project";
+          repo = "sglang";
+          rev = "73a255206f916366c8d26d4022f82ddfb0ab558d";
+          hash = "sha256-7idPvXJCurLcQXcpppOuZjvoy/mEYIWB85ItBCQK/pI=";
+        };
+        sglangPatchesPath = ../pkgs/sglang/patches-qwen4-exp;
+        sglangTestsPath = ../pkgs/sglang/tests-qwen4-exp;
+        sglangExtraScripts = [
+          ../scripts/qwen38-flash-next-bench.py
+          ../scripts/qwen38-flash-next-fp16-audit.py
+          ../scripts/qwen38-flash-next-inventory.py
+          ../scripts/qwen38-flash-next-quantize-experts.py
+          ../scripts/qwen38-flash-next-qsa-aot.py
+          ../scripts/qwen38-flash-next-runtime-smoke.py
+        ];
+        sglangRunChecks = false;
+        # The PR advertises optional CUDA and gfx95-only extras that are
+        # deliberately absent from this gfx1030 closure.
+        sglangRelaxRuntimeDeps = true;
       };
       vllm-rocm = final."vllm-rocm-therock-${suffix}";
     }

--- a/overlays/pkgs.nix
+++ b/overlays/pkgs.nix
@@ -378,6 +378,7 @@ let
           ../scripts/qwen38-flash-next-quantize-experts.py
           ../scripts/qwen38-flash-next-qsa-aot.py
           ../scripts/qwen38-flash-next-runtime-smoke.py
+          ../scripts/qwen38-flash-next-serve.sh
         ];
         sglangRunChecks = false;
         # The PR advertises optional CUDA and gfx95-only extras that are

--- a/pkgs/pi-wrap/default.nix
+++ b/pkgs/pi-wrap/default.nix
@@ -54,9 +54,34 @@ writeShellApplication {
       exit 2
     fi
 
-    extension="$(mktemp --suffix=.js -t pi-wrap-XXXXXX)"
+    context_window="''${PI_CONTEXT_WINDOW:-32768}"
+    max_tokens="''${PI_MAX_TOKENS:-2048}"
+    reasoning="''${PI_REASONING:-false}"
+    case "$context_window:$max_tokens" in
+      *[!0-9:]*|:*|*:|0:*|*:0) echo "pi-wrap: context/token limits must be positive integers" >&2; exit 2 ;;
+    esac
+    case "$reasoning" in
+      true|false) ;;
+      *) echo "pi-wrap: PI_REASONING must be true or false" >&2; exit 2 ;;
+    esac
+
+    if [ -n "''${PI_WRAP_RUNTIME_DIR:-}" ]; then
+      runtime_root="$PI_WRAP_RUNTIME_DIR"
+    elif [ -n "''${XDG_RUNTIME_DIR:-}" ]; then
+      runtime_root="$XDG_RUNTIME_DIR/pi-wrap"
+    else
+      echo "pi-wrap: set XDG_RUNTIME_DIR or PI_WRAP_RUNTIME_DIR" >&2
+      exit 2
+    fi
+    case "$runtime_root/" in
+      /tmp/*) echo "pi-wrap: refusing a /tmp runtime directory" >&2; exit 2 ;;
+    esac
+    mkdir -p -- "$runtime_root"
+    chmod 700 -- "$runtime_root"
+    session_dir="$(mktemp -d "$runtime_root/session.XXXXXX")"
+    extension="$session_dir/provider.js"
     cleanup() {
-      rm -f "$extension"
+      rm -rf -- "$session_dir"
     }
     trap cleanup EXIT
 
@@ -76,16 +101,16 @@ writeShellApplication {
         models: [{
           id: model,
           name: model,
-          reasoning: false,
+          reasoning: $reasoning,
           input: ["text"],
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: 32768,
-          maxTokens: 2048,
+          contextWindow: $context_window,
+          maxTokens: $max_tokens,
         }],
       });
     }
     EOF
 
-    exec ${pi}/bin/pi -e "$extension" --provider "$provider_id" --model "$model" "$@"
+    ${pi}/bin/pi -e "$extension" --provider "$provider_id" --model "$model" "$@"
   '';
 }

--- a/pkgs/sglang/default.nix
+++ b/pkgs/sglang/default.nix
@@ -300,6 +300,15 @@ pythonPackages.buildPythonApplication rec {
     for patch_file in ${./patches}/*.patch; do
       patch -p1 -d "$out/${pythonSitePackages}" < "$patch_file"
     done
+  ''
+  + lib.optionalString (gpuArch != null) ''
+    arch_patch_dir=${lib.escapeShellArg "${./patches}/${gpuArch}"}
+    if [ -d "$arch_patch_dir" ]; then
+      for patch_file in "$arch_patch_dir"/*.patch; do
+        [ -e "$patch_file" ] || continue
+        patch -p1 -d "$out/${pythonSitePackages}" < "$patch_file"
+      done
+    fi
   '';
 
   postFixup = ''

--- a/pkgs/sglang/default.nix
+++ b/pkgs/sglang/default.nix
@@ -16,6 +16,17 @@
   rocmSdk,
   packageSuffix ? "rocm",
   hsaOverrideGfxVersion ? null,
+  # Keep the released wheel as the default.  Qwen4-Exp support currently lives
+  # in an unmerged upstream PR, so its package is built side-by-side from the
+  # exact reviewed source revision instead of mutating the known-good service.
+  sglangVersion ? "0.5.14",
+  sglangGitCommit ? null,
+  sglangSource ? null,
+  sglangPatchesPath ? ./patches,
+  sglangTestsPath ? null,
+  sglangExtraScripts ? [ ],
+  sglangRunChecks ? false,
+  sglangRelaxRuntimeDeps ? false,
 }:
 
 let
@@ -25,6 +36,11 @@ let
   rocmRuntimeLibraryPath =
     (pythonPackages.torch.passthru.rocmRuntimeEnv or { }).LD_LIBRARY_PATH or "";
   gpuArch = if lib.hasPrefix "gfx" packageSuffix then packageSuffix else null;
+  sourceBuild = sglangSource != null;
+  sglangPatches = builtins.path {
+    path = sglangPatchesPath;
+    name = "sglang-${sglangVersion}-patches";
+  };
   rocmSdkForJit = symlinkJoin {
     name = "${rocmSdk.name or "rocm-sdk"}-sglang-jit";
     paths = [ rocmSdk ];
@@ -184,18 +200,53 @@ assert lib.assertMsg (
 ) "sglang-rocm requires the TheRock torch wheel package with passthru.sitePackages";
 pythonPackages.buildPythonApplication rec {
   pname = "sglang-rocm-${packageSuffix}";
-  version = "0.5.14";
-  format = "wheel";
+  version = sglangVersion;
+  format = if sourceBuild then "pyproject" else "wheel";
 
-  src = fetchurl {
-    url = "https://files.pythonhosted.org/packages/45/72/276c6252abfe5a0c893ab7b975253c73ae73f69d1fe7746e168bbefa2fcc/sglang-${version}-cp313-cp313-manylinux_2_34_x86_64.whl";
-    hash = "sha256-LSLmoX9sc1gK7yXSJPMWKh47yc1QQ7QCLYSXXF6WoM0=";
+  src =
+    if sourceBuild then
+      sglangSource
+    else
+      fetchurl {
+        url = "https://files.pythonhosted.org/packages/45/72/276c6252abfe5a0c893ab7b975253c73ae73f69d1fe7746e168bbefa2fcc/sglang-${version}-cp313-cp313-manylinux_2_34_x86_64.whl";
+        hash = "sha256-LSLmoX9sc1gK7yXSJPMWKh47yc1QQ7QCLYSXXF6WoM0=";
+      };
+
+  sourceRoot = lib.optionalString sourceBuild "source/python";
+
+  postPatch = lib.optionalString sourceBuild ''
+    cp pyproject_other.toml pyproject.toml
+    substituteInPlace pyproject.toml \
+      --replace-fail ', "setuptools-rust>=1.10"' ""
+  '';
+
+  env = {
+    # torch._dynamo initializes its cache during SGLang's import check.  The
+    # Nix builder HOME is /homeless-shelter, so give it a writable build-root
+    # cache instead of disabling the useful import gate.
+    XDG_CACHE_HOME = "/build/sglang-cache";
+    TORCHINDUCTOR_CACHE_DIR = "/build/sglang-cache/inductor";
+  }
+  // lib.optionalAttrs sourceBuild {
+    SETUPTOOLS_SCM_PRETEND_VERSION = version;
+    SGLANG_BUILD_RUST_EXTS = "none";
   };
 
   nativeBuildInputs = [
     autoPatchelfHook
     makeWrapper
-  ];
+  ]
+  ++ lib.optionals sourceBuild (
+    with pythonPackages;
+    [
+      setuptools
+      setuptools-scm
+      wheel
+    ]
+  );
+
+  doCheck = sglangRunChecks;
+  dontCheckRuntimeDeps = sglangRelaxRuntimeDeps;
 
   buildInputs = [
     stdenv.cc.cc.lib
@@ -208,6 +259,7 @@ pythonPackages.buildPythonApplication rec {
     amd-aiter
     anthropic
     apache-tvm-ffi
+    av
     blobfile
     build
     compressed-tensors
@@ -259,6 +311,7 @@ pythonPackages.buildPythonApplication rec {
     uvloop
     watchfiles
     xgrammar_0_2_1
+    xxhash
   ];
 
   pythonRemoveDeps = [
@@ -297,18 +350,30 @@ pythonPackages.buildPythonApplication rec {
   ];
 
   postInstall = ''
-    for patch_file in ${./patches}/*.patch; do
+    for patch_file in ${sglangPatches}/*.patch; do
+      [ -e "$patch_file" ] || continue
       patch -p1 -d "$out/${pythonSitePackages}" < "$patch_file"
     done
   ''
   + lib.optionalString (gpuArch != null) ''
-    arch_patch_dir=${lib.escapeShellArg "${./patches}/${gpuArch}"}
+    arch_patch_dir=${lib.escapeShellArg "${sglangPatches}/${gpuArch}"}
     if [ -d "$arch_patch_dir" ]; then
       for patch_file in "$arch_patch_dir"/*.patch; do
         [ -e "$patch_file" ] || continue
         patch -p1 -d "$out/${pythonSitePackages}" < "$patch_file"
       done
     fi
+  ''
+  # The Qwen4-Exp acceptance suite covers the gfx1030-only V620 patch set.
+  + lib.optionalString (sglangTestsPath != null && gpuArch == "gfx1030") ''
+    SGLANG_ROOT_UNDER_TEST="$out/${pythonSitePackages}" \
+      ${pythonPackages.python.interpreter} \
+        ${sglangTestsPath}/test_qsa_rocm_decode_patch.py
+  ''
+  + lib.optionalString (sglangExtraScripts != [ ]) ''
+    ${lib.concatMapStringsSep "\n" (script: ''
+      install -Dm755 ${script} "$out/bin/${lib.removeSuffix ".py" (baseNameOf script)}"
+    '') sglangExtraScripts}
   '';
 
   postFixup = ''
@@ -347,8 +412,18 @@ pythonPackages.buildPythonApplication rec {
     ${lib.optionalString (hsaOverrideGfxVersion != null) ''
       wrap_args+=(--set HSA_OVERRIDE_GFX_VERSION ${lib.escapeShellArg hsaOverrideGfxVersion})
     ''}
+    ${lib.optionalString (sglangGitCommit != null) ''
+      wrap_args+=(--set SGLANG_GIT_COMMIT ${lib.escapeShellArg sglangGitCommit})
+    ''}
 
-    for bin in "$out/bin/sglang" "$out/bin/killall_sglang"; do
+    for bin in \
+      "$out/bin/sglang" \
+      "$out/bin/killall_sglang" \
+      ${
+        lib.concatMapStringsSep " \\\n      " (
+          script: ''"$out/bin/${lib.removeSuffix ".py" (baseNameOf script)}"''
+        ) sglangExtraScripts
+      }; do
       [ -x "$bin" ] || continue
       wrapProgram "$bin" "''${wrap_args[@]}"
     done

--- a/pkgs/sglang/patches-qwen4-exp/0001-qwen4-exp-language-model-only.patch
+++ b/pkgs/sglang/patches-qwen4-exp/0001-qwen4-exp-language-model-only.patch
@@ -1,0 +1,16 @@
+diff --git a/sglang/srt/server_args.py b/sglang/srt/server_args.py
+index f22b4b48d..49897163e 100644
+--- a/sglang/srt/server_args.py
++++ b/sglang/srt/server_args.py
+@@ -7665,7 +7665,10 @@ class ServerArgs:
+         except Exception:
+             return False
+
+-    LANGUAGE_MODEL_ONLY_ARCHITECTURES = ("MuseGlimmerForConditionalGeneration",)
++    LANGUAGE_MODEL_ONLY_ARCHITECTURES = (
++        "MuseGlimmerForConditionalGeneration",
++        "Qwen4ExpForConditionalGeneration",
++    )
+
+     def _handle_language_model_only(self):
+         if not self.language_model_only:

--- a/pkgs/sglang/patches-qwen4-exp/0002-rocm-64-bit-warp-mask.patch
+++ b/pkgs/sglang/patches-qwen4-exp/0002-rocm-64-bit-warp-mask.patch
@@ -1,0 +1,21 @@
+ROCm 10 requires the mask passed to its *_sync warp intrinsics to be a 64-bit
+integer, including on RDNA wave32 targets.  Keep CUDA's 32-bit mask ABI and use
+the native 64-bit HIP mask under SGLang's existing USE_ROCM compile define.
+
+--- a/sglang/kernels/jit/csrc/moe/moe_align_kernel.cu
++++ b/sglang/kernels/jit/csrc/moe/moe_align_kernel.cu
+@@ -46,7 +46,13 @@ inline uint32_t next_pow2(uint32_t x) noexcept {
+ namespace moe {
+
+-__device__ __forceinline__ int warp_exclusive_scan(int v, unsigned mask = 0xffffffffu) {
++#ifdef USE_ROCM
++using warp_mask_t = unsigned long long;
++#else
++using warp_mask_t = unsigned;
++#endif
++
++__device__ __forceinline__ int warp_exclusive_scan(int v, warp_mask_t mask = ~warp_mask_t{0}) {
+   int original = v;
+ #pragma unroll
+   for (int offset = 1; offset < WARP_SIZE; offset <<= 1) {
+     int n = __shfl_up_sync(mask, v, offset);

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0001-qsa-rocm-reference-decode.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0001-qsa-rocm-reference-decode.patch
@@ -1,0 +1,240 @@
+Qwen4-Exp QSA decode treats every CUDA-like tensor as NVIDIA CUDA and then
+requires FA2 or FA4.  PyTorch deliberately exposes HIP tensors through the
+torch.cuda API, so q.is_cuda is true on the V620 and the upstream fallback
+raises ImportError before the first decoded token.
+
+Map logical QSA indices through the paged token table, then run a ROCm-portable
+Triton sparse GQA decode kernel over the physical slots.  Scores, online
+softmax state, and accumulation remain FP32.  The device-agnostic Torch
+implementation remains the independent reference for the campaign's kernel
+gate; the serving path no longer smuggles CUDA FlashAttention into a ROCm
+closure or pays Python-loop/index_select overhead on every decoded token.
+
+--- a/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
++++ b/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+@@ -29,6 +29,7 @@ from sglang.srt.layers.attention.qsa.metadata import (
+ )
+ from sglang.srt.layers.attention.qsa.sparse_attn import (
+     qwen_sparse_fa2_cu_seqlens_triton,
++    sparse_gqa_decode_physical_triton,
+     qwen_sparse_kv_extraction_compact_triton,
+     qwen_sparse_valid_counts_triton,
+     sparse_gqa_fwd_interface_triton,
+@@ -1666,7 +1667,22 @@ class QwenSparseAttnBackend(AttentionBackend):
+         pool = self.token_to_kv_pool
+         k_buffer = pool.get_key_buffer(layer.layer_id)
+         v_buffer = pool.get_value_buffer(layer.layer_id)
+-        if not q.is_cuda:
++        # torch.cuda is also the public HIP API, so q.is_cuda is true on ROCm.
++        # The generic branch below is NVIDIA-only (TRT-LLM or FA2/FA4).  Map
++        # QSA's logical indices through the paged table and use the portable
++        # Triton kernel directly on the physical KV slots instead.
++        if q.is_cuda and torch.version.hip is not None:
++            metadata = self._resolve_metadata(forward_batch)
++            slots = self._logical_to_physical(topk_indices, metadata)
++            output = sparse_gqa_decode_physical_triton(
++                q.contiguous(),
++                k_buffer,
++                v_buffer,
++                slots.contiguous(),
++                layer.scaling,
++            )
++            return output.reshape(q.shape[0], -1)
++        if not q.is_cuda:
+             metadata = self._resolve_metadata(forward_batch)
+             slots = self._logical_to_physical(topk_indices, metadata)
+             output = qsa_sparse_attention(q, k_buffer, v_buffer, slots, layer.scaling)
+--- a/sglang/srt/layers/attention/qsa/sparse_attn.py
++++ b/sglang/srt/layers/attention/qsa/sparse_attn.py
+@@ -24,6 +24,191 @@ def _get_best_config(total_q: int):
+     return next(cfg for limit, cfg in table if total_q <= limit)
+
+
++@triton.jit
++def _sparse_gqa_decode_scores_physical(
++    q,
++    k,
++    scores,
++    slots,
++    scale,
++    topk,
++    sq_m: tl.constexpr,
++    sq_h: tl.constexpr,
++    sq_d: tl.constexpr,
++    sk_n: tl.constexpr,
++    sk_h: tl.constexpr,
++    sk_d: tl.constexpr,
++    sx_m: tl.constexpr,
++    sx_h: tl.constexpr,
++    sx_n: tl.constexpr,
++    ss_m: tl.constexpr,
++    ss_n: tl.constexpr,
++    GROUP_SIZE: tl.constexpr,
++    BLOCK_M: tl.constexpr,
++    BLOCK_N: tl.constexpr,
++    HEAD_DIM: tl.constexpr,
++):
++    row = tl.program_id(0)
++    group = tl.program_id(1)
++    start = tl.program_id(2) * BLOCK_N
++    offs_h = tl.arange(0, BLOCK_M)
++    offs_d = tl.arange(0, HEAD_DIM)
++    offs_n = start + tl.arange(0, BLOCK_N)
++    token = tl.load(
++        slots + row * ss_m + offs_n * ss_n,
++        mask=offs_n < topk,
++        other=-1,
++    )
++    valid = (offs_n < topk) & (token >= 0)
++    q_values = tl.load(
++        q
++        + row * sq_m
++        + (group * GROUP_SIZE + offs_h[:, None]) * sq_h
++        + offs_d[None, :] * sq_d,
++        mask=(offs_h < GROUP_SIZE)[:, None],
++        other=0.0,
++    )
++    q_values = (q_values * scale * 1.4426950408).to(q_values.dtype)
++    keys = tl.load(
++        k
++        + token[None, :] * sk_n
++        + group * sk_h
++        + offs_d[:, None] * sk_d,
++        mask=valid[None, :],
++        other=0.0,
++    )
++    block_scores = tl.where(
++        valid[None, :], tl.dot(q_values, keys), -float("inf")
++    )
++    tl.store(
++        scores
++        + row * sx_m
++        + (group * GROUP_SIZE + offs_h[:, None]) * sx_h
++        + offs_n[None, :] * sx_n,
++        block_scores,
++        mask=(offs_h < GROUP_SIZE)[:, None] & (offs_n < topk)[None, :],
++    )
++
++
++@triton.jit
++def _sparse_gqa_decode_values_physical(
++    v,
++    out,
++    scores,
++    slots,
++    topk,
++    sv_n: tl.constexpr,
++    sv_h: tl.constexpr,
++    sv_d: tl.constexpr,
++    so_m: tl.constexpr,
++    so_h: tl.constexpr,
++    so_d: tl.constexpr,
++    sx_m: tl.constexpr,
++    sx_h: tl.constexpr,
++    sx_n: tl.constexpr,
++    ss_m: tl.constexpr,
++    ss_n: tl.constexpr,
++    GROUP_SIZE: tl.constexpr,
++    BLOCK_N: tl.constexpr,
++    BLOCK_D: tl.constexpr,
++    HEAD_DIM: tl.constexpr,
++):
++    row = tl.program_id(0)
++    head = tl.program_id(1)
++    group = head // GROUP_SIZE
++    d_start = tl.program_id(2) * BLOCK_D
++    offs_d = d_start + tl.arange(0, BLOCK_D)
++    offs_n = tl.arange(0, BLOCK_N)
++    max_value = tl.full([1], -float("inf"), tl.float32)
++    normalizer = tl.zeros([1], tl.float32)
++    accumulator = tl.zeros([BLOCK_D], tl.float32)
++    row_limit = ((topk + BLOCK_N - 1) // BLOCK_N) * BLOCK_N
++    for start in range(0, row_limit, BLOCK_N):
++        current = start + offs_n
++        token = tl.load(
++            slots + row * ss_m + current * ss_n,
++            mask=current < topk,
++            other=-1,
++        )
++        valid = (current < topk) & (token >= 0)
++        block_scores = tl.load(
++            scores + row * sx_m + head * sx_h + current * sx_n,
++            mask=current < topk,
++            other=-float("inf"),
++        )
++        block_scores = tl.where(valid, block_scores, -float("inf"))
++        next_max = tl.maximum(max_value, tl.max(block_scores, 0))
++        has_values = next_max > -float("inf")
++        alpha = tl.where(
++            has_values, tl.math.exp2(max_value - next_max), 0.0
++        )
++        probabilities = tl.where(
++            valid & has_values,
++            tl.math.exp2(block_scores - next_max),
++            0.0,
++        )
++        values = tl.load(
++            v
++            + token[:, None] * sv_n
++            + group * sv_h
++            + offs_d[None, :] * sv_d,
++            mask=valid[:, None] & (offs_d < HEAD_DIM)[None, :],
++            other=0.0,
++        )
++        accumulator = accumulator * alpha + tl.sum(
++            probabilities[:, None] * values, 0
++        )
++        normalizer = normalizer * alpha + tl.sum(probabilities, 0)
++        max_value = next_max
++    output = tl.where(normalizer > 0, accumulator / normalizer, 0.0)
++    tl.store(
++        out + row * so_m + head * so_h + offs_d * so_d,
++        output,
++        mask=offs_d < HEAD_DIM,
++    )
++
++
++def sparse_gqa_decode_physical_triton(q, k, v, slots, scale):
++    """Two-pass sparse GQA avoids spilling the [heads, dim] accumulator."""
++    rows, num_q_heads, head_dim = q.shape
++    num_kv_heads = k.shape[1]
++    group_size = num_q_heads // num_kv_heads
++    block_m = max(16, triton.next_power_of_2(group_size))
++    # The upstream L20 table spills 0.3--1.8 KiB on gfx1030 for every
++    # configuration except 32x8.  Keep the compiler-proven no-spill shape;
++    # row count is expressed by the launch grid, not this attention tile.
++    block_n, warps, stages = 32, 8, 2
++    out = torch.empty_like(q)
++    scores = torch.empty(
++        (rows, num_q_heads, slots.shape[1]), dtype=torch.float32, device=q.device
++    )
++    score_grid = (rows, num_kv_heads, triton.cdiv(slots.shape[1], block_n))
++    _sparse_gqa_decode_scores_physical[score_grid](
++        q, k, scores, slots, scale, slots.shape[1],
++        q.stride(0), q.stride(1), q.stride(2),
++        k.stride(0), k.stride(1), k.stride(2),
++        scores.stride(0), scores.stride(1), scores.stride(2),
++        slots.stride(0), slots.stride(1),
++        GROUP_SIZE=group_size,
++        BLOCK_M=block_m, BLOCK_N=block_n, HEAD_DIM=head_dim,
++        num_warps=warps, num_stages=stages,
++    )
++    value_block_n = 64
++    value_block_d = 64
++    value_grid = (rows, num_q_heads, triton.cdiv(head_dim, value_block_d))
++    _sparse_gqa_decode_values_physical[value_grid](
++        v, out, scores, slots, slots.shape[1],
++        v.stride(0), v.stride(1), v.stride(2),
++        out.stride(0), out.stride(1), out.stride(2),
++        scores.stride(0), scores.stride(1), scores.stride(2),
++        slots.stride(0), slots.stride(1),
++        GROUP_SIZE=group_size, BLOCK_N=value_block_n,
++        BLOCK_D=value_block_d, HEAD_DIM=head_dim,
++        num_warps=4, num_stages=2,
++    )
++    return out
++
++
+ @triton.jit
+ def _sparse_gqa_prefill(
+     q,

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0002-gfx1030-quant-import-gates.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0002-gfx1030-quant-import-gates.patch
@@ -1,0 +1,105 @@
+The generic quantization registry imports MXFP4 and Quark implementations even
+when the checkpoint uses compressed-tensors W4A16.  Both modules probe AITER
+at import time on HIP, while AITER deliberately has no gfx1030 target.  This
+made even `sglang serve --help` JIT an unsupported module and abort.
+
+Do not import the AITER MXFP4 shuffle helpers unless AITER was explicitly
+enabled, and omit the two AITER-backed Quark methods from the gfx10 registry.
+This does not claim MXFP4 support on V620: upstream already registers native
+MXFP4 only on CPU, CUDA, or gfx95.
+
+The separate diffusion registry is imported while rendering the generic
+`sglang serve --help` page.  Gate its AITER import on gfx95 as well, so merely
+asking for help cannot JIT an unsupported gfx1030 module.
+
+--- a/sglang/srt/layers/quantization/mxfp4.py
++++ b/sglang/srt/layers/quantization/mxfp4.py
+@@ -154,7 +154,7 @@
+ _is_shuffle_moe_mxfp4 = is_gfx95_supported()
+ _is_cpu_amx_available = cpu_has_amx_support()
+
+-if _is_hip:
++if _use_aiter:
+     # import aiter
+     try:
+         from aiter.ops.shuffle import (
+--- a/sglang/srt/layers/quantization/__init__.py
++++ b/sglang/srt/layers/quantization/__init__.py
+@@ -5,6 +5,7 @@
+
+ import builtins
+ import inspect
++import os
+ from typing import TYPE_CHECKING, Dict, Optional, Type
+
+ import torch
+@@ -48,8 +49,6 @@
+ from sglang.srt.layers.quantization.npu_mxfp4_w4a4 import Mxfp4W4A4Config
+ from sglang.srt.layers.quantization.nvfp4_online import NvFp4OnlineConfig
+ from sglang.srt.layers.quantization.petit import PetitNvFp4Config
+-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
+-from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
+ from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
+ from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
+ from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
+@@ -59,12 +58,23 @@
+     is_cpu,
+     is_cuda,
+     is_gfx95_supported,
++    is_hip,
+     is_mps,
+     is_npu,
+ )
+
+ _is_gfx95_supported = is_gfx95_supported()
+
++# AITER has no gfx10 implementation.  The Quark modules import AITER at module
++# scope even when the selected checkpoint uses a different quantizer.
++_rocm_arch = os.environ.get("PYTORCH_ROCM_ARCH") or os.environ.get(
++    "GPU_ARCHS", ""
++)
++_quark_available = not (is_hip() and _rocm_arch.startswith("gfx10"))
++if _quark_available:
++    from sglang.srt.layers.quantization.quark.quark import QuarkConfig
++    from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
++
+ if TYPE_CHECKING:
+     from sglang.srt.layers.moe.topk import TopKOutput
+
+@@ -90,16 +100,22 @@
+     "compressed-tensors": CompressedTensorsConfig,
+     "w4afp8": W4AFp8Config,
+     "petit_nvfp4": PetitNvFp4Config,
+-    "quark": QuarkConfig,
+-    "quark_mxfp4": QuarkConfig,
+     "auto-round": AutoRoundConfig,
+     "auto-round-int8": W8A8Int8Config,
+     "modelslim": ModelSlimConfig,
+-    "quark_int4fp8_moe": QuarkInt4Fp8Config,
+     "humming": HummingConfig,
+     "mxfp_w4a8": Mxfp4W4A8Config,
+ }
+
++if _quark_available:
++    BASE_QUANTIZATION_METHODS.update(
++        {
++            "quark": QuarkConfig,
++            "quark_mxfp4": QuarkConfig,
++            "quark_int4fp8_moe": QuarkInt4Fp8Config,
++        }
++    )
++
+
+ if is_cpu() or is_cuda() or _is_gfx95_supported:
+     BASE_QUANTIZATION_METHODS.update(
+--- a/sglang/multimodal_gen/runtime/layers/quantization/mxfp4.py
++++ b/sglang/multimodal_gen/runtime/layers/quantization/mxfp4.py
+@@ -15,7 +15,7 @@
+ logger = logging.getLogger(__name__)
+ _is_hip = is_hip()
+
+-if _is_hip:
++if _is_hip and is_gfx95_supported():
+     try:
+         import aiter
+         from aiter.ops.gemm_op_a4w4 import gemm_a4w4

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0003-gfx1030-sgl-kernel-free-moe.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0003-gfx1030-sgl-kernel-free-moe.patch
@@ -1,0 +1,108 @@
+Qwen4-Exp reaches the Triton MoE runner during model import.  On HIP that
+runner and the shared activation layer import sgl_kernel unconditionally,
+even though their actual gated activation operations are also provided by
+SGLang's in-tree JIT kernels.  The sgl-kernel wheels do not target gfx1030,
+so the unconditional import prevents the model from loading on V620.
+
+The Qwen module also imports the generic runner package, whose prefill graph
+module imports EAGLE helpers even when speculation is disabled.  Route the two
+HIP tree operations through their existing Triton implementations so that this
+otherwise-unused import does not reintroduce sgl_kernel.
+
+Use the portable JIT activation implementation on HIP.  Keep QuickGELU's
+existing mathematical reference as a local fallback because the JIT module
+does not expose a unary QuickGELU kernel.  Qwen4-Exp uses SiLU, but keeping
+the module's complete HIP symbol contract prevents unrelated model imports
+from failing.
+
+--- a/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
++++ b/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+@@ -65,7 +65,7 @@
+ elif _is_cpu and _is_cpu_amx_available:
+     pass
+ elif _is_hip:
+-    from sgl_kernel import gelu_and_mul, silu_and_mul
++    from sglang.kernels.ops.activation.activation import gelu_and_mul, silu_and_mul
+
+     if _use_aiter:
+         try:
+--- a/sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py
++++ b/sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py
+@@ -18,7 +18,7 @@
+ from triton_kernels.swiglu import swiglu_fn
+ from triton_kernels.tensor import FP4
+
+-from sglang.srt.utils import is_cuda
++from sglang.srt.utils import is_cuda, is_hip
+ from sglang.srt.utils.common import is_sm120_supported
+
+ if is_sm120_supported():
+@@ -26,7 +26,7 @@
+     # use the regular gather/scatter implementation for unsupported devices.
+     update_opt_flags_constraints({"is_persistent": False})
+
+-if is_cuda():
++if is_cuda() or is_hip():
+     from sglang.kernels.ops.activation.activation import gelu_and_mul, silu_and_mul
+ else:
+     from sgl_kernel import gelu_and_mul, silu_and_mul
+--- a/sglang/srt/layers/activation.py
++++ b/sglang/srt/layers/activation.py
+@@ -103,7 +103,18 @@
+ elif _is_xpu:
+     from sgl_kernel import gelu_and_mul, gelu_tanh_and_mul, silu_and_mul
+ elif _is_hip:
+-    from sgl_kernel import gelu_and_mul, gelu_quick, gelu_tanh_and_mul, silu_and_mul
++    from sglang.kernels.ops.activation.activation import (
++        gelu_and_mul,
++        gelu_tanh_and_mul,
++        silu_and_mul,
++    )
++
++    def gelu_quick(input: torch.Tensor, out=None) -> torch.Tensor:
++        result = input * torch.sigmoid(1.702 * input)
++        if out is None:
++            return result
++        out.copy_(result)
++        return out
+ elif _is_musa:
+     from sglang.srt.utils.patch_torch import register_fake_if_exists
+
+--- a/sglang/srt/speculative/eagle_utils.py
++++ b/sglang/srt/speculative/eagle_utils.py
+@@ -46,7 +46,7 @@
+
+ logger = logging.getLogger(__name__)
+
+-if _is_cuda or _is_hip or _is_musa:
++if _is_cuda or _is_musa:
+     from sgl_kernel import (
+         build_tree_kernel_efficient as sgl_build_tree_kernel_efficient,
+     )
+@@ -234,7 +234,7 @@
+             num_verify_tokens,
+             tree_mask_mode,
+         )
+-    elif _is_xpu:
++    elif _is_xpu or _is_hip:
+         sgl_build_tree_kernel_triton(
+             parent_list,
+             top_scores_index,
+@@ -382,7 +382,7 @@
+     target_predict: torch.Tensor,
+     topk: int = -1,
+ ):
+-    if _is_cuda or _is_hip or _is_musa:
++    if _is_cuda or _is_musa:
+         from sgl_kernel import verify_tree_greedy
+
+         verify_tree_greedy(
+@@ -425,7 +425,7 @@
+             retrieve_next_sibling=retrieve_next_sibling,
+             target_predict=target_predict,
+         )
+-    elif _is_xpu:
++    elif _is_xpu or _is_hip:
+         verify_tree_greedy_triton(
+             predicts=predicts,
+             accept_index=accept_index,

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0004-gfx1030-optional-hisparse-kernel.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0004-gfx1030-optional-hisparse-kernel.patch
@@ -1,0 +1,74 @@
+HiSparse is disabled for the Qwen4-Exp V620 service, but the scheduler imports
+its memory-pool module unconditionally.  The module in turn assumes every HIP
+target ships sgl-kernel's kvcacheio extension.  gfx1030 has no compatible
+sgl-kernel wheel, so keep the dependency at its actual feature boundary and
+report a useful error only if HiSparse is selected.
+
+--- a/sglang/srt/mem_cache/hisparse_memory_pool.py
++++ b/sglang/srt/mem_cache/hisparse_memory_pool.py
+@@ -8,18 +8,14 @@
+ from sglang.srt.layers.radix_attention import RadixAttention
+ from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+-from sglang.srt.utils import is_cuda, is_hip
+
+ logger = logging.getLogger(__name__)
+
+-# sgl_kernel.kvcacheio is only available in CUDA/ROCm sgl-kernel builds (not XPU/MPS/NPU/CPU).
+-_is_cuda = is_cuda()
+-_is_hip = is_hip()
+-if _is_cuda or _is_hip:
++try:
+     from sgl_kernel.kvcacheio import transfer_kv_all_layer_mla
+-else:
++except ImportError:
+
+     def transfer_kv_all_layer_mla(*args, **kwargs):
+         raise RuntimeError(
+-            "HiSparse device KV transfer requires sgl_kernel.kvcacheio (CUDA/ROCm). "
+-            "It is not available on this backend."
++            "HiSparse device KV transfer requires sgl_kernel.kvcacheio, which "
++            "is not available in this runtime closure."
+         )
+
+--- a/sglang/srt/managers/scheduler.py
++++ b/sglang/srt/managers/scheduler.py
+@@ -76,9 +76,6 @@
+     DecodeTransferQueue,
+     SchedulerDisaggregationDecodeMixin,
+ )
+-from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
+-    DecodeKVCacheOffloadManager,
+-)
+ from sglang.srt.disaggregation.encode_receiver import create_mm_receiver
+ from sglang.srt.disaggregation.prefill import (
+     PrefillBootstrapQueue,
+@@ -570,6 +567,10 @@
+             get_disagg().disaggregation_mode == "decode"
+             and get_disagg().disaggregation_decode_enable_offload_kvcache
+         ):
++            from sglang.srt.disaggregation.decode_kvcache_offload_manager import (
++                DecodeKVCacheOffloadManager,
++            )
++
+             self.decode_offload_manager = DecodeKVCacheOffloadManager(
+                 req_to_token_pool=self.req_to_token_pool,
+                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+
+--- a/sglang/srt/managers/scheduler.py
++++ b/sglang/srt/managers/scheduler.py
+@@ -105,7 +105,6 @@
+ from sglang.srt.lora.lora_drainer import LoRADrainer
+ from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
+ from sglang.srt.managers.disagg_service import maybe_create_ascend_config_store
+-from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+ from sglang.srt.managers.io_struct import (
+     AbortReq,
+     ActiveRanksOutput,
+@@ -1131,6 +1130,6 @@
+         )
+
+     def init_hisparse_coordinator(self) -> None:
+-        self.hisparse_coordinator: Optional[HiSparseCoordinator] = None
++        self.hisparse_coordinator: Optional[Any] = None
+         if not self.enable_hisparse:
+             return

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0005-gfx1030-optional-host-cache-kernel.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0005-gfx1030-optional-host-cache-kernel.patch
@@ -1,0 +1,57 @@
+The generic unified radix cache imports the hierarchical host-pool types even
+when hierarchical caching is disabled.  Keep sgl-kernel's device-transfer
+extension at the feature boundary: gfx1030 can import and use the normal cache,
+while an attempted host-cache transfer fails with an explicit error.
+
+--- a/sglang/srt/mem_cache/memory_pool_host.py
++++ b/sglang/srt/mem_cache/memory_pool_host.py
+@@ -27,7 +27,7 @@
+ _is_npu = is_npu()
+ _is_xpu = is_xpu()
+ _is_mps = is_mps()
+-if _is_cuda or _is_hip:
++try:
+     from sgl_kernel.kvcacheio import (
+         transfer_kv_all_layer_direct_lf_pf,
+         transfer_kv_all_layer_mla,
+@@ -38,6 +38,20 @@
+         transfer_kv_per_layer_mla,
+         transfer_kv_per_layer_mla_pf_lf,
+     )
++except ImportError:
++    def _missing_kvcacheio(*args, **kwargs):
++        raise RuntimeError(
++            "Hierarchical host-cache transfer requires sgl_kernel.kvcacheio, "
++            "which is not available in this runtime closure."
++        )
++
++    transfer_kv_all_layer_direct_lf_pf = _missing_kvcacheio
++    transfer_kv_all_layer_mla = _missing_kvcacheio
++    transfer_kv_all_layer_mla_lf_pf = _missing_kvcacheio
++    transfer_kv_direct = _missing_kvcacheio
++    transfer_kv_per_layer_direct_pf_lf = _missing_kvcacheio
++    transfer_kv_per_layer_mla = _missing_kvcacheio
++    transfer_kv_per_layer_mla_pf_lf = _missing_kvcacheio
+ if _is_cuda or _is_hip:
+     from sglang.kernels.ops.mamba.transfer_mamba import (
+         transfer_kv_mamba_lf_pf,
+
+--- a/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
++++ b/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+@@ -32,7 +32,6 @@
+ )
+ from sglang.srt.mem_cache.l2_transfer import L2Transfer
+ from sglang.srt.mem_cache.memory_pool_host import HostPoolGroup, PoolEntry
+-from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
+
+ if TYPE_CHECKING:
+     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
+@@ -710,6 +709,8 @@
+             PoolName.DRAFT,
+             PoolName.DRAFT_SWA,
+         ):
++            from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
++
+             entry = self.mem_pool_host.entry_map.get(transfer.name)
+             return entry is not None and isinstance(
+                 entry.host_pool, MHATokenToKVPoolHost

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0006-gfx1030-spec-utils-fast-topk.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0006-gfx1030-spec-utils-fast-topk.patch
@@ -1,0 +1,15 @@
+The generic scheduler imports DFlash validation even when speculation is off.
+That reaches spec_utils, whose HIP branch requires sgl-kernel solely for
+fast_topk.  Use SGLang's existing portable implementation on HIP; keep the AOT
+kernel on CUDA.
+
+--- a/sglang/srt/speculative/spec_utils.py
++++ b/sglang/srt/speculative/spec_utils.py
+@@ -83,7 +83,5 @@
+
+ if _is_cuda:
+     from sgl_kernel import fast_topk
+-elif _is_hip:
+-    from sgl_kernel import fast_topk
+ else:
+     from sglang.srt.utils.common import fast_topk

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0007-gfx1030-optional-rope-kernel.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0007-gfx1030-optional-rope-kernel.patch
@@ -1,0 +1,29 @@
+The gfx1030 closure intentionally omits sgl-kernel.  RotaryEmbedding imports
+its HIP fallback while constructing the layer even when Qwen's MRoPE subclass
+will use its own native/Triton forward.  Pin the portable native path when the
+optional extension is absent; subclasses resolve self.forward_native to their
+own implementation.
+
+--- a/sglang/srt/layers/rotary_embedding/base.py
++++ b/sglang/srt/layers/rotary_embedding/base.py
+@@ -114,11 +114,17 @@ class RotaryEmbedding(BaseFusedOp):
+             if _is_cuda:
+                 from sglang.kernels.ops.attention.rope import rotary_embedding
+             elif _is_hip:
+-                from sgl_kernel import rotary_embedding
++                try:
++                    from sgl_kernel import rotary_embedding
++                except ImportError:
++                    self.use_fallback_kernel = False
++                    self._forward_method = self.forward_native
++                    rotary_embedding = None
+             else:
+                 from vllm._custom_ops import rotary_embedding
+
+-            self.use_fallback_kernel = True
+-            self.fallback_rotary_embedding = rotary_embedding
++            if rotary_embedding is not None:
++                self.use_fallback_kernel = True
++                self.fallback_rotary_embedding = rotary_embedding
+         else:
+             self.use_fallback_kernel = False

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0008-gfx1030-low-peak-wna16-layout.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0008-gfx1030-low-peak-wna16-layout.patch
@@ -6,12 +6,14 @@ layouts and needs up to another 200 MiB.  Qwen3.8-Flash-Next TP4 has only about
 Perform the one-time layout conversion through host memory.  Removing the old
 registered parameter and releasing its cached segment before copying the new
 layout back makes the GPU peak equal to the larger of the two layouts instead
-of their sum.  The tensors are identical byte-for-byte after the same
+of their sum.  Explicit synchronization brackets the free/reallocate boundary
+because ROCm otherwise occasionally faults an in-flight H2D copy on this very
+tight residency path.  The tensors are identical byte-for-byte after the same
 transpose/contiguous/view operations; only the temporary location changes.
 
 --- a/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
 +++ b/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
-@@ -508,26 +508,35 @@ class CompressedTensorsWNA16TritonMoE(CompressedTensorsWNA16MoE):
+@@ -508,26 +508,38 @@ class CompressedTensorsWNA16TritonMoE(CompressedTensorsWNA16MoE):
          if getattr(layer, "is_triton_converted", False):
              return
 
@@ -19,7 +21,9 @@ transpose/contiguous/view operations; only the temporary location changes.
 +        def transpose_parameter_on_host(name: str, view_uint8: bool = False) -> None:
 +            parameter = getattr(layer, name)
 +            device = parameter.device
-+            host_tensor = parameter.detach().cpu()
++            torch.cuda.synchronize(device)
++            host_tensor = parameter.detach().to(device="cpu", non_blocking=False)
++            torch.cuda.synchronize(device)
 
 -        # Convert w13 weights: [E, K//8, N] int32 -> [E, N, K//2] uint8
 -        w13 = layer.w13_weight_packed.data
@@ -40,7 +44,8 @@ transpose/contiguous/view operations; only the temporary location changes.
 +            host_tensor = host_tensor.transpose(1, 2).contiguous()
 +            if view_uint8:
 +                host_tensor = host_tensor.view(torch.uint8)
-+            converted = host_tensor.to(device=device)
++            converted = host_tensor.to(device=device, non_blocking=False)
++            torch.cuda.synchronize(device)
 +            setattr(
 +                layer,
 +                name,

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0008-gfx1030-low-peak-wna16-layout.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0008-gfx1030-low-peak-wna16-layout.patch
@@ -1,0 +1,66 @@
+The ROCm Triton WNA16 path transposes each packed MoE parameter after the
+checkpoint has filled VRAM.  A direct GPU contiguous() temporarily holds both
+layouts and needs up to another 200 MiB.  Qwen3.8-Flash-Next TP4 has only about
+114 MiB free per V620 at that point, so the otherwise resident model fails.
+
+Perform the one-time layout conversion through host memory.  Removing the old
+registered parameter and releasing its cached segment before copying the new
+layout back makes the GPU peak equal to the larger of the two layouts instead
+of their sum.  The tensors are identical byte-for-byte after the same
+transpose/contiguous/view operations; only the temporary location changes.
+
+--- a/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
++++ b/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16_moe.py
+@@ -508,26 +508,35 @@ class CompressedTensorsWNA16TritonMoE(CompressedTensorsWNA16MoE):
+         if getattr(layer, "is_triton_converted", False):
+             return
+
+-        num_experts = layer.w13_weight_packed.shape[0]
++        def transpose_parameter_on_host(name: str, view_uint8: bool = False) -> None:
++            parameter = getattr(layer, name)
++            device = parameter.device
++            host_tensor = parameter.detach().cpu()
+
+-        # Convert w13 weights: [E, K//8, N] int32 -> [E, N, K//2] uint8
+-        w13 = layer.w13_weight_packed.data
+-        w13 = w13.transpose(1, 2).contiguous().view(torch.uint8)
+-        layer.w13_weight_packed = torch.nn.Parameter(w13, requires_grad=False)
++            # Loader bookkeeping can retain the Parameter object after it is
++            # removed from the module.  Empty its data first so those external
++            # references cannot keep the full GPU storage alive.
++            parameter.data = parameter.data.new_empty(0)
++            setattr(layer, name, None)
++            del parameter
++            torch.cuda.empty_cache()
+
+-        # Convert w2 weights: [E, K//8, N] int32 -> [E, N, K//2] uint8
+-        w2 = layer.w2_weight_packed.data
+-        w2 = w2.transpose(1, 2).contiguous().view(torch.uint8)
+-        layer.w2_weight_packed = torch.nn.Parameter(w2, requires_grad=False)
++            host_tensor = host_tensor.transpose(1, 2).contiguous()
++            if view_uint8:
++                host_tensor = host_tensor.view(torch.uint8)
++            converted = host_tensor.to(device=device)
++            setattr(
++                layer,
++                name,
++                torch.nn.Parameter(converted, requires_grad=False),
++            )
+
+-        # Convert w13 scales: [E, K//group_size, N] -> [E, N, K//group_size]
+-        w13_scale = layer.w13_weight_scale.data
+-        w13_scale = w13_scale.transpose(1, 2).contiguous()
+-        layer.w13_weight_scale = torch.nn.Parameter(w13_scale, requires_grad=False)
++        # [E, K//8, N] int32 -> [E, N, K//2] uint8.
++        transpose_parameter_on_host("w13_weight_packed", view_uint8=True)
++        transpose_parameter_on_host("w2_weight_packed", view_uint8=True)
+
+-        # Convert w2 scales: [E, K//group_size, N] -> [E, N, K//group_size]
+-        w2_scale = layer.w2_weight_scale.data
+-        w2_scale = w2_scale.transpose(1, 2).contiguous()
+-        layer.w2_weight_scale = torch.nn.Parameter(w2_scale, requires_grad=False)
++        # [E, K//group_size, N] -> [E, N, K//group_size].
++        transpose_parameter_on_host("w13_weight_scale")
++        transpose_parameter_on_host("w2_weight_scale")
+
+         layer.is_triton_converted = True

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0009-gfx1030-triton-xgrammar-bitmask.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0009-gfx1030-triton-xgrammar-bitmask.patch
@@ -1,0 +1,48 @@
+The xgrammar backend imports sgl_kernel's CUDA bitmask operation on every HIP
+device.  The gfx1030 closure has no compatible sgl-kernel wheel, while SGLang's
+in-tree Triton implementation is already used by the other GPU backends and is
+portable to HIP.  Use it on gfx1030 as well so scheduler initialization keeps
+grammar-constrained decoding and tool calls without an unavailable extension.
+
+--- a/sglang/srt/constrained/xgrammar_backend.py
++++ b/sglang/srt/constrained/xgrammar_backend.py
+@@ -38,14 +38,11 @@ from sglang.srt.constrained.utils import is_legacy_structural_tag
+ from sglang.srt.utils import is_hip
+ from sglang.srt.utils.common import is_pin_memory_available
+
+ _is_hip = is_hip()
+
+-if _is_hip:
+-    from sgl_kernel import apply_token_bitmask_inplace_cuda
+-else:
+-    from sglang.kernels.ops.grammar.bitmask_ops import (
+-        apply_token_bitmask_inplace_triton,
+-    )
++from sglang.kernels.ops.grammar.bitmask_ops import (
++    apply_token_bitmask_inplace_triton,
++)
+
+ from sglang.kernels.ops.grammar.token_filter_ops import set_token_filter_triton
+ from sglang.srt.constrained.torch_ops.token_filter_torch_ops import (
+@@ -108,10 +105,7 @@ class XGrammarGrammar(BaseGrammarObject):
+         return vocab_mask.to(device, non_blocking=True)
+
+     def apply_vocab_mask(self, logits: torch.Tensor, vocab_mask: torch.Tensor) -> None:
+         if logits.device.type in {"cuda", "xpu", "musa"}:
+-            if _is_hip:
+-                apply_token_bitmask_inplace_cuda(logits, vocab_mask)
+-            else:
+-                apply_token_bitmask_inplace_triton(logits, vocab_mask)
++            apply_token_bitmask_inplace_triton(logits, vocab_mask)
+         elif logits.device.type == "npu":
+             import sgl_kernel_npu  # noqa: F401
+@@ -258,10 +252,7 @@ class XGrammarGrammarBackend(BaseGrammarBackend):
+     def apply_vocab_mask(logits: torch.Tensor, vocab_mask: torch.Tensor) -> None:
+         if logits.device.type in {"cuda", "npu", "xpu", "musa"}:
+-            if _is_hip:
+-                apply_token_bitmask_inplace_cuda(logits, vocab_mask)
+-            else:
+-                apply_token_bitmask_inplace_triton(logits, vocab_mask)
++            apply_token_bitmask_inplace_triton(logits, vocab_mask)
+         else:
+             raise RuntimeError(f"Unsupported device: {logits.device.type}")

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0010-gfx1030-disable-cuda-hyperconnection-jit.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0010-gfx1030-disable-cuda-hyperconnection-jit.patch
@@ -1,0 +1,20 @@
+PyTorch exposes HIP devices through the torch.cuda compatibility namespace, and
+gfx1030 is consequently reported as compute capability 10.3.  Do not confuse
+that with NVIDIA SM100: the split-K mix kernel imports cuda-python.  Keep the
+portable Triton/torch mix paths on ROCm by including SGLang's real platform
+predicate in the SM100-only JIT gate.
+
+--- a/sglang/srt/layers/hyperconnection.py
++++ b/sglang/srt/layers/hyperconnection.py
+@@ -8 +8,2 @@
+-from sglang.srt.layers.hc_mix_triton import fused_hc_mix, fused_hc_mix_supported
++from sglang.srt.layers.hc_mix_triton import fused_hc_mix, fused_hc_mix_supported
++from sglang.srt.utils import is_cuda
+@@ -156,6 +157,7 @@ class GatedResidual(HyperConnectionBase):
+             lowrank = self.config.hc_lowrank
+             self._jit_mix_ok = (
+                 envs.SGLANG_HC_MIX_CUDA.get()
++                and is_cuda()
+                 and torch.cuda.is_available()
+                 # The CuTe split-K pair is tcgen05 (sm_100 family) only; the
+                 # default-on env must not route Hopper/Ada to it.

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0011-gfx1030-qwen4-exp-fp16-runtime-dtype.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0011-gfx1030-qwen4-exp-fp16-runtime-dtype.patch
@@ -1,0 +1,43 @@
+Qwen4-Exp hard-codes BF16 for its HyperConnection parameters and PLE gather
+outputs.  That conflicts with the selected FP16 model dtype on gfx1030: the
+first HyperConnection GEMM receives FP16 activations and BF16 weights.  Use
+SGLang's construction-time default dtype for compute tensors while retaining
+BF16/FP8 as the pinned PLE table's checkpoint storage dtype.
+
+--- a/sglang/srt/models/qwen4_exp.py
++++ b/sglang/srt/models/qwen4_exp.py
+@@ -500 +500 @@ class Qwen4ExpNGramEmbedding(nn.Module):
+-            output_dtype=torch.bfloat16,
++            output_dtype=torch.get_default_dtype(),
+@@ -504 +504 @@ class Qwen4ExpNGramEmbedding(nn.Module):
+-            "weight_scale", torch.ones(1, dtype=torch.bfloat16), persistent=True
++            "weight_scale", torch.ones(1, dtype=torch.get_default_dtype()), persistent=True
+@@ -742 +742 @@ def _gather_ple_embedding_from_pinned_kernel(
+-    ).to(tl.bfloat16)
++    )
+@@ -754 +754,2 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
+-    weight_scale for fp8 checkpoints, bf16 otherwise); gathers emit bf16.
++    weight_scale for fp8 checkpoints, bf16 otherwise); gathers emit the
++    selected model compute dtype.
+@@ -770 +771,2 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
+-        "embedding_dim",
++        "embedding_dim",
++        "output_dtype",
+@@ -826,2 +828,2 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
+-            # The gather kernel emits bf16 rows regardless of the table dtype.
+-            return torch.empty(shape, dtype=torch.bfloat16, device=device)
++            # The output pointer dtype controls the gather kernel's conversion.
++            return torch.empty(shape, dtype=self.output_dtype, device=device)
+@@ -841 +843 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
+-            if out.dtype != torch.bfloat16 or out.device != input_ids.device:
++            if out.dtype != self.output_dtype or out.device != input_ids.device:
+@@ -843 +845,2 @@ class Qwen4ExpPinnedHostEmbedding(VocabParallelEmbedding):
+-                    "PLE prefetch output must be bfloat16 on the id device"
++                    "PLE prefetch output must use the model compute dtype on "
++                    "the id device"
+@@ -1260 +1263 @@ class Qwen4ExpLayerExtensionMixin:
+-            params_dtype=torch.bfloat16,
++            params_dtype=torch.get_default_dtype(),
+@@ -1614 +1617 @@ class Qwen4ExpModel(Qwen3VLTextModel):
+-            params_dtype=torch.bfloat16,
++            params_dtype=torch.get_default_dtype(),

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0012-gfx1030-native-moe-topk.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0012-gfx1030-native-moe-topk.patch
@@ -1,0 +1,32 @@
+The default HIP softmax router resolves the AOT moe.topk_softmax registration
+from sgl_kernel at first forward.  The gfx1030 closure deliberately has no
+compatible sgl-kernel wheel.  Route this plain softmax case through SGLang's
+existing torch-native implementation; it computes routing scores in FP32 and
+preserves the requested renormalization.
+
+--- a/sglang/srt/layers/moe/topk.py
++++ b/sglang/srt/layers/moe/topk.py
+@@ -896,7 +896,16 @@ def fused_topk(
++        elif _is_hip:
++            topk_weights, topk_ids = fused_topk_torch_native(
++                hidden_states=hidden_states,
++                gating_output=gating_output,
++                topk=topk,
++                renormalize=renormalize,
++                correction_bias=correction_bias,
++                scoring_func=scoring_func,
++            )
+-        else:
+-            topk_softmax(
+-                topk_weights,
+-                topk_ids,
+-                gating_output,
+-                renormalize,
+-            )
++        else:
++            topk_softmax(
++                topk_weights,
++                topk_ids,
++                gating_output,
++                renormalize,
++            )

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0013-gfx1030-jit-moe-align.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0013-gfx1030-jit-moe-align.patch
@@ -1,0 +1,57 @@
+The generic Triton MoE runner selects the prebuilt sgl_kernel align op on HIP.
+That extension is not available in the gfx1030 package, but SGLang ships the
+same HIP-compatible kernel through its runtime JIT loader.  Select that
+implementation on HIP while leaving the released CUDA/XPU/MUSA paths alone.
+
+The JIT wrapper does not implement ignore_invalid_expert.  Fail explicitly for
+that unused EP contract rather than silently changing its semantics.
+
+--- a/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
++++ b/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+@@ -15,7 +15,11 @@ _is_xpu = is_xpu()
+ _is_musa = is_musa()
+
+-if _is_cuda or _is_hip or _is_xpu or _is_musa:
++if _is_cuda or _is_xpu or _is_musa:
+     from sglang.kernels.ops.moe import moe_align_block_size as sgl_moe_align_block_size
++elif _is_hip:
++    from sglang.kernels.ops.moe.moe_align import (
++        moe_align_block_size as jit_moe_align_block_size,
++    )
+
+ if _is_cuda:
+     from sglang.kernels.ops.moe.moe_align_small_numel import (
+@@ -148,15 +152,32 @@ def moe_align_block_size(
+         )
+     # ===== END TO BE REFACTORED ====
+     else:
+-        sgl_moe_align_block_size(
++        if _is_hip:
++            if ignore_invalid_expert:
++                raise NotImplementedError(
++                    "HIP JIT MoE alignment does not support ignore_invalid_expert"
++                )
++            jit_moe_align_block_size(
++                topk_ids,
++                num_experts + 1,
++                block_size,
++                sorted_ids,
++                expert_ids,
++                num_tokens_post_pad,
++                cumsum_buffer,
++                True,
++            )
++        else:
++            sgl_moe_align_block_size(
+             topk_ids,
+             num_experts + 1,
+             block_size,
+             sorted_ids,
+             expert_ids,
+             num_tokens_post_pad,
+             cumsum_buffer,
+             True,
+             ignore_invalid_expert,
+         )
++
+     return sorted_ids, expert_ids, num_tokens_post_pad

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0013-gfx1030-jit-moe-align.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0013-gfx1030-jit-moe-align.patch
@@ -16,7 +16,7 @@ that unused EP contract rather than silently changing its semantics.
      from sglang.kernels.ops.moe import moe_align_block_size as sgl_moe_align_block_size
 +elif _is_hip:
 +    from sglang.kernels.ops.moe.moe_align import (
-+        moe_align_block_size as jit_moe_align_block_size,
++        moe_align_block_size as hip_jit_moe_align_block_size,
 +    )
 
  if _is_cuda:
@@ -31,7 +31,7 @@ that unused EP contract rather than silently changing its semantics.
 +                raise NotImplementedError(
 +                    "HIP JIT MoE alignment does not support ignore_invalid_expert"
 +                )
-+            jit_moe_align_block_size(
++            hip_jit_moe_align_block_size(
 +                topk_ids,
 +                num_experts + 1,
 +                block_size,

--- a/pkgs/sglang/patches-qwen4-exp/gfx1030/0014-gfx1030-qsa-prefill-lds.patch
+++ b/pkgs/sglang/patches-qwen4-exp/gfx1030/0014-gfx1030-qsa-prefill-lds.patch
@@ -1,0 +1,19 @@
+The upstream QSA tuning table assumes NVIDIA shared-memory limits.  Its
+64-token prefill tile compiles to 67,584 bytes of LDS on gfx1030, just over
+the V620's 65,536-byte workgroup limit, and terminates every scheduler rank.
+
+Keep the selected tile and warp count, but use a single software-pipeline
+stage on ROCm.  This removes the double-buffered LDS peak while leaving CUDA's
+upstream tuning unchanged.
+
+--- a/sglang/srt/layers/attention/qsa/sparse_attn.py
++++ b/sglang/srt/layers/attention/qsa/sparse_attn.py
+@@ -26 +26,7 @@ def _get_best_config(total_q: int):
+-    return next(cfg for limit, cfg in table if total_q <= limit)
++    block_n, warps, stages = next(cfg for limit, cfg in table if total_q <= limit)
++    # gfx1030 exposes 64 KiB of LDS per workgroup.  Triton's two-stage
++    # 64-token QSA prefill requires 67,584 bytes, so avoid double buffering
++    # on ROCm while preserving the upstream CUDA configurations.
++    if torch.version.hip is not None:
++        stages = 1
++    return block_n, warps, stages

--- a/pkgs/sglang/patches/gfx1030/0101-gfx1030-boot-fixes.patch
+++ b/pkgs/sglang/patches/gfx1030/0101-gfx1030-boot-fixes.patch
@@ -1,0 +1,146 @@
+gfx1030 boot/launch fixes, extracted from the in-place edits on the serving
+closure hx22r2fa7m6axpixv9lyklqhvbp7r80v-sglang-rocm-gfx1030-0.5.14:
+
+  * quantization/__init__.py: skip the quark imports on ROCm gfx10 -- quark's
+    module-level imports probe AITER, which has no gfx10 implementation.
+  * quantization/mxfp4.py: gate the aiter shuffle imports on _use_aiter
+    instead of _is_hip.
+  * batch_invariant_ops.py: RDNA2-sized tiles (64 KiB LDS) for the
+    batch-invariant persistent matmul on HIP.
+  * triton_ops/extend_attention.py: _is_gfx10 detection and a
+    BLOCK_M=16/BLOCK_N=32/num_warps=4 tile for gfx10 (the generic HIP
+    BLOCK_M=64 tile cannot launch within 64 KiB LDS at large Lv).
+
+--- a/sglang/srt/layers/quantization/__init__.py
++++ b/sglang/srt/layers/quantization/__init__.py
+@@ -5,6 +5,7 @@
+ 
+ import builtins
+ import inspect
++import os
+ from typing import TYPE_CHECKING, Dict, Optional, Type
+ 
+ import torch
+@@ -47,8 +48,6 @@
+ from sglang.srt.layers.quantization.nvfp4_online import NvFp4OnlineConfig
+ from sglang.srt.layers.quantization.petit import PetitNvFp4Config
+ from sglang.srt.layers.quantization.qoq import QoQConfig
+-from sglang.srt.layers.quantization.quark.quark import QuarkConfig
+-from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
+ from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
+ from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
+ from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
+@@ -65,6 +64,16 @@
+ 
+ _is_mxfp_supported = mxfp_supported()
+ 
++# AITER has no gfx10 implementation. Quark's module-level imports otherwise
++# probe AITER even when this process is loading an unrelated FP8 checkpoint.
++_rocm_arch = os.environ.get("PYTORCH_ROCM_ARCH") or os.environ.get(
++    "GPU_ARCHS", ""
++)
++_quark_available = not (is_hip() and _rocm_arch.startswith("gfx10"))
++if _quark_available:
++    from sglang.srt.layers.quantization.quark.quark import QuarkConfig
++    from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
++
+ if TYPE_CHECKING:
+     from sglang.srt.layers.moe.topk import TopKOutput
+ 
+@@ -92,11 +101,8 @@
+     "w4afp8": W4AFp8Config,
+     "petit_nvfp4": PetitNvFp4Config,
+     "fbgemm_fp8": FBGEMMFp8Config,
+-    "quark": QuarkConfig,
+-    "quark_mxfp4": QuarkConfig,
+     "auto-round": AutoRoundConfig,
+     "modelslim": ModelSlimConfig,
+-    "quark_int4fp8_moe": QuarkInt4Fp8Config,
+ }
+ 
+ 
+--- a/sglang/srt/layers/quantization/mxfp4.py
++++ b/sglang/srt/layers/quantization/mxfp4.py
+@@ -149,7 +149,7 @@
+ _is_shuffle_moe_mxfp4 = is_gfx95_supported()
+ _is_cpu_amx_available = cpu_has_amx_support()
+ 
+-if _is_hip:
++if _use_aiter:
+     # import aiter
+     try:
+         from aiter.ops.shuffle import (
+--- a/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
++++ b/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
+@@ -222,6 +222,36 @@
+             "num_warps": 8,
+         },
+     }
++    if torch.version.hip is not None:
++        # The CUDA-oriented 128x128, three-stage tiles above request 112 KiB
++        # of shared memory, while gfx1030 exposes 64 KiB. Fixed smaller tiles
++        # preserve the batch-invariant reduction order and fit RDNA2.
++        configs = {
++            torch.bfloat16: {
++                "BLOCK_SIZE_M": 64,
++                "BLOCK_SIZE_N": 64,
++                "BLOCK_SIZE_K": 32,
++                "GROUP_SIZE_M": 8,
++                "num_stages": 2,
++                "num_warps": 4,
++            },
++            torch.float16: {
++                "BLOCK_SIZE_M": 64,
++                "BLOCK_SIZE_N": 64,
++                "BLOCK_SIZE_K": 32,
++                "GROUP_SIZE_M": 8,
++                "num_stages": 2,
++                "num_warps": 4,
++            },
++            torch.float32: {
++                "BLOCK_SIZE_M": 64,
++                "BLOCK_SIZE_N": 64,
++                "BLOCK_SIZE_K": 16,
++                "GROUP_SIZE_M": 8,
++                "num_stages": 2,
++                "num_warps": 4,
++            },
++        }
+     # print(a.device, b.device, c.device)
+     matmul_kernel_persistent[grid](
+         a,
+--- a/sglang/srt/layers/attention/triton_ops/extend_attention.py
++++ b/sglang/srt/layers/attention/triton_ops/extend_attention.py
+@@ -33,6 +33,16 @@
+ _is_gfx95 = _is_hip and is_gfx95_supported()
+ 
+ 
++def _is_gfx10_device() -> bool:
++    if not _is_hip:
++        return False
++    arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
++    return arch.split(":", maxsplit=1)[0].startswith("gfx10")
++
++
++_is_gfx10 = _is_gfx10_device()
++
++
+ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
+     """
+     Get block sizes and configuration for extend attention kernels.
+@@ -62,7 +72,14 @@
+ 
+     # Determine BLOCK_M, BLOCK_N, and num_warps based on hardware
+     if _is_hip:
+-        if _is_gfx95 and 128 < Lq <= 256:
++        if _is_gfx10:
++            # gfx1030 exposes 64 KiB LDS. With GLM DSA's Lv=512 the generic
++            # BLOCK_M=64 accumulator alone requests 128 KiB, so verification
++            # cannot launch. A 16-row tile keeps the same reduction and mask
++            # semantics while fitting the hardware.
++            BLOCK_M, BLOCK_N = (16, 32)
++            num_warps = 4
++        elif _is_gfx95 and 128 < Lq <= 256:
+             # gfx950 (CDNA4), 128 < head_dim <= 256: a larger query tile halves KV bytes
+             # streamed per call (each workgroup reads the whole prefix); 8 warps
+             # hide the loads. Measured on MI350X head_dim 256: -36% kernel time,

--- a/pkgs/sglang/patches/gfx1030/0102-gfx1030-extend-attention-qk-split.patch
+++ b/pkgs/sglang/patches/gfx1030/0102-gfx1030-extend-attention-qk-split.patch
@@ -1,0 +1,167 @@
+gfx1030: split the head_dim-deep QK contraction in the extend-attention kernel.
+
+Source-ified from .bench-artifacts/attn/graft/qwen38_attn_ksplit.py.  RDNA2
+has no matrix cores; Triton lowers tl.dot to an FMA tree that keeps both
+operands fully live, and the single 256-deep QK dot overflows the 256-VGPR
+wave32 register file (305 scratch spills, 1.24 TFLOP/s; split into 16 dots of
+depth 16 it drops to ~114 spills, 7.21 TFLOP/s).  Each tl.dot(q, k) becomes
+QK_SPLIT accumulating dots of depth BLOCK_DMODEL // QK_SPLIT; no tile size,
+grid, launch parameter, mask, or softmax reduction order changes.
+
+This is the BIT-EXACT variant: the shipped gfx10 BLOCK_M=16/BLOCK_N=32 tile
+(installed by 0101) is kept, with QK_SPLIT=16.  The faster BLOCK_M=32/
+BLOCK_N=16 retile measured during the campaign is NOT shipped because it is
+not bit-exact (up to 1 fp16 ULP).  QWEN38_ATTN_KSPLIT=1 restores the shipped
+single-dot kernel; the split silently disables itself when BLOCK_DMODEL is
+not divisible or the per-dot depth would drop below 16.
+
+--- a/sglang/srt/layers/attention/triton_ops/extend_attention.py
++++ b/sglang/srt/layers/attention/triton_ops/extend_attention.py
+@@ -16,6 +16,8 @@
+ It supports page size = 1 and prefill with KV cache (i.e. extend).
+ """
+ 
++import os
++
+ import torch
+ import triton
+ import triton.language as tl
+@@ -42,6 +44,17 @@
+ 
+ _is_gfx10 = _is_gfx10_device()
+ 
++# QK contraction split for gfx10 (RDNA2).  There are no matrix cores, so
++# Triton lowers tl.dot to an FMA tree and keeps the whole [M, K] and [K, N]
++# operands live; at head_dim 256 the single 256-deep QK dot overflows the
++# 256-VGPR wave32 register file and spills (305 spills, 1.24 TFLOP/s vs
++# 114 spills, 7.21 TFLOP/s when split -- see .bench-artifacts/attn).
++# Accumulating QK_SPLIT dots of depth BLOCK_DMODEL // QK_SPLIT changes only
++# the association order of the fp32 accumulation inside the QK contraction;
++# with the shipped gfx10 BLOCK_M=16/BLOCK_N=32 tile, QK_SPLIT=16 is bit-exact
++# against the unsplit kernel.  QWEN38_ATTN_KSPLIT=1 restores the single dot.
++_QK_SPLIT_DEFAULT = int(os.environ.get("QWEN38_ATTN_KSPLIT", "16"))
++
+ 
+ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
+     """
+@@ -299,6 +312,7 @@
+     SKIP_PREFIX_CUSTOM_MASK: tl.constexpr,
+     STORE_TRANSPOSE: tl.constexpr,
+     HAS_SINK: tl.constexpr,
++    QK_SPLIT: tl.constexpr,
+ ):
+     cur_seq = tl.program_id(0)
+     cur_head = tl.program_id(1)
+@@ -327,6 +341,8 @@
+     mask_d = offs_d < Lq
+     mask_dv = offs_dv < Lv
+ 
++    KC: tl.constexpr = BLOCK_DMODEL // QK_SPLIT
++
+     if xai_temperature_len > 0:
+         offs_qidx = cur_seq_len_prefix + cur_block_m * BLOCK_M + offs_m
+         xai_temperature_scale = 1.0 / tl.log2(float(xai_temperature_len))
+@@ -400,18 +416,29 @@
+                 other=0,
+             )
+ 
+-            # load k in transposed way
+-            offs_buf_k = (
+-                offs_kv_loc[None, :] * stride_buf_kbs
+-                + cur_kv_head * stride_buf_kh
+-                + offs_d[:, None]
+-            )
+-            k = tl.load(
+-                K_Buffer + offs_buf_k,
+-                mask=(mask_n[None, :]) & (mask_d[:, None]),
+-                other=0.0,
+-            )
+-            qk = tl.dot(q.to(k.dtype), k)
++            # QK_SPLIT accumulating dots of depth KC (load k in transposed way)
++            qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
++            for j in tl.static_range(QK_SPLIT):
++                offs_dj = j * KC + tl.arange(0, KC)
++                mask_dj = offs_dj < Lq
++                kj = tl.load(
++                    K_Buffer
++                    + offs_kv_loc[None, :] * stride_buf_kbs
++                    + cur_kv_head * stride_buf_kh
++                    + offs_dj[:, None],
++                    mask=(mask_n[None, :]) & (mask_dj[:, None]),
++                    other=0.0,
++                )
++                qj = tl.load(
++                    Q_Extend
++                    + (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
++                    * stride_qbs
++                    + cur_head * stride_qh
++                    + offs_dj[None, :],
++                    mask=(mask_m[:, None]) & (mask_dj[None, :]),
++                    other=0.0,
++                )
++                qk += tl.dot(qj.to(kj.dtype), kj)
+             if BLOCK_DPE > 0:
+                 offs_kpe = (
+                     offs_kv_loc[None, :] * stride_buf_kbs
+@@ -506,17 +533,29 @@
+             SKIP_TILE = tl.max(tl.max(final_mask.to(tl.int32), axis=1), axis=0) == 0
+ 
+         if not SKIP_TILE:
+-            # load k in transposed way
+-            offs_k = (
+-                (cur_seq_extend_start_idx + start_n + offs_n[None, :]) * stride_kbs
+-                + cur_kv_head * stride_kh
+-                + offs_d[:, None]
+-            )
+-            k = tl.load(
+-                K_Extend + offs_k, mask=(mask_n[None, :]) & (mask_d[:, None]), other=0.0
+-            )
+-
+-            qk = tl.dot(q, k, out_dtype=tl.float32)
++            # QK_SPLIT accumulating dots of depth KC (load k in transposed way)
++            qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
++            for j in tl.static_range(QK_SPLIT):
++                offs_dj = j * KC + tl.arange(0, KC)
++                mask_dj = offs_dj < Lq
++                kj = tl.load(
++                    K_Extend
++                    + (cur_seq_extend_start_idx + start_n + offs_n[None, :]) * stride_kbs
++                    + cur_kv_head * stride_kh
++                    + offs_dj[:, None],
++                    mask=(mask_n[None, :]) & (mask_dj[:, None]),
++                    other=0.0,
++                )
++                qj = tl.load(
++                    Q_Extend
++                    + (cur_seq_extend_start_idx + cur_block_m * BLOCK_M + offs_m[:, None])
++                    * stride_qbs
++                    + cur_head * stride_qh
++                    + offs_dj[None, :],
++                    mask=(mask_m[:, None]) & (mask_dj[None, :]),
++                    other=0.0,
++                )
++                qk += tl.dot(qj, kj, out_dtype=tl.float32)
+             if BLOCK_DPE > 0:
+                 offs_kpe = (
+                     (cur_seq_extend_start_idx + start_n + offs_n[None, :]) * stride_kbs
+@@ -638,6 +677,12 @@
+     grid = (batch_size, head_num, triton.cdiv(max_len_extend, BLOCK_M))
+     num_stages = 1
+ 
++    # Split the QK contraction only when it divides the model dimension and
++    # keeps the per-dot depth >= 16; otherwise fall back to the single dot.
++    qk_split = _QK_SPLIT_DEFAULT
++    if BLOCK_DMODEL % qk_split != 0 or BLOCK_DMODEL // qk_split < 16:
++        qk_split = 1
++
+     extra_kargs = {}
+     if _is_hip:
+         extra_kargs = {"waves_per_eu": 1, "matrix_instr_nonkdim": 16, "kpack": 2}
+@@ -687,6 +732,7 @@
+         SKIP_PREFIX_CUSTOM_MASK=SKIP_PREFIX_CUSTOM_MASK,
+         HAS_SINK=HAS_SINK,
+         STORE_TRANSPOSE=_is_hip,
++        QK_SPLIT=qk_split,
+         num_warps=num_warps,
+         num_stages=num_stages,
+         **extra_kargs,

--- a/pkgs/sglang/patches/gfx1030/0103-gfx1030-fla-retile.patch
+++ b/pkgs/sglang/patches/gfx1030/0103-gfx1030-fla-retile.patch
@@ -1,0 +1,89 @@
+gfx1030: retile the four Gated-DeltaNet chunked-prefill Triton kernels.
+
+Source-ified from .bench-artifacts/prefill/graft/qwen38_gdn_tiles.py.  The
+shipped tile constants were chosen on CDNA/Hopper; on gfx1030 (wave32, 1024
+VGPRs/SIMD) every one of these kernels lands on 256 VGPRs and spills to
+scratch.  Only launch constants change; no kernel body is touched.
+Measured on one V620, TP4 shard shapes (H=4, HV=12, K=V=128), T=2048:
+
+  chunk_fwd_kernel_o           BK128 BV64 w4 s2  645us -> BK32 BV128 w8 s2  249us
+  ..._fwd_kernel_h_blockdim64  BV32       w4 s2 1005us -> BV16       w8 s2  419us
+  ..._fwd_kkt_solve_kernel     BK64       w4 s1  252us -> BK16       w2 s2  182us
+  recompute_w_u_fwd_kernel     BK64 BV64  w4 s3  189us -> BK64 BV64  w8 s1  104us
+
+chunk_delta_h.py keeps its upstream SGLANG_GDN_CHUNK_H_* env knobs (only the
+defaults change), and keeps the load-bearing single-config autotune property.
+causal_conv1d is deliberately untouched: at the real call-site strides the
+shipped kernel already runs at occupancy 16 with zero spills.
+
+--- a/sglang/srt/layers/attention/fla/chunk_o.py
++++ b/sglang/srt/layers/attention/fla/chunk_o.py
+@@ -164,11 +164,16 @@
+         K=K,
+         V=V,
+         BT=BT,
+-        BK=128,
+-        BV=64,
++        # gfx1030 (RDNA2, wave32, 1024 VGPRs/SIMD): the CDNA-era BK=128/BV=64
++        # tile lands on 256 VGPRs (occupancy 4) and spills hundreds of values
++        # to scratch.  BK=32/BV=128 with 8 warps holds less of the tile per
++        # lane and removes the spills: 645us -> 249us on V620 TP4 shard shapes
++        # (H=4, HV=12, K=V=128, T=2048).  Kernel body unchanged.
++        BK=32,
++        BV=128,
+         USE_G=g is not None,
+         IS_VARLEN=cu_seqlens is not None,
+-        num_warps=4,
++        num_warps=8,
+         num_stages=2,
+     )
+     return o
+--- a/sglang/srt/layers/attention/fla/wy_fast.py
++++ b/sglang/srt/layers/attention/fla/wy_fast.py
+@@ -147,8 +147,10 @@
+         BK=BK,
+         BV=BV,
+         IS_VARLEN=cu_seqlens is not None,
+-        num_warps=4,
+-        num_stages=3,
++        # gfx1030: 8 warps / 1 stage avoids the register spills of the shipped
++        # 4-warp 3-stage launch: 189us -> 104us on V620 TP4 shard shapes.
++        num_warps=8,
++        num_stages=1,
+     )
+     return w, u
+ 
+--- a/sglang/srt/layers/attention/fla/chunk_delta_h.py
++++ b/sglang/srt/layers/attention/fla/chunk_delta_h.py
+@@ -21,8 +21,12 @@
+ 
+ NUM_WARPS = [2, 4] if is_nvidia_hopper else [2, 4, 8, 16]
+ CHUNK_SIZE = 64
+-GDN_CHUNK_H_BV = int(os.getenv("SGLANG_GDN_CHUNK_H_BV", "32"))
+-GDN_CHUNK_H_NUM_WARPS = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_WARPS", "4"))
++# gfx1030 defaults: the shipped BV=32/4-warp tile spills on RDNA2's 256-VGPR
++# wave32 register file; BV=16 with 8 warps runs 1005us -> 419us on V620 TP4
++# shard shapes.  The env knobs keep the single-config property (see below)
++# while allowing local revalidation.
++GDN_CHUNK_H_BV = int(os.getenv("SGLANG_GDN_CHUNK_H_BV", "16"))
++GDN_CHUNK_H_NUM_WARPS = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_WARPS", "8"))
+ GDN_CHUNK_H_NUM_STAGES = int(os.getenv("SGLANG_GDN_CHUNK_H_NUM_STAGES", "2"))
+ 
+ 
+--- a/sglang/srt/layers/attention/fla/chunk_fwd.py
++++ b/sglang/srt/layers/attention/fla/chunk_fwd.py
+@@ -28,10 +28,11 @@
+     }
+ )
+ @triton.autotune(
++    # gfx1030: the winner is BK=16 with 2 warps / 2 stages (252us -> 182us on
++    # V620 TP4 shard shapes), which is not in the upstream BK in [32, 64] x
++    # num_warps in [1, 2, 4] search space at all.  Pinned to a single config.
+     configs=[
+-        triton.Config({"BK": BK}, num_warps=num_warps)
+-        for BK in [32, 64]
+-        for num_warps in [1, 2, 4]
++        triton.Config({"BK": 16}, num_warps=2, num_stages=2),
+     ],
+     key=["H", "Hg", "K", "BC"],
+     **autotune_cache_kwargs,

--- a/pkgs/sglang/patches/gfx1030/0104-rocm-mamba-radix-extra-buffer.patch
+++ b/pkgs/sglang/patches/gfx1030/0104-rocm-mamba-radix-extra-buffer.patch
@@ -1,0 +1,39 @@
+ROCm: allow the mamba radix cache "extra_buffer" strategy on HIP with the
+triton linear-attn backend.
+
+Source-ified from .bench-artifacts/radix/graft/sitecustomize.py.  The
+CUDA/MUSA/NPU assert in ServerArgs._validate_mamba_extra_buffer over-guards:
+for --linear-attn-backend triton the entire extra_buffer data path is Triton
+plus plain torch indexing (chunk_gated_delta_rule_fwd_h already produces the
+per-chunk hidden states unconditionally; the checkpoint tracking is pure
+tensor indexing; mamba_checkpoint_pool's one CUDA symbol,
+torch.cuda.mem_get_info, is implemented on ROCm).  Every other assert in the
+method is kept verbatim; unlike the runtime graft, the gate is widened rather
+than dropped, so non-triton linear-attn backends on HIP still fail loudly.
+
+Applies on top of 0002-rocm-default-triton-and-xgrammar-fallback.patch (which
+touches a different region of server_args.py).
+
+--- a/sglang/srt/server_args.py
++++ b/sglang/srt/server_args.py
+@@ -4365,9 +4365,18 @@
+         assert self._support_mamba_cache_extra_buffer(
+             model_arch
+         ), f"extra_buffer is not supported for {model_arch}; use no_buffer."
++        # ROCm with the triton linear-attn backend is also fine: the whole
++        # extra_buffer data path there is Triton kernels (fla.chunk already
++        # returns the per-chunk hidden states h unconditionally) plus plain
++        # torch indexing, and torch.cuda.mem_get_info() exists on ROCm.  The
++        # CUDA-only kernels (gdn_cutedsl, gdn_flashinfer) are selected by
++        # --linear-attn-backend and raise their own errors.
+         assert (
+-            is_cuda() or is_musa() or is_npu()
+-        ), "extra_buffer needs CUDA/MUSA/NPU (FLA)."
++            is_cuda()
++            or is_musa()
++            or is_npu()
++            or (is_hip() and self.linear_attn_backend == "triton")
++        ), "extra_buffer needs CUDA/MUSA/NPU, or ROCm with --linear-attn-backend triton (FLA)."
+         if self.speculative_num_draft_tokens is not None:
+             assert (
+                 not self.enable_mamba_extra_buffer_lazy()

--- a/pkgs/sglang/patches/gfx1030/0110-gfx1030-tgemv-m1-gemv.patch
+++ b/pkgs/sglang/patches/gfx1030/0110-gfx1030-tgemv-m1-gemv.patch
@@ -1,0 +1,659 @@
+gfx1030: Triton small-M GEMV replacing rocBLAS for skinny decode GEMMs
+
+At batch-1 decode the model is a chain of M=1 fp16 GEMVs; rocBLAS/Tensile
+picks prefill macro-tiles for them and reads weights at ~212 GB/s against
+~350-430 GB/s achievable on gfx1030 (Radeon Pro V620).  This patch adds
+sglang/srt/layers/tgemv.py (Triton kernels + tuned per-shape config table)
+and routes three decode paths through it when M <= 8:
+
+  * UnquantizedLinearMethod.apply        (all dense linears)
+  * LogitsProcessor._compute_lm_head     (the 3.3x lm_head win)
+  * Qwen3_5GatedDeltaNet in_proj         (bit-exact column-concat of
+                                          in_proj_ba onto in_proj_qkvz)
+
+Prefill (M > 8) falls through to the original rocBLAS paths bit-identically.
+Measured on the Qwen3.8 27B campaign: 12.68 -> 20.674 tok/s decode.
+
+Kill switches (read once at import of tgemv.py, default enabled), kept for
+A/B attribution: QWEN38_GEMV=0 disables everything; QWEN38_GEMV_LINEAR /
+_LMHEAD / _CONCAT disable individual sites.  The graft's off-by-default
+SiluAndMul MLP fusion (QWEN38_GEMV_SILU) measured slower and is not ported.
+
+diff -ruN a/sglang/srt/layers/logits_processor.py b/sglang/srt/layers/logits_processor.py
+--- a/sglang/srt/layers/logits_processor.py	2026-08-25 23:52:55.644476863 +0200
++++ b/sglang/srt/layers/logits_processor.py	2026-08-25 23:54:29.779810366 +0200
+@@ -25,6 +25,7 @@
+     tensor_model_parallel_all_gather,
+ )
+ from sglang.srt.environ import envs
++from sglang.srt.layers import tgemv
+ from sglang.srt.layers.dp_attention import (
+     DpPaddingMode,
+     attn_tp_all_gather,
+@@ -877,6 +878,33 @@
+         lm_head: VocabParallelEmbedding,
+         embedding_bias: Optional[torch.Tensor] = None,
+     ) -> torch.Tensor:
++        # Triton GEMV for the decode lm_head (M <= tgemv.MAX_M): the [vocab, K]
++        # matmul is the single largest decode GEMM and rocBLAS reads it at a
++        # fraction of the achievable bandwidth at M=1.  Prefill and every
++        # special lm_head flavour (LoRA, fp32, rl_on_policy_target, bias) fall
++        # through below bit-identically.
++        w = getattr(lm_head, "weight", None)
++        if (
++            tgemv.LMHEAD
++            and w is not None
++            and embedding_bias is None
++            and not self.use_fp32_lm_head
++            and not hasattr(lm_head, "set_lora")
++            and get_global_server_args().rl_on_policy_target is None
++            and w.dtype is torch.float16
++            and w.dim() == 2
++            and w.stride(1) == 1
++            and hidden_states.dim() == 2
++            and hidden_states.shape[0] <= tgemv.MAX_M
++            and hidden_states.shape[1] == w.shape[1]
++            and hidden_states.is_cuda
++        ):
++            h = hidden_states.to(torch.float16)
++            if not h.is_contiguous():
++                h = h.contiguous()
++            tgemv.STATS["lmhead"] += 1
++            return tgemv.gemv(h, w)
++
+         if hasattr(lm_head, "set_lora") and hasattr(lm_head, "apply_lora"):
+             # This is a LoRA-wrapped module, use its forward method
+             logits = lm_head(hidden_states)
+diff -ruN a/sglang/srt/layers/quantization/unquant.py b/sglang/srt/layers/quantization/unquant.py
+--- a/sglang/srt/layers/quantization/unquant.py	2026-08-25 23:52:55.650135474 +0200
++++ b/sglang/srt/layers/quantization/unquant.py	2026-08-25 23:54:15.201829666 +0200
+@@ -10,6 +10,7 @@
+ from torch.nn.parameter import Parameter
+ 
+ from sglang.srt.environ import envs
++from sglang.srt.layers import tgemv
+ from sglang.srt.layers.amx_utils import (
+     CPUQuantMethod,
+     _amx_process_weight_after_loading,
+@@ -142,6 +143,20 @@
+         x: torch.Tensor,
+         bias: Optional[torch.Tensor] = None,
+     ) -> torch.Tensor:
++        # Triton GEMV for skinny decode GEMMs (M <= tgemv.MAX_M): rocBLAS picks
++        # prefill macro-tiles at M=1 and leaves ~40% of the achievable weight
++        # bandwidth on the table.  Prefill (large M) must fall through below
++        # bit-identically -- rocBLAS is compute-bound and faster there.
++        w = getattr(layer, "weight", None)
++        if (
++            tgemv.LINEAR
++            and w is not None
++            and type(w.data) is torch.Tensor
++            and tgemv.supported(x, w)
++        ):
++            tgemv.STATS["linear"] += 1
++            return tgemv.gemv(x, w, bias)
++
+         if use_intel_amx_backend(layer):
+             x_shapes = x.shape
+             if len(x_shapes) == 3:
+diff -ruN a/sglang/srt/layers/tgemv_config.json b/sglang/srt/layers/tgemv_config.json
+--- a/sglang/srt/layers/tgemv_config.json	1970-01-01 01:00:00.000000000 +0100
++++ b/sglang/srt/layers/tgemv_config.json	2026-08-25 23:54:01.877880861 +0200
+@@ -0,0 +1,194 @@
++{
++ "1,5120,8704": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "1,4352,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 256,
++  "num_warps": 2,
++  "num_stages": 1
++ },
++ "1,5120,4096": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "1,5120,62080": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "1,1536,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "1,5120,3584": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "1,5120,24": {
++  "BLOCK_N": 32,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "1,5120,4120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "2,5120,8704": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "4,5120,8704": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "8,5120,8704": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "2,4352,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 256,
++  "num_warps": 2,
++  "num_stages": 1
++ },
++ "4,4352,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 256,
++  "num_warps": 2,
++  "num_stages": 1
++ },
++ "8,4352,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "2,5120,4096": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "4,5120,4096": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "8,5120,4096": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "2,5120,62080": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "4,5120,62080": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "8,5120,62080": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 2,
++  "num_stages": 1
++ },
++ "2,1536,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "4,1536,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "8,1536,5120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 2,
++  "num_stages": 1
++ },
++ "2,5120,3584": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "4,5120,3584": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "8,5120,3584": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "2,5120,24": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "4,5120,24": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "8,5120,24": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ },
++ "2,5120,4120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "4,5120,4120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 8,
++  "num_stages": 1
++ },
++ "8,5120,4120": {
++  "BLOCK_N": 8,
++  "BLOCK_K": 512,
++  "num_warps": 4,
++  "num_stages": 1
++ }
++}
+\ No newline at end of file
+diff -ruN a/sglang/srt/layers/tgemv.py b/sglang/srt/layers/tgemv.py
+--- a/sglang/srt/layers/tgemv.py	1970-01-01 01:00:00.000000000 +0100
++++ b/sglang/srt/layers/tgemv.py	2026-08-25 23:53:58.031895641 +0200
+@@ -0,0 +1,221 @@
++"""Triton small-M GEMV/GEMM for gfx1030 (Radeon Pro V620), fp16.
++
++Why this exists: rocBLAS/Tensile picks prefill macro-tiles for M=1 problems and
++delivers ~212 GB/s aggregate against ~350-430 GB/s achievable on this part.  At
++batch 1 decode the whole model is one long chain of M=1 GEMVs, so that shortfall
++*is* the token rate.  Dispatch is capped at M <= MAX_M (8): beyond that rocBLAS
++is compute-bound and already good (30.17 TFLOP/s at prefill sizes), so prefill
++must fall through to it untouched.
++
++Layout contract: torch stores nn.Linear weights as W[N, K] row-major, and
++F.linear(x, W) computes x @ W.T.  So the *reduction* axis K is the contiguous
++one and each output column n owns a contiguous K-element row.  A program
++therefore claims BLOCK_N whole rows and streams them; every byte of the weight
++is read exactly once, coalesced, with no transpose and no split-K bookkeeping.
++
++Numerics: accumulation is fp32 in a fixed order (ascending k, BLOCK_K at a
++time), independent of BLOCK_N, of the program id, and of how many output
++columns the matrix has.  That last property is what makes the in_proj_qkvz +
++in_proj_ba column-concatenation bit-exact rather than merely close.
++
++Kill switches, read once at import time (default enabled).  A/B attribution
++against the rocBLAS baseline is how every number in this campaign was
++validated, so keep them working:
++
++  QWEN38_GEMV=0          disable everything
++  QWEN38_GEMV_LINEAR=0   leave UnquantizedLinearMethod.apply alone
++  QWEN38_GEMV_LMHEAD=0   leave LogitsProcessor._compute_lm_head alone
++  QWEN38_GEMV_CONCAT=0   do not column-concat in_proj_ba into in_proj_qkvz
++"""
++
++import json
++import os
++from typing import Optional
++
++import torch
++import triton
++import triton.language as tl
++
++
++def _flag(name, default):
++    return os.environ.get(name, "1" if default else "0") not in ("0", "false", "False", "")
++
++
++ENABLED = _flag("QWEN38_GEMV", True)
++LINEAR = ENABLED and _flag("QWEN38_GEMV_LINEAR", True)
++LMHEAD = ENABLED and _flag("QWEN38_GEMV_LMHEAD", True)
++CONCAT = ENABLED and _flag("QWEN38_GEMV_CONCAT", True)
++
++STATS = {"linear": 0, "lmhead": 0, "concat_layers": 0}
++
++# --------------------------------------------------------------------------
++# config table
++# --------------------------------------------------------------------------
++_CFG_PATH = os.environ.get(
++    "TGEMV_CONFIG", os.path.join(os.path.dirname(os.path.abspath(__file__)), "tgemv_config.json")
++)
++_TABLE = {}
++if os.path.exists(_CFG_PATH):
++    try:
++        with open(_CFG_PATH) as f:
++            _TABLE = json.load(f)
++    except Exception:  # a broken table must degrade to heuristics, never crash a server
++        _TABLE = {}
++
++
++def _heuristic(M: int, K: int, N: int):
++    """Fallback when the shape is not in the tuned table."""
++    if N <= 64:
++        bn = 16 if N <= 16 else 32
++        return {"BLOCK_N": bn, "BLOCK_K": 256, "num_warps": 4, "num_stages": 1}
++    if N <= 1024:
++        return {"BLOCK_N": 32, "BLOCK_K": 128, "num_warps": 4, "num_stages": 1}
++    return {"BLOCK_N": 64, "BLOCK_K": 128, "num_warps": 4, "num_stages": 1}
++
++
++_OVERRIDE = None  # set by the tuner while sweeping candidates
++
++
++def get_config(M: int, K: int, N: int):
++    if _OVERRIDE is not None:
++        return _OVERRIDE
++    c = _TABLE.get(f"{M},{K},{N}")
++    if c is None:
++        # An untuned M reuses the M=1 tile for the same matrix before falling
++        # back to heuristics: the tile choice is driven by the weight stream,
++        # which is identical, not by M.
++        c = _TABLE.get(f"1,{K},{N}")
++    if c is None:
++        c = _heuristic(M, K, N)
++    return c
++
++
++# --------------------------------------------------------------------------
++# kernels
++# --------------------------------------------------------------------------
++@triton.jit
++def _gemv_m1_kernel(
++    X, W, Y, BIAS,
++    K, N,
++    stride_wn,
++    HAS_BIAS: tl.constexpr,
++    EVEN_N: tl.constexpr,
++    EVEN_K: tl.constexpr,
++    BLOCK_N: tl.constexpr,
++    BLOCK_K: tl.constexpr,
++):
++    """y[0, n] = sum_k x[0, k] * W[n, k]   for BLOCK_N consecutive n."""
++    pid = tl.program_id(0)
++    offs_n = pid * BLOCK_N + tl.arange(0, BLOCK_N)
++    if EVEN_N:
++        mask_n = offs_n < offs_n + 1  # all-true, keeps the type uniform
++    else:
++        mask_n = offs_n < N
++    wptr = W + offs_n[:, None] * stride_wn
++    acc = tl.zeros((BLOCK_N,), dtype=tl.float32)
++    for k0 in range(0, K, BLOCK_K):
++        offs_k = k0 + tl.arange(0, BLOCK_K)
++        if EVEN_K:
++            x = tl.load(X + offs_k)
++            w = tl.load(wptr + offs_k[None, :], mask=mask_n[:, None], other=0.0)
++        else:
++            mk = offs_k < K
++            x = tl.load(X + offs_k, mask=mk, other=0.0)
++            w = tl.load(wptr + offs_k[None, :], mask=mask_n[:, None] & mk[None, :], other=0.0)
++        acc += tl.sum(w.to(tl.float32) * x.to(tl.float32)[None, :], axis=1)
++    if HAS_BIAS:
++        acc += tl.load(BIAS + offs_n, mask=mask_n, other=0.0).to(tl.float32)
++    tl.store(Y + offs_n, acc.to(Y.dtype.element_ty), mask=mask_n)
++
++
++@triton.jit
++def _gemm_smallm_kernel(
++    X, W, Y, BIAS,
++    M, K, N,
++    stride_xm, stride_wn, stride_ym,
++    HAS_BIAS: tl.constexpr,
++    EVEN_N: tl.constexpr,
++    EVEN_K: tl.constexpr,
++    BLOCK_M: tl.constexpr,
++    BLOCK_N: tl.constexpr,
++    BLOCK_K: tl.constexpr,
++):
++    """Same, for 1 < M <= BLOCK_M.  The weight tile is loaded once and reused
++    across the M rows, which is the whole point: if decode is bandwidth-bound,
++    M=8 must cost what M=1 costs."""
++    pid = tl.program_id(0)
++    offs_n = pid * BLOCK_N + tl.arange(0, BLOCK_N)
++    offs_m = tl.arange(0, BLOCK_M)
++    mask_n = offs_n < N if not EVEN_N else offs_n < offs_n + 1
++    mask_m = offs_m < M
++    wptr = W + offs_n[:, None] * stride_wn
++    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
++    for k0 in range(0, K, BLOCK_K):
++        offs_k = k0 + tl.arange(0, BLOCK_K)
++        if EVEN_K:
++            w = tl.load(wptr + offs_k[None, :], mask=mask_n[:, None], other=0.0)
++            x = tl.load(X + offs_m[:, None] * stride_xm + offs_k[None, :],
++                        mask=mask_m[:, None], other=0.0)
++        else:
++            mk = offs_k < K
++            w = tl.load(wptr + offs_k[None, :], mask=mask_n[:, None] & mk[None, :], other=0.0)
++            x = tl.load(X + offs_m[:, None] * stride_xm + offs_k[None, :],
++                        mask=mask_m[:, None] & mk[None, :], other=0.0)
++        acc += tl.sum(x.to(tl.float32)[:, None, :] * w.to(tl.float32)[None, :, :], axis=2)
++    if HAS_BIAS:
++        acc += tl.load(BIAS + offs_n, mask=mask_n, other=0.0).to(tl.float32)[None, :]
++    tl.store(Y + offs_m[:, None] * stride_ym + offs_n[None, :],
++             acc.to(Y.dtype.element_ty), mask=mask_m[:, None] & mask_n[None, :])
++
++
++# --------------------------------------------------------------------------
++# python entry points
++# --------------------------------------------------------------------------
++MAX_M = int(os.environ.get("TGEMV_MAX_M", "8"))
++
++
++def supported(x: torch.Tensor, w: torch.Tensor) -> bool:
++    return (
++        x.dtype == torch.float16
++        and w.dtype == torch.float16
++        and x.dim() == 2
++        and w.dim() == 2
++        and x.shape[0] <= MAX_M
++        and x.shape[1] == w.shape[1]
++        and w.stride(1) == 1
++        and x.is_contiguous()
++        and x.is_cuda
++    )
++
++
++def gemv(x: torch.Tensor, w: torch.Tensor, bias: Optional[torch.Tensor] = None,
++         out: Optional[torch.Tensor] = None) -> torch.Tensor:
++    """x: [M, K] fp16 contiguous.  w: [N, K] fp16, w.stride(1)==1.  -> [M, N]."""
++    M, K = x.shape
++    N = w.shape[0]
++    if out is None:
++        out = torch.empty((M, N), dtype=x.dtype, device=x.device)
++    cfg = get_config(M, K, N)
++    BLOCK_N = cfg["BLOCK_N"]
++    BLOCK_K = cfg["BLOCK_K"]
++    grid = (triton.cdiv(N, BLOCK_N),)
++    even_n = (N % BLOCK_N) == 0
++    even_k = (K % BLOCK_K) == 0
++    if M == 1:
++        _gemv_m1_kernel[grid](
++            x, w, out, bias if bias is not None else x,
++            K, N, w.stride(0),
++            HAS_BIAS=bias is not None, EVEN_N=even_n, EVEN_K=even_k,
++            BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
++            num_warps=cfg["num_warps"], num_stages=cfg["num_stages"],
++        )
++    else:
++        BLOCK_M = triton.next_power_of_2(M)
++        _gemm_smallm_kernel[grid](
++            x, w, out, bias if bias is not None else x,
++            M, K, N, x.stride(0), w.stride(0), out.stride(0),
++            HAS_BIAS=bias is not None, EVEN_N=even_n, EVEN_K=even_k,
++            BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,
++            num_warps=cfg["num_warps"], num_stages=cfg["num_stages"],
++        )
++    return out
+diff -ruN a/sglang/srt/models/qwen3_5.py b/sglang/srt/models/qwen3_5.py
+--- a/sglang/srt/models/qwen3_5.py	2026-08-25 23:52:55.665135416 +0200
++++ b/sglang/srt/models/qwen3_5.py	2026-08-25 23:55:35.703520536 +0200
+@@ -37,6 +37,7 @@
+ from sglang.srt.distributed import get_pp_group
+ from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
+ from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
++from sglang.srt.layers import tgemv
+ 
+ # Layers - Attention
+ from sglang.srt.layers.attention.fla.layernorm_gated import RMSNorm as RMSNormGated
+@@ -456,7 +457,60 @@
+ 
+         return query, key, value, z, b, a
+ 
++    def _fuse_in_proj_gemv(self) -> bool:
++        """Column-concat in_proj_ba [24, K] onto in_proj_qkvz [4096, K].
++
++        The two projections are GEMVs over the same input vector, so fusing
++        them halves the launch count and makes the 24-column matrix -- which
++        rocBLAS read at 4.3 GB/s, 53.9 us for 245 KB -- effectively free.
++        Because the tgemv kernel reduces over K in a fixed order that depends
++        neither on N nor on the program id, the split of the fused output is
++        BIT-IDENTICAL to the two separate GEMVs.
++        """
++        if getattr(self, "_gemv_fused_w", None) is not None:
++            return False
++        wq = getattr(getattr(self, "in_proj_qkvz", None), "weight", None)
++        wb = getattr(getattr(self, "in_proj_ba", None), "weight", None)
++        if wq is None or wb is None:
++            return False
++        if (
++            wq.dtype is not torch.float16
++            or wb.dtype is not torch.float16
++            or wq.dim() != 2
++            or wb.dim() != 2
++            or wq.shape[1] != wb.shape[1]
++            or type(wq.data) is not torch.Tensor
++            or type(wb.data) is not torch.Tensor
++        ):
++            return False
++        nq = wq.shape[0]
++        fused = torch.cat([wq.data, wb.data], dim=0).contiguous()
++        # Re-point the original parameters at views of the fused buffer so
++        # the un-fused path stays correct and no memory is duplicated.
++        self.in_proj_qkvz.weight.data = fused[:nq]
++        self.in_proj_ba.weight.data = fused[nq:]
++        self._gemv_fused_w = fused
++        self._gemv_nq = nq
++        tgemv.STATS["concat_layers"] += 1
++        return True
++
+     def _forward_input_proj(self, hidden_states: torch.Tensor):
++        # Decode (M <= tgemv.MAX_M) takes the fused single-GEMV path; prefill
++        # falls through to the original two projections.
++        w = getattr(self, "_gemv_fused_w", None)
++        if (
++            w is not None
++            and hidden_states.dim() == 2
++            and hidden_states.shape[0] <= tgemv.MAX_M
++            and hidden_states.dtype is torch.float16
++            and hidden_states.shape[1] == w.shape[1]
++        ):
++            x = hidden_states
++            if not x.is_contiguous():
++                x = x.contiguous()
++            out = tgemv.gemv(x, w)
++            nq = self._gemv_nq
++            return out[:, :nq], out[:, nq:]
+         if (
+             _is_cpu
+             or _is_npu
+@@ -561,6 +615,32 @@
+         return output
+ 
+ 
++def _fuse_gdn_in_proj_gemv(model: nn.Module) -> None:
++    """Fuse in_proj weights on every GatedDeltaNet layer for the tgemv path.
++
++    Called at the end of load_weights, before the KV pool is sized, so the
++    transient extra copy from the cat is paid out of free memory rather than
++    out of the graph pool.
++    """
++    if not tgemv.CONCAT:
++        return
++    try:
++        n = 0
++        for m in model.modules():
++            if isinstance(m, Qwen3_5GatedDeltaNet):
++                n += bool(m._fuse_in_proj_gemv())
++        if n:
++            logger.info(
++                "tgemv: column-concatenated in_proj_ba into in_proj_qkvz "
++                "on %d GatedDeltaNet layers",
++                n,
++            )
++    except Exception:  # never take the server down over an optimisation
++        logger.exception(
++            "tgemv: in_proj concat failed, falling back to the unfused path"
++        )
++
++
+ class Qwen3_5LinearDecoderLayer(nn.Module):
+     """Qwen3.5 Decoder Layer with Linear Attention (GatedDeltaNet)."""
+ 
+@@ -1358,6 +1438,7 @@
+                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                 weight_loader(param, loaded_weight)
+             loaded_params.add(name)
++        _fuse_gdn_in_proj_gemv(self)
+         return loaded_params
+ 
+     @classmethod
+@@ -1576,6 +1657,7 @@
+                         logger.warning(f"Parameter {name} not found in params_dict")
+             loaded_params.add(name)
+ 
++        _fuse_gdn_in_proj_gemv(self)
+         return loaded_params
+ 
+ 
+@@ -1728,6 +1810,7 @@
+                     )
+                     weight_loader(param_lm_head, loaded_weight)
+             loaded_params.add(name)
++        _fuse_gdn_in_proj_gemv(self)
+         return loaded_params
+ 
+ 
+@@ -2101,6 +2184,7 @@
+             }
+         )
+ 
++        _fuse_gdn_in_proj_gemv(self)
+         return loaded_params
+ 
+     @property

--- a/pkgs/sglang/tests-qwen4-exp/test_qsa_rocm_decode_patch.py
+++ b/pkgs/sglang/tests-qwen4-exp/test_qsa_rocm_decode_patch.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Static contract for the Qwen4-Exp ROCm QSA decode boot fix."""
+
+from __future__ import annotations
+
+import ast
+import os
+import textwrap
+from pathlib import Path
+
+import torch
+
+
+root = Path(os.environ["SGLANG_ROOT_UNDER_TEST"])
+server_args_source = (root / "sglang/srt/server_args.py").read_text(encoding="utf-8")
+assert '"Qwen4ExpForConditionalGeneration",' in server_args_source
+
+source_path = root / "sglang/srt/layers/attention/qwen_sparse_attn_backend.py"
+source = source_path.read_text(encoding="utf-8")
+tree = ast.parse(source, filename=str(source_path))
+
+backend = next(
+    node
+    for node in tree.body
+    if isinstance(node, ast.ClassDef) and node.name == "QwenSparseAttnBackend"
+)
+paged = next(
+    node
+    for node in backend.body
+    if isinstance(node, ast.FunctionDef) and node.name == "_forward_paged_attention"
+)
+paged_source = ast.get_source_segment(source, paged)
+assert paged_source is not None
+assert "if q.is_cuda and torch.version.hip is not None:" in paged_source
+assert "slots = self._logical_to_physical(topk_indices, metadata)" in paged_source
+assert "sparse_gqa_decode_physical_triton(" in paged_source
+
+sparse_source = (
+    root / "sglang/srt/layers/attention/qsa/sparse_attn.py"
+).read_text(encoding="utf-8")
+assert "def _sparse_gqa_decode_scores_physical(" in sparse_source
+assert "def _sparse_gqa_decode_values_physical(" in sparse_source
+assert "def sparse_gqa_decode_physical_triton(" in sparse_source
+assert "scores = torch.empty(" in sparse_source
+assert "accumulator = tl.zeros([BLOCK_D], tl.float32)" in sparse_source
+assert "has_values = next_max > -float(\"inf\")" in sparse_source
+
+# The CUDA implementation remains available for supported NVIDIA systems; the
+# patch must not pretend that FA2/FA4 itself became portable.
+assert "flash_attn_varlen_func = _resolve_flash_attn_varlen_func()" in paged_source
+
+quant_root = root / "sglang/srt/layers/quantization"
+mxfp4_source = (quant_root / "mxfp4.py").read_text(encoding="utf-8")
+registry_source = (quant_root / "__init__.py").read_text(encoding="utf-8")
+diffusion_mxfp4_source = (
+    root / "sglang/multimodal_gen/runtime/layers/quantization/mxfp4.py"
+).read_text(encoding="utf-8")
+assert "if _use_aiter:\n    # import aiter" in mxfp4_source
+assert '_quark_available = not (is_hip() and _rocm_arch.startswith("gfx10"))' in registry_source
+assert "if _is_hip and is_gfx95_supported():" in diffusion_mxfp4_source
+
+activation_source = (root / "sglang/srt/layers/activation.py").read_text(
+    encoding="utf-8"
+)
+moe_runner_source = (
+    root
+    / "sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py"
+).read_text(encoding="utf-8")
+triton_moe_source = (
+    root / "sglang/srt/layers/moe/fused_moe_triton/triton_kernels_moe.py"
+).read_text(encoding="utf-8")
+assert "elif _is_hip:\n    from sglang.kernels.ops.activation.activation import (" in activation_source
+assert "def gelu_quick(input: torch.Tensor, out=None)" in activation_source
+assert "elif _is_hip:\n    from sglang.kernels.ops.activation.activation import gelu_and_mul, silu_and_mul" in moe_runner_source
+assert "if is_cuda() or is_hip():" in triton_moe_source
+
+wna16_source = (
+    quant_root
+    / "compressed_tensors/schemes/compressed_tensors_wNa16_moe.py"
+).read_text(encoding="utf-8")
+assert "def transpose_parameter_on_host(" in wna16_source
+assert "parameter.data = parameter.data.new_empty(0)" in wna16_source
+assert 'setattr(layer, name, None)' in wna16_source
+assert "torch.cuda.empty_cache()" in wna16_source
+assert 'transpose_parameter_on_host("w13_weight_packed", view_uint8=True)' in wna16_source
+assert 'transpose_parameter_on_host("w2_weight_scale")' in wna16_source
+
+# Exercise the actual patched method body on CPU without importing SGLang's
+# quantization package, whose import probes for a physical GPU.  Keep external
+# references to the original Parameters to reproduce the loader bookkeeping
+# that caused the live V620 peak: those objects must survive but their
+# GPU-sized storage must not.
+wna16_tree = ast.parse(wna16_source)
+wna16_class = next(
+    node
+    for node in wna16_tree.body
+    if isinstance(node, ast.ClassDef)
+    and node.name == "CompressedTensorsWNA16TritonMoE"
+)
+wna16_method = next(
+    node
+    for node in wna16_class.body
+    if isinstance(node, ast.FunctionDef)
+    and node.name == "process_weights_after_loading"
+)
+wna16_method_source = ast.get_source_segment(wna16_source, wna16_method)
+assert wna16_method_source is not None
+wna16_namespace = {"torch": torch}
+exec(
+    "class _PatchedWNA16Scheme:\n"
+    + textwrap.indent(textwrap.dedent(wna16_method_source), "    "),
+    wna16_namespace,
+)
+
+
+class _FakeLayer(torch.nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.w13_weight_packed = torch.nn.Parameter(
+            torch.arange(24, dtype=torch.int32).reshape(2, 3, 4),
+            requires_grad=False,
+        )
+        self.w2_weight_packed = torch.nn.Parameter(
+            (torch.arange(24, dtype=torch.int32) + 100).reshape(2, 3, 4),
+            requires_grad=False,
+        )
+        self.w13_weight_scale = torch.nn.Parameter(
+            torch.arange(24, dtype=torch.float32).reshape(2, 3, 4),
+            requires_grad=False,
+        )
+        self.w2_weight_scale = torch.nn.Parameter(
+            (torch.arange(24, dtype=torch.float32) + 100).reshape(2, 3, 4),
+            requires_grad=False,
+        )
+
+
+layer = _FakeLayer()
+names = (
+    "w13_weight_packed",
+    "w2_weight_packed",
+    "w13_weight_scale",
+    "w2_weight_scale",
+)
+old_parameters = {name: getattr(layer, name) for name in names}
+expected = {
+    name: parameter.detach().transpose(1, 2).contiguous()
+    for name, parameter in old_parameters.items()
+}
+expected["w13_weight_packed"] = expected["w13_weight_packed"].view(torch.uint8)
+expected["w2_weight_packed"] = expected["w2_weight_packed"].view(torch.uint8)
+
+empty_cache = torch.cuda.empty_cache
+torch.cuda.empty_cache = lambda: None
+try:
+    scheme = wna16_namespace["_PatchedWNA16Scheme"]()
+    scheme.process_weights_after_loading(layer)
+    first_parameters = {name: getattr(layer, name) for name in names}
+    scheme.process_weights_after_loading(layer)
+finally:
+    torch.cuda.empty_cache = empty_cache
+
+assert layer.is_triton_converted
+for name in names:
+    assert old_parameters[name].numel() == 0
+    assert torch.equal(first_parameters[name], expected[name])
+    assert getattr(layer, name) is first_parameters[name]
+
+xgrammar_source = (
+    root / "sglang/srt/constrained/xgrammar_backend.py"
+).read_text(encoding="utf-8")
+assert "from sgl_kernel import apply_token_bitmask_inplace_cuda" not in xgrammar_source
+assert "_is_hip = is_hip()" in xgrammar_source
+assert xgrammar_source.count("apply_token_bitmask_inplace_triton(logits, vocab_mask)") == 2
+
+hyperconnection_source = (
+    root / "sglang/srt/layers/hyperconnection.py"
+).read_text(encoding="utf-8")
+assert "from sglang.srt.utils import is_cuda" in hyperconnection_source
+assert (
+    "envs.SGLANG_HC_MIX_CUDA.get()\n"
+    "                and is_cuda()\n"
+    "                and torch.cuda.is_available()"
+) in hyperconnection_source
+
+hc_mix_source = (
+    root / "sglang/kernels/ops/elementwise/hc_mix.py"
+).read_text(encoding="utf-8")
+assert "def hc_mix(" in hc_mix_source
+assert "flashinfer_pr4266_dense_bf16_gemm_sm100_splitk import (" in hc_mix_source
+
+qwen4_source = (root / "sglang/srt/models/qwen4_exp.py").read_text(
+    encoding="utf-8"
+)
+assert qwen4_source.count("params_dtype=torch.get_default_dtype(),") == 2
+assert "output_dtype=torch.get_default_dtype()," in qwen4_source
+assert '"output_dtype",' in qwen4_source
+assert "dtype=self.output_dtype" in qwen4_source
+assert "out.dtype != self.output_dtype" in qwen4_source
+assert "weight_scale\", torch.ones(1, dtype=torch.get_default_dtype())" in qwen4_source
+
+topk_source = (root / "sglang/srt/layers/moe/topk.py").read_text(encoding="utf-8")
+assert "elif _is_hip:\n            topk_weights, topk_ids = fused_topk_torch_native(" in topk_source
+assert "scoring_func=scoring_func," in topk_source
+
+moe_align_source = (
+    root
+    / "sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py"
+).read_text(encoding="utf-8")
+assert "if _is_cuda or _is_xpu or _is_musa:" in moe_align_source
+assert "elif _is_hip:" in moe_align_source
+assert "moe_align_block_size as jit_moe_align_block_size" in moe_align_source
+assert "if ignore_invalid_expert:" in moe_align_source
+assert "jit_moe_align_block_size(" in moe_align_source
+
+eagle_source = (root / "sglang/srt/speculative/eagle_utils.py").read_text(
+    encoding="utf-8"
+)
+assert "if _is_cuda or _is_hip or _is_musa:" not in eagle_source
+assert eagle_source.count("elif _is_xpu or _is_hip:") == 2
+
+hisparse_source = (root / "sglang/srt/mem_cache/hisparse_memory_pool.py").read_text(
+    encoding="utf-8"
+)
+assert "try:\n    from sgl_kernel.kvcacheio import transfer_kv_all_layer_mla" in hisparse_source
+assert 'except ImportError:' in hisparse_source
+
+scheduler_source = (root / "sglang/srt/managers/scheduler.py").read_text(
+    encoding="utf-8"
+)
+assert scheduler_source.count(
+    "from sglang.srt.disaggregation.decode_kvcache_offload_manager import ("
+) == 1
+assert (
+    "\n            from sglang.srt.disaggregation."
+    "decode_kvcache_offload_manager import ("
+) in scheduler_source
+assert "from sglang.srt.managers.hisparse_coordinator import" not in scheduler_source
+assert "self.hisparse_coordinator: Optional[Any] = None" in scheduler_source
+
+host_pool_source = (root / "sglang/srt/mem_cache/memory_pool_host.py").read_text(
+    encoding="utf-8"
+)
+assert "except ImportError:\n    def _missing_kvcacheio" in host_pool_source
+assert "transfer_kv_per_layer_mla_pf_lf = _missing_kvcacheio" in host_pool_source
+
+hybrid_controller_source = (
+    root / "sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py"
+).read_text(encoding="utf-8")
+assert hybrid_controller_source.count(
+    "from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost"
+) == 1
+assert (
+    "\n            from sglang.srt.mem_cache.pool_host.mha import "
+    "MHATokenToKVPoolHost"
+) in hybrid_controller_source
+
+spec_utils_source = (root / "sglang/srt/speculative/spec_utils.py").read_text(
+    encoding="utf-8"
+)
+assert "elif _is_hip:\n    from sgl_kernel import fast_topk" not in spec_utils_source
+
+rope_source = (
+    root / "sglang/srt/layers/rotary_embedding/base.py"
+).read_text(encoding="utf-8")
+assert "except ImportError:\n                    self.use_fallback_kernel = False" in rope_source
+assert "self._forward_method = self.forward_native" in rope_source
+assert "if rotary_embedding is not None:" in rope_source

--- a/pkgs/sglang/tests-qwen4-exp/test_qsa_rocm_decode_patch.py
+++ b/pkgs/sglang/tests-qwen4-exp/test_qsa_rocm_decode_patch.py
@@ -44,6 +44,7 @@ assert "def sparse_gqa_decode_physical_triton(" in sparse_source
 assert "scores = torch.empty(" in sparse_source
 assert "accumulator = tl.zeros([BLOCK_D], tl.float32)" in sparse_source
 assert "has_values = next_max > -float(\"inf\")" in sparse_source
+assert "if torch.version.hip is not None:\n        stages = 1" in sparse_source
 
 # The CUDA implementation remains available for supported NVIDIA systems; the
 # patch must not pretend that FA2/FA4 itself became portable.
@@ -79,9 +80,12 @@ wna16_source = (
     / "compressed_tensors/schemes/compressed_tensors_wNa16_moe.py"
 ).read_text(encoding="utf-8")
 assert "def transpose_parameter_on_host(" in wna16_source
+assert 'to(device="cpu", non_blocking=False)' in wna16_source
 assert "parameter.data = parameter.data.new_empty(0)" in wna16_source
 assert 'setattr(layer, name, None)' in wna16_source
 assert "torch.cuda.empty_cache()" in wna16_source
+assert wna16_source.count("torch.cuda.synchronize(device)") == 3
+assert "to(device=device, non_blocking=False)" in wna16_source
 assert 'transpose_parameter_on_host("w13_weight_packed", view_uint8=True)' in wna16_source
 assert 'transpose_parameter_on_host("w2_weight_scale")' in wna16_source
 
@@ -150,7 +154,9 @@ expected["w13_weight_packed"] = expected["w13_weight_packed"].view(torch.uint8)
 expected["w2_weight_packed"] = expected["w2_weight_packed"].view(torch.uint8)
 
 empty_cache = torch.cuda.empty_cache
+synchronize = torch.cuda.synchronize
 torch.cuda.empty_cache = lambda: None
+torch.cuda.synchronize = lambda _device: None
 try:
     scheme = wna16_namespace["_PatchedWNA16Scheme"]()
     scheme.process_weights_after_loading(layer)
@@ -158,6 +164,7 @@ try:
     scheme.process_weights_after_loading(layer)
 finally:
     torch.cuda.empty_cache = empty_cache
+    torch.cuda.synchronize = synchronize
 
 assert layer.is_triton_converted
 for name in names:
@@ -208,9 +215,16 @@ moe_align_source = (
 ).read_text(encoding="utf-8")
 assert "if _is_cuda or _is_xpu or _is_musa:" in moe_align_source
 assert "elif _is_hip:" in moe_align_source
-assert "moe_align_block_size as jit_moe_align_block_size" in moe_align_source
+assert "moe_align_block_size as hip_jit_moe_align_block_size" in moe_align_source
 assert "if ignore_invalid_expert:" in moe_align_source
-assert "jit_moe_align_block_size(" in moe_align_source
+assert "hip_jit_moe_align_block_size(" in moe_align_source
+
+moe_align_kernel_source = (
+    root / "sglang/kernels/jit/csrc/moe/moe_align_kernel.cu"
+).read_text(encoding="utf-8")
+assert "using warp_mask_t = unsigned long long;" in moe_align_kernel_source
+assert "using warp_mask_t = unsigned;" in moe_align_kernel_source
+assert "warp_mask_t mask = ~warp_mask_t{0}" in moe_align_kernel_source
 
 eagle_source = (root / "sglang/srt/speculative/eagle_utils.py").read_text(
     encoding="utf-8"

--- a/pkgs/transformers-5_12_1.nix
+++ b/pkgs/transformers-5_12_1.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  buildPythonPackage,
+  fetchurl,
+  filelock,
+  huggingface-hub,
+  numpy,
+  packaging,
+  pyyaml,
+  regex,
+  requests,
+  safetensors,
+  tokenizers,
+  tqdm,
+  typer,
+}:
+
+buildPythonPackage rec {
+  pname = "transformers";
+  version = "5.12.1";
+  format = "wheel";
+
+  src = fetchurl {
+    url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-${version}-py3-none-any.whl";
+    hash = "sha256-Kl4QnSAhJl33CY/7tzgpWsr1rSVvEsvFhtsupNy7Goo=";
+  };
+
+  dependencies = [
+    filelock
+    huggingface-hub
+    numpy
+    packaging
+    pyyaml
+    regex
+    requests
+    safetensors
+    tokenizers
+    tqdm
+    typer
+  ];
+
+  pythonRelaxDeps = [
+    "huggingface-hub"
+    "regex"
+    "tokenizers"
+  ];
+
+  doCheck = false;
+  # Qwen4-Exp's config/model implementation is carried by the matching SGLang
+  # support commit, not by the Transformers wheel.  This pin supplies the HF
+  # APIs that implementation was developed and tested against.
+  pythonImportsCheck = [
+    "transformers"
+  ];
+
+  meta = {
+    description = "Transformers API release used by SGLang's Qwen4-Exp support";
+    homepage = "https://github.com/huggingface/transformers";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/scripts/qwen38-flash-next-bench.py
+++ b/scripts/qwen38-flash-next-bench.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Async TTFT/decode/prefix-cache benchmark for Qwen Flash-Next on SGLang.
+
+The harness deliberately uses one asyncio event loop and direct HTTP/1.1
+connections.  It does not put blocking urllib calls in Python threads: that
+pattern made earlier concurrent client throughput results wrong by up to 4x.
+
+Each trial flushes the radix cache, sends a concurrent wave of unique cold
+prompts, then sends a concurrent wave whose prompts reuse those cold prefixes.
+Every run has a fresh nonce, and cache state is checked against
+``meta_info.cached_tokens`` whenever the server supplies it.
+
+The append-only JSONL contains run metadata, one record per request, per-trial
+summaries, and a final run summary.  ``variant`` and ``block_index`` make files
+suitable for externally interleaved A/B/A/B runs; repeated ``trial`` summaries
+carry minima as well as medians for min-of-N analysis.
+
+SGLang's own server-side generation throughput remains authoritative.  The
+client wave throughput here is a useful async cross-check, not a replacement.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import math
+import os
+import random
+import secrets
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Iterable
+
+
+SCHEMA = "qwen38-flash-next-bench-v1"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Measure concurrent cold/warm TTFT, decode, and end-to-end latency "
+            "against SGLang; append durable ABAB-ready JSONL."
+        )
+    )
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=30801)
+    parser.add_argument(
+        "--out",
+        type=Path,
+        required=True,
+        help="append-only JSONL output path (parent directories are created)",
+    )
+    parser.add_argument(
+        "--variant",
+        default="unlabeled",
+        help="server/config label, normally A or B for an interleaved campaign",
+    )
+    parser.add_argument(
+        "--block-index",
+        type=int,
+        default=0,
+        help="external ABAB block/order index",
+    )
+    parser.add_argument("--tag", default="")
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=4,
+        help="distinct cache prefixes (and cold requests) per trial",
+    )
+    parser.add_argument(
+        "--warm-repeats",
+        type=int,
+        default=1,
+        help="warm requests with distinct tails per seeded prefix",
+    )
+    parser.add_argument("--concurrency", type=int, default=4)
+    parser.add_argument("--prefix-tokens", type=int, default=16384)
+    parser.add_argument("--query-tokens", type=int, default=64)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--token-id-low", type=int, default=1000)
+    parser.add_argument("--token-id-high", type=int, default=100000)
+    parser.add_argument(
+        "--nonce",
+        help="reproduce prompt construction; omit during measurement for fresh prompts",
+    )
+    parser.add_argument("--request-timeout", type=float, default=300.0)
+    parser.add_argument("--flush-timeout", type=float, default=120.0)
+    args = parser.parse_args()
+
+    positive = {
+        "trials": args.trials,
+        "samples": args.samples,
+        "warm_repeats": args.warm_repeats,
+        "concurrency": args.concurrency,
+        "prefix_tokens": args.prefix_tokens,
+        "query_tokens": args.query_tokens,
+        "max_new_tokens": args.max_new_tokens,
+    }
+    bad = [name for name, value in positive.items() if value <= 0]
+    if bad:
+        parser.error("must be positive: " + ", ".join(bad))
+    if args.token_id_low < 0 or args.token_id_high <= args.token_id_low:
+        parser.error("token ID range must satisfy 0 <= low < high")
+    if args.request_timeout <= 0 or args.flush_timeout <= 0:
+        parser.error("timeouts must be positive")
+    return args
+
+
+@dataclass
+class HTTPResponse:
+    status: int
+    reason: str
+    headers: dict[str, str]
+    reader: asyncio.StreamReader
+    writer: asyncio.StreamWriter
+
+    async def iter_bytes(self) -> AsyncIterator[bytes]:
+        try:
+            transfer = self.headers.get("transfer-encoding", "").lower()
+            length_text = self.headers.get("content-length")
+            if "chunked" in transfer:
+                while True:
+                    size_line = await self.reader.readline()
+                    if not size_line:
+                        raise RuntimeError("unexpected EOF in chunked response")
+                    size = int(size_line.split(b";", 1)[0].strip(), 16)
+                    if size == 0:
+                        while True:
+                            trailer = await self.reader.readline()
+                            if trailer in (b"\r\n", b"\n", b""):
+                                break
+                        break
+                    yield await self.reader.readexactly(size)
+                    ending = await self.reader.readexactly(2)
+                    if ending != b"\r\n":
+                        raise RuntimeError("malformed chunk terminator")
+            elif length_text is not None:
+                remaining = int(length_text)
+                while remaining:
+                    chunk = await self.reader.read(min(65536, remaining))
+                    if not chunk:
+                        raise RuntimeError("unexpected EOF in fixed-length response")
+                    remaining -= len(chunk)
+                    yield chunk
+            else:
+                while True:
+                    chunk = await self.reader.read(65536)
+                    if not chunk:
+                        break
+                    yield chunk
+        finally:
+            self.writer.close()
+            try:
+                await self.writer.wait_closed()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+    async def read(self) -> bytes:
+        return b"".join([chunk async for chunk in self.iter_bytes()])
+
+
+class AsyncSGLangClient:
+    def __init__(self, host: str, port: int) -> None:
+        self.host = host
+        self.port = port
+
+    async def request(
+        self, method: str, path: str, payload: Any | None = None
+    ) -> HTTPResponse:
+        reader, writer = await asyncio.open_connection(self.host, self.port)
+        body = b"" if payload is None else json.dumps(payload).encode("utf-8")
+        headers = [
+            f"{method} {path} HTTP/1.1",
+            f"Host: {self.host}:{self.port}",
+            "Accept: application/json, text/event-stream",
+            "Connection: close",
+            f"Content-Length: {len(body)}",
+        ]
+        if payload is not None:
+            headers.append("Content-Type: application/json")
+        writer.write(("\r\n".join(headers) + "\r\n\r\n").encode("ascii") + body)
+        await writer.drain()
+
+        status_line = await reader.readline()
+        if not status_line:
+            writer.close()
+            raise RuntimeError("server closed before returning an HTTP status")
+        fields = status_line.decode("iso-8859-1").rstrip().split(" ", 2)
+        if len(fields) < 2 or not fields[1].isdigit():
+            writer.close()
+            raise RuntimeError(f"malformed HTTP status: {status_line!r}")
+        status = int(fields[1])
+        reason = fields[2] if len(fields) == 3 else ""
+        response_headers: dict[str, str] = {}
+        while True:
+            line = await reader.readline()
+            if line in (b"\r\n", b"\n", b""):
+                break
+            name, sep, value = line.decode("iso-8859-1").partition(":")
+            if not sep:
+                writer.close()
+                raise RuntimeError(f"malformed HTTP header: {line!r}")
+            response_headers[name.strip().lower()] = value.strip()
+        return HTTPResponse(status, reason, response_headers, reader, writer)
+
+    async def json_request(
+        self, method: str, path: str, payload: Any | None, timeout: float
+    ) -> Any:
+        async def operation() -> Any:
+            response = await self.request(method, path, payload)
+            body = await response.read()
+            if not 200 <= response.status < 300:
+                text = body.decode("utf-8", "replace")
+                raise RuntimeError(f"{path} HTTP {response.status}: {text[:1000]}")
+            if not body:
+                return None
+            try:
+                return json.loads(body)
+            except json.JSONDecodeError:
+                # /flush_cache has returned both JSON and plain text across
+                # SGLang releases.  The HTTP status is the contract we need.
+                return body.decode("utf-8", "replace")
+
+        return await asyncio.wait_for(operation(), timeout=timeout)
+
+
+class DurableJSONL:
+    def __init__(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = path.open("a", encoding="utf-8")
+
+    def write_batch(self, records: Iterable[dict[str, Any]]) -> None:
+        for record in records:
+            self._file.write(json.dumps(record, sort_keys=True, allow_nan=False) + "\n")
+        self._file.flush()
+        os.fsync(self._file.fileno())
+
+    def close(self) -> None:
+        self._file.close()
+
+
+def seeded_tokens(
+    nonce: str, low: int, high: int, count: int, *identity: object
+) -> list[int]:
+    digest = hashlib.sha256(
+        (nonce + "\0" + "\0".join(map(str, identity))).encode("utf-8")
+    ).digest()
+    rng = random.Random(int.from_bytes(digest[:16], "big"))
+    return [rng.randrange(low, high) for _ in range(count)]
+
+
+def scalar_meta(meta: Any) -> dict[str, Any]:
+    """Keep useful server metadata without accidentally logging token arrays."""
+    if not isinstance(meta, dict):
+        return {}
+    return {
+        key: value
+        for key, value in meta.items()
+        if value is None or isinstance(value, (bool, int, float, str))
+    }
+
+
+def cache_state(kind: str, cached_tokens: Any) -> tuple[str, bool]:
+    if not isinstance(cached_tokens, int):
+        return "unavailable", True
+    if kind == "cold":
+        return ("verified_miss", True) if cached_tokens == 0 else ("contaminated", False)
+    return ("verified_hit", True) if cached_tokens > 0 else ("unexpected_miss", False)
+
+
+async def generate_once(
+    client: AsyncSGLangClient,
+    timeout: float,
+    request_record: dict[str, Any],
+    input_ids: list[int],
+    max_new_tokens: int,
+) -> dict[str, Any]:
+    payload = {
+        "input_ids": input_ids,
+        "sampling_params": {
+            "max_new_tokens": max_new_tokens,
+            "temperature": 0.0,
+            "ignore_eos": True,
+        },
+        "stream": True,
+    }
+    loop = asyncio.get_running_loop()
+    started = loop.time()
+    first_token_at: float | None = None
+    last_token_at: float | None = None
+    completion_tokens = 0
+    final_obj: dict[str, Any] = {}
+
+    async def operation() -> None:
+        nonlocal first_token_at, last_token_at, completion_tokens, final_obj
+        response = await client.request("POST", "/generate", payload)
+        if not 200 <= response.status < 300:
+            body = await response.read()
+            raise RuntimeError(
+                f"/generate HTTP {response.status}: "
+                f"{body.decode('utf-8', 'replace')[:1000]}"
+            )
+        pending = ""
+        async for chunk in response.iter_bytes():
+            pending += chunk.decode("utf-8", "replace")
+            while "\n" in pending:
+                line, pending = pending.split("\n", 1)
+                line = line.rstrip("\r")
+                if not line.startswith("data:"):
+                    continue
+                data = line[5:].strip()
+                if not data or data == "[DONE]":
+                    continue
+                obj = json.loads(data)
+                if not isinstance(obj, dict):
+                    continue
+                final_obj = obj
+                count = obj.get("meta_info", {}).get("completion_tokens", 0)
+                if isinstance(count, int) and count > completion_tokens:
+                    now = loop.time()
+                    if first_token_at is None:
+                        first_token_at = now
+                    last_token_at = now
+                    completion_tokens = count
+
+    try:
+        await asyncio.wait_for(operation(), timeout=timeout)
+        finished = loop.time()
+        meta = final_obj.get("meta_info", {})
+        if isinstance(meta, dict):
+            server_count = meta.get("completion_tokens")
+            if isinstance(server_count, int):
+                completion_tokens = max(completion_tokens, server_count)
+        decode_s = None
+        decode_tok_s = None
+        ms_per_decode_token = None
+        if (
+            completion_tokens > 1
+            and first_token_at is not None
+            and last_token_at is not None
+            and last_token_at > first_token_at
+        ):
+            decode_s = last_token_at - first_token_at
+            decode_tok_s = (completion_tokens - 1) / decode_s
+            ms_per_decode_token = 1000.0 * decode_s / (completion_tokens - 1)
+        cached_tokens = meta.get("cached_tokens") if isinstance(meta, dict) else None
+        state, valid = cache_state(request_record["kind"], cached_tokens)
+        return {
+            **request_record,
+            "record_type": "request",
+            "ok": True,
+            "valid_measurement": valid,
+            "cache_state": state,
+            "prompt_tokens": meta.get("prompt_tokens") if isinstance(meta, dict) else None,
+            "cached_tokens": cached_tokens,
+            "completion_tokens": completion_tokens,
+            "ttft_s": None if first_token_at is None else first_token_at - started,
+            "decode_s": decode_s,
+            "decode_tok_s": decode_tok_s,
+            "ms_per_decode_token": ms_per_decode_token,
+            "e2e_s": finished - started,
+            "server_meta": scalar_meta(meta),
+            "finished_at_utc": utc_now(),
+        }
+    except Exception as error:  # Preserve failures in the durable campaign log.
+        return {
+            **request_record,
+            "record_type": "request",
+            "ok": False,
+            "valid_measurement": False,
+            "cache_state": "error",
+            "error_type": type(error).__name__,
+            "error": str(error),
+            "e2e_s": loop.time() - started,
+            "finished_at_utc": utc_now(),
+        }
+
+
+async def run_wave(
+    jobs: list[tuple[dict[str, Any], list[int]]],
+    client: AsyncSGLangClient,
+    args: argparse.Namespace,
+) -> tuple[list[dict[str, Any]], float]:
+    semaphore = asyncio.Semaphore(args.concurrency)
+
+    async def guarded(
+        record: dict[str, Any], prompt: list[int]
+    ) -> dict[str, Any]:
+        async with semaphore:
+            return await generate_once(
+                client, args.request_timeout, record, prompt, args.max_new_tokens
+            )
+
+    started = asyncio.get_running_loop().time()
+    results = await asyncio.gather(*(guarded(record, prompt) for record, prompt in jobs))
+    return results, asyncio.get_running_loop().time() - started
+
+
+def numeric_summary(records: list[dict[str, Any]], metric: str) -> dict[str, Any]:
+    values = [
+        float(record[metric])
+        for record in records
+        if record.get("ok")
+        and record.get("valid_measurement")
+        and isinstance(record.get(metric), (int, float))
+        and math.isfinite(float(record[metric]))
+    ]
+    if not values:
+        return {"n": 0, "min": None, "median": None, "max": None}
+    return {
+        "n": len(values),
+        "min": min(values),
+        "median": statistics.median(values),
+        "max": max(values),
+    }
+
+
+def summarize_wave(
+    kind: str, records: list[dict[str, Any]], wall_s: float
+) -> dict[str, Any]:
+    total_tokens = sum(
+        record.get("completion_tokens", 0)
+        for record in records
+        if record.get("ok") and isinstance(record.get("completion_tokens"), int)
+    )
+    return {
+        "kind": kind,
+        "requests": len(records),
+        "ok": sum(bool(record.get("ok")) for record in records),
+        "valid": sum(bool(record.get("valid_measurement")) for record in records),
+        "cache_state_counts": {
+            state: sum(record.get("cache_state") == state for record in records)
+            for state in sorted({str(record.get("cache_state")) for record in records})
+        },
+        "wave_wall_s": wall_s,
+        "client_completion_tok_s": total_tokens / wall_s if wall_s > 0 else None,
+        "ttft_s": numeric_summary(records, "ttft_s"),
+        "decode_tok_s": numeric_summary(records, "decode_tok_s"),
+        "e2e_s": numeric_summary(records, "e2e_s"),
+        "cached_tokens": numeric_summary(records, "cached_tokens"),
+    }
+
+
+def base_record(args: argparse.Namespace, run_id: str, nonce: str) -> dict[str, Any]:
+    return {
+        "schema": SCHEMA,
+        "run_id": run_id,
+        "run_nonce": nonce,
+        "variant": args.variant,
+        "block_index": args.block_index,
+        "tag": args.tag,
+    }
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    run_nonce = args.nonce or f"{time.time_ns()}-{os.getpid()}-{secrets.token_hex(8)}"
+    run_id = hashlib.sha256(run_nonce.encode("utf-8")).hexdigest()[:16]
+    base = base_record(args, run_id, run_nonce)
+    writer = DurableJSONL(args.out)
+    client = AsyncSGLangClient(args.host, args.port)
+    all_requests: list[dict[str, Any]] = []
+    trial_summaries: list[dict[str, Any]] = []
+    exit_code = 0
+
+    try:
+        try:
+            server_info = await client.json_request(
+                "GET", "/get_server_info", None, min(args.request_timeout, 60.0)
+            )
+            server_info_record = scalar_meta(server_info)
+        except Exception as error:
+            server_info_record = {"_error": f"{type(error).__name__}: {error}"}
+        writer.write_batch(
+            [
+                {
+                    **base,
+                    "record_type": "run_start",
+                    "started_at_utc": utc_now(),
+                    "argv": sys.argv,
+                    "host": args.host,
+                    "port": args.port,
+                    "trials": args.trials,
+                    "samples": args.samples,
+                    "warm_repeats": args.warm_repeats,
+                    "concurrency": args.concurrency,
+                    "prefix_tokens_requested": args.prefix_tokens,
+                    "query_tokens_requested": args.query_tokens,
+                    "max_new_tokens_requested": args.max_new_tokens,
+                    "server_info": server_info_record,
+                }
+            ]
+        )
+
+        for trial in range(args.trials):
+            try:
+                flush_result = await client.json_request(
+                    "POST", "/flush_cache", None, args.flush_timeout
+                )
+                flush_error = None
+            except Exception as error:
+                flush_result = None
+                flush_error = f"{type(error).__name__}: {error}"
+            flush_record = {
+                **base,
+                "record_type": "cache_flush",
+                "trial": trial,
+                "at_utc": utc_now(),
+                "ok": flush_error is None,
+                "response": flush_result,
+                "error": flush_error,
+            }
+            writer.write_batch([flush_record])
+            if flush_error is not None:
+                print(f"trial {trial}: cache flush failed: {flush_error}", file=sys.stderr)
+                exit_code = 2
+                break
+
+            prefixes: list[list[int]] = []
+            cold_jobs: list[tuple[dict[str, Any], list[int]]] = []
+            for pair in range(args.samples):
+                prefix = seeded_tokens(
+                    run_nonce,
+                    args.token_id_low,
+                    args.token_id_high,
+                    args.prefix_tokens,
+                    "prefix",
+                    trial,
+                    pair,
+                )
+                tail = seeded_tokens(
+                    run_nonce,
+                    args.token_id_low,
+                    args.token_id_high,
+                    args.query_tokens,
+                    "cold-tail",
+                    trial,
+                    pair,
+                )
+                prefixes.append(prefix)
+                cold_jobs.append(
+                    (
+                        {
+                            **base,
+                            "trial": trial,
+                            "kind": "cold",
+                            "pair_id": pair,
+                            "warm_repeat": None,
+                            "request_ordinal": pair,
+                            "submitted_at_utc": utc_now(),
+                        },
+                        prefix + tail,
+                    )
+                )
+
+            cold, cold_wall = await run_wave(cold_jobs, client, args)
+            writer.write_batch(cold)
+            all_requests.extend(cold)
+
+            warm_jobs: list[tuple[dict[str, Any], list[int]]] = []
+            for pair, prefix in enumerate(prefixes):
+                seed_ok = cold[pair].get("ok") and cold[pair].get("valid_measurement")
+                if not seed_ok:
+                    continue
+                for repeat in range(args.warm_repeats):
+                    tail = seeded_tokens(
+                        run_nonce,
+                        args.token_id_low,
+                        args.token_id_high,
+                        args.query_tokens,
+                        "warm-tail",
+                        trial,
+                        pair,
+                        repeat,
+                    )
+                    warm_jobs.append(
+                        (
+                            {
+                                **base,
+                                "trial": trial,
+                                "kind": "warm",
+                                "pair_id": pair,
+                                "warm_repeat": repeat,
+                                "request_ordinal": len(warm_jobs),
+                                "submitted_at_utc": utc_now(),
+                            },
+                            prefix + tail,
+                        )
+                    )
+
+            if warm_jobs:
+                warm, warm_wall = await run_wave(warm_jobs, client, args)
+            else:
+                warm, warm_wall = [], 0.0
+            writer.write_batch(warm)
+            all_requests.extend(warm)
+
+            trial_summary = {
+                **base,
+                "record_type": "trial_summary",
+                "trial": trial,
+                "finished_at_utc": utc_now(),
+                "cold": summarize_wave("cold", cold, cold_wall),
+                "warm": summarize_wave("warm", warm, warm_wall),
+            }
+            cold_ttft = trial_summary["cold"]["ttft_s"]["median"]
+            warm_ttft = trial_summary["warm"]["ttft_s"]["median"]
+            trial_summary["warm_ttft_speedup"] = (
+                cold_ttft / warm_ttft
+                if isinstance(cold_ttft, float)
+                and isinstance(warm_ttft, float)
+                and warm_ttft > 0
+                else None
+            )
+            trial_summary["valid"] = (
+                trial_summary["cold"]["valid"] == len(cold)
+                and len(warm) == len(warm_jobs)
+                and trial_summary["warm"]["valid"] == len(warm)
+                and bool(warm)
+            )
+            if not trial_summary["valid"]:
+                exit_code = 2
+            writer.write_batch([trial_summary])
+            trial_summaries.append(trial_summary)
+            print(
+                json.dumps(
+                    {
+                        "trial": trial,
+                        "valid": trial_summary["valid"],
+                        "cold_ttft_median_s": cold_ttft,
+                        "warm_ttft_median_s": warm_ttft,
+                        "warm_ttft_speedup": trial_summary["warm_ttft_speedup"],
+                    },
+                    sort_keys=True,
+                ),
+                file=sys.stderr,
+            )
+
+        valid_trials = [trial for trial in trial_summaries if trial["valid"]]
+        run_summary = {
+            **base,
+            "record_type": "run_summary",
+            "finished_at_utc": utc_now(),
+            "valid": exit_code == 0 and len(valid_trials) == args.trials,
+            "trials_completed": len(trial_summaries),
+            "valid_trials": len(valid_trials),
+            "cold": summarize_wave(
+                "cold", [r for r in all_requests if r.get("kind") == "cold"], 0.0
+            ),
+            "warm": summarize_wave(
+                "warm", [r for r in all_requests if r.get("kind") == "warm"], 0.0
+            ),
+            "trial_cold_ttft_median_s": numeric_summary(
+                [
+                    {
+                        "ok": trial["valid"],
+                        "valid_measurement": trial["valid"],
+                        "value": trial["cold"]["ttft_s"]["median"],
+                    }
+                    for trial in trial_summaries
+                ],
+                "value",
+            ),
+            "trial_warm_ttft_median_s": numeric_summary(
+                [
+                    {
+                        "ok": trial["valid"],
+                        "valid_measurement": trial["valid"],
+                        "value": trial["warm"]["ttft_s"]["median"],
+                    }
+                    for trial in trial_summaries
+                ],
+                "value",
+            ),
+        }
+        writer.write_batch([run_summary])
+        print(json.dumps(run_summary, sort_keys=True), file=sys.stderr)
+        return exit_code
+    finally:
+        writer.close()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        return asyncio.run(async_main(args))
+    except KeyboardInterrupt:
+        print("interrupted", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen38-flash-next-fp16-audit.py
+++ b/scripts/qwen38-flash-next-fp16-audit.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Exhaustively audit BF16 checkpoint values for native gfx1030 FP16 loading."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+
+
+EXPERT_RE = re.compile(
+    r"\.mlp\.experts\.\d+\.(?:gate_proj|up_proj|down_proj)\.weight$"
+)
+FUSED_EXPERT_RE = re.compile(
+    r"^model\.language_model\.layers\.\d+\.mlp\.experts\."
+    r"(?:gate_up_proj|down_proj)$"
+)
+
+
+def category(name: str) -> str:
+    if ".mtp." in name or name.startswith("mtp."):
+        return "mtp"
+    if EXPERT_RE.search(name) or FUSED_EXPERT_RE.fullmatch(name):
+        return "routed_experts"
+    if ".mlp.shared_expert." in name:
+        return "shared_expert"
+    if ".ple." in name:
+        return "ple"
+    if ".visual." in name:
+        return "vision"
+    return "other"
+
+
+def empty_metrics() -> dict[str, int | float]:
+    return {
+        "tensors": 0,
+        "values": 0,
+        "source_nonfinite": 0,
+        "fp16_overflow": 0,
+        "fp16_flush_to_zero": 0,
+        "exact_values": 0,
+        "source_energy": 0.0,
+        "squared_error": 0.0,
+        "max_abs_source": 0.0,
+        "max_abs_error": 0.0,
+    }
+
+
+def merge(target: dict[str, int | float], source: dict[str, int | float]) -> None:
+    for key in (
+        "tensors",
+        "values",
+        "source_nonfinite",
+        "fp16_overflow",
+        "fp16_flush_to_zero",
+        "exact_values",
+        "source_energy",
+        "squared_error",
+    ):
+        target[key] += source[key]
+    target["max_abs_source"] = max(target["max_abs_source"], source["max_abs_source"])
+    target["max_abs_error"] = max(target["max_abs_error"], source["max_abs_error"])
+
+
+@torch.no_grad()
+def audit_tensor(tensor: torch.Tensor) -> dict[str, int | float]:
+    result = empty_metrics()
+    result["tensors"] = 1
+    result["values"] = tensor.numel()
+    source = tensor.to(torch.float32)
+    source_finite = torch.isfinite(source)
+    result["source_nonfinite"] = torch.count_nonzero(~source_finite).item()
+    finite_source = torch.where(source_finite, source, torch.zeros_like(source))
+    converted = source.to(torch.float16)
+    converted32 = converted.to(torch.float32)
+    converted_finite = torch.isfinite(converted32)
+    overflow = source_finite & ~converted_finite
+    comparable = source_finite & converted_finite
+    result["fp16_overflow"] = torch.count_nonzero(overflow).item()
+    result["fp16_flush_to_zero"] = torch.count_nonzero(
+        comparable & (source != 0) & (converted32 == 0)
+    ).item()
+    result["exact_values"] = torch.count_nonzero(comparable & (source == converted32)).item()
+    difference = torch.where(comparable, converted32 - source, torch.zeros_like(source))
+    result["source_energy"] = torch.sum(
+        finite_source * finite_source, dtype=torch.float64
+    ).item()
+    result["squared_error"] = torch.sum(
+        difference * difference, dtype=torch.float64
+    ).item()
+    result["max_abs_source"] = torch.max(torch.abs(finite_source)).item()
+    result["max_abs_error"] = torch.max(torch.abs(difference)).item()
+    return result
+
+
+def write_json_atomic(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    partial = path.with_name(f".{path.name}.partial")
+    partial.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    os.replace(partial, path)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    model = args.model.resolve()
+    output = args.output.resolve()
+    if not model.is_dir():
+        print(f"audit error: model directory does not exist: {model}", file=sys.stderr)
+        return 2
+    if output.is_relative_to("/tmp"):
+        print("audit error: output must be durable and cannot use /tmp", file=sys.stderr)
+        return 2
+
+    index_path = model / "model.safetensors.index.json"
+    if not index_path.is_file():
+        print("audit error: complete safetensors index is required", file=sys.stderr)
+        return 2
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    shards = sorted({model / value for value in index["weight_map"].values()})
+    missing = [str(path) for path in shards if not path.is_file()]
+    if missing:
+        print(f"audit error: {len(missing)} indexed shards are missing", file=sys.stderr)
+        return 2
+
+    aggregate = empty_metrics()
+    categories: dict[str, dict[str, int | float]] = {}
+    overflow_tensors: list[dict[str, Any]] = []
+    nonfinite_tensors: list[dict[str, Any]] = []
+    for shard_number, shard in enumerate(shards, start=1):
+        print(f"[{shard_number}/{len(shards)}] {shard.name}", flush=True)
+        with safe_open(shard, framework="pt", device="cpu") as handle:
+            for name in handle.keys():
+                tensor = handle.get_tensor(name)
+                if not tensor.is_floating_point():
+                    continue
+                measured = audit_tensor(tensor)
+                merge(aggregate, measured)
+                bucket = categories.setdefault(category(name), empty_metrics())
+                merge(bucket, measured)
+                if measured["fp16_overflow"]:
+                    overflow_tensors.append(
+                        {"name": name, "count": measured["fp16_overflow"]}
+                    )
+                if measured["source_nonfinite"]:
+                    nonfinite_tensors.append(
+                        {"name": name, "count": measured["source_nonfinite"]}
+                    )
+
+    for measured in [aggregate, *categories.values()]:
+        energy = float(measured["source_energy"])
+        error = float(measured["squared_error"])
+        measured["relative_frobenius_error"] = (
+            math.sqrt(error / energy) if energy > 0 else 0.0
+        )
+        measured["exact_fraction"] = (
+            int(measured["exact_values"]) / int(measured["values"])
+            if measured["values"]
+            else 1.0
+        )
+
+    passed = not overflow_tensors and not nonfinite_tensors
+    report = {
+        "model": str(model),
+        "passed": passed,
+        "target_dtype": "float16",
+        "aggregate": aggregate,
+        "categories": categories,
+        "overflow_tensors": overflow_tensors,
+        "nonfinite_tensors": nonfinite_tensors,
+    }
+    write_json_atomic(output, report)
+    print(
+        f"passed={passed} values={aggregate['values']} "
+        f"overflow={aggregate['fp16_overflow']} "
+        f"flush_to_zero={aggregate['fp16_flush_to_zero']} "
+        f"relative_error={aggregate['relative_frobenius_error']:.10g}"
+    )
+    print(f"report: {output}")
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen38-flash-next-inventory.py
+++ b/scripts/qwen38-flash-next-inventory.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Verify and inventory a sharded Qwen3.8-Flash-Next checkpoint.
+
+This intentionally parses safetensors headers without importing torch.  It is
+safe to run while diagnosing a partial download and cheap enough to run as the
+final staging gate for all 131 shards.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import struct
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+DTYPE_BYTES = {
+    "BOOL": 1,
+    "U8": 1,
+    "I8": 1,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I16": 2,
+    "U16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "I32": 4,
+    "U32": 4,
+    "F32": 4,
+    "F64": 8,
+    "I64": 8,
+    "U64": 8,
+}
+EXPERT_RE = re.compile(
+    r"\.mlp\.experts\.\d+\.(?:gate_proj|up_proj|down_proj)\.weight(?:_|$)"
+)
+FUSED_EXPERT_RE = re.compile(
+    r"^model\.language_model\.layers\.\d+\.mlp\.experts\."
+    r"(?:gate_up_proj|down_proj)$"
+)
+
+
+class InventoryError(RuntimeError):
+    pass
+
+
+def tensor_category(name: str) -> str:
+    if ".mtp." in name or name.startswith("mtp."):
+        return "mtp"
+    if EXPERT_RE.search(name) or FUSED_EXPERT_RE.fullmatch(name):
+        return "routed_experts"
+    if ".mlp.shared_expert." in name:
+        return "shared_expert"
+    if ".ple." in name:
+        return "ple"
+    if ".visual." in name:
+        return "vision"
+    return "other"
+
+
+def read_safetensors_header(path: Path) -> dict[str, dict[str, Any]]:
+    file_size = path.stat().st_size
+    if file_size < 8:
+        raise InventoryError(f"truncated safetensors file: {path}")
+    with path.open("rb") as handle:
+        raw_length = handle.read(8)
+        header_length = struct.unpack("<Q", raw_length)[0]
+        if header_length > file_size - 8:
+            raise InventoryError(
+                f"invalid header length {header_length} for {path} ({file_size} bytes)"
+            )
+        try:
+            header = json.loads(handle.read(header_length))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise InventoryError(f"invalid safetensors JSON header in {path}: {exc}")
+
+    payload_size = file_size - 8 - header_length
+    tensors: dict[str, dict[str, Any]] = {}
+    ranges: list[tuple[int, int, str]] = []
+    for name, entry in header.items():
+        if name == "__metadata__":
+            continue
+        try:
+            dtype = entry["dtype"]
+            shape = entry["shape"]
+            start, end = entry["data_offsets"]
+        except (KeyError, TypeError, ValueError) as exc:
+            raise InventoryError(f"malformed tensor {name!r} in {path}: {exc}")
+        if dtype not in DTYPE_BYTES:
+            raise InventoryError(f"unknown dtype {dtype!r} for {name!r} in {path}")
+        if not isinstance(shape, list) or any(
+            not isinstance(dim, int) or dim < 0 for dim in shape
+        ):
+            raise InventoryError(f"invalid shape for {name!r} in {path}: {shape!r}")
+        expected_bytes = math.prod(shape) * DTYPE_BYTES[dtype]
+        if start < 0 or end < start or end > payload_size:
+            raise InventoryError(
+                f"invalid data offsets [{start}, {end}] for {name!r} in {path}"
+            )
+        if end - start != expected_bytes:
+            raise InventoryError(
+                f"size mismatch for {name!r} in {path}: offsets contain "
+                f"{end - start} bytes, shape/dtype require {expected_bytes}"
+            )
+        ranges.append((start, end, name))
+        tensors[name] = entry
+
+    previous_end = 0
+    previous_name = "<payload-start>"
+    for start, end, name in sorted(ranges):
+        if start < previous_end:
+            raise InventoryError(
+                f"overlapping tensors {previous_name!r} and {name!r} in {path}"
+            )
+        previous_end = end
+        previous_name = name
+    return tensors
+
+
+def inspect(args: argparse.Namespace) -> tuple[dict[str, Any], list[str]]:
+    model_dir = args.model.resolve()
+    errors: list[str] = []
+    if not model_dir.is_dir():
+        raise InventoryError(f"model directory does not exist: {model_dir}")
+
+    config_path = model_dir / "config.json"
+    config: dict[str, Any] = {}
+    if config_path.is_file():
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        if config.get("model_type") != "qwen4_exp":
+            errors.append(
+                f"config model_type is {config.get('model_type')!r}, expected 'qwen4_exp'"
+            )
+        architectures = config.get("architectures") or []
+        if "Qwen4ExpForConditionalGeneration" not in architectures:
+            errors.append(
+                "config does not declare Qwen4ExpForConditionalGeneration"
+            )
+    else:
+        errors.append("missing config.json")
+
+    index_path = model_dir / "model.safetensors.index.json"
+    index: dict[str, Any] | None = None
+    if index_path.is_file():
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    elif args.require_complete:
+        errors.append("missing model.safetensors.index.json")
+
+    present_shards = sorted(model_dir.glob("model-*-of-*.safetensors"))
+    headers: dict[str, dict[str, dict[str, Any]]] = {}
+    for shard in present_shards:
+        try:
+            headers[shard.name] = read_safetensors_header(shard)
+        except (OSError, InventoryError) as exc:
+            errors.append(str(exc))
+
+    expected_shards: set[str] = set()
+    weight_map: dict[str, str] = {}
+    index_total_size: int | None = None
+    if index is not None:
+        weight_map = index.get("weight_map") or {}
+        if not isinstance(weight_map, dict) or not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in weight_map.items()
+        ):
+            errors.append("index weight_map is not a string-to-string mapping")
+            weight_map = {}
+        expected_shards = set(weight_map.values())
+        index_total_size = (index.get("metadata") or {}).get("total_size")
+
+        missing_shards = expected_shards - set(headers)
+        extra_shards = set(headers) - expected_shards
+        if missing_shards:
+            errors.append(
+                f"missing {len(missing_shards)} indexed shard(s): "
+                + ", ".join(sorted(missing_shards)[:5])
+            )
+        if extra_shards:
+            errors.append(
+                f"found {len(extra_shards)} shard(s) absent from index: "
+                + ", ".join(sorted(extra_shards)[:5])
+            )
+
+        for shard_name, shard_header in headers.items():
+            indexed_names = {
+                name for name, mapped_shard in weight_map.items() if mapped_shard == shard_name
+            }
+            actual_names = set(shard_header)
+            missing_names = indexed_names - actual_names
+            extra_names = actual_names - indexed_names
+            if missing_names:
+                errors.append(
+                    f"{shard_name} lacks {len(missing_names)} indexed tensor(s): "
+                    + ", ".join(sorted(missing_names)[:3])
+                )
+            if extra_names:
+                errors.append(
+                    f"{shard_name} contains {len(extra_names)} unindexed tensor(s): "
+                    + ", ".join(sorted(extra_names)[:3])
+                )
+
+    shard_goal = len(expected_shards) if expected_shards else args.expected_shards
+    if args.require_complete and len(present_shards) != shard_goal:
+        errors.append(
+            f"found {len(present_shards)} model shards, expected {shard_goal}"
+        )
+
+    dtype_counts: Counter[str] = Counter()
+    dtype_bytes: Counter[str] = Counter()
+    category_counts: Counter[str] = Counter()
+    category_bytes: Counter[str] = Counter()
+    for shard_header in headers.values():
+        for name, entry in shard_header.items():
+            dtype = entry["dtype"]
+            logical_bytes = math.prod(entry["shape"]) * DTYPE_BYTES[dtype]
+            category = tensor_category(name)
+            dtype_counts[dtype] += 1
+            dtype_bytes[dtype] += logical_bytes
+            category_counts[category] += 1
+            category_bytes[category] += logical_bytes
+
+    file_bytes = sum(path.stat().st_size for path in present_shards)
+    report: dict[str, Any] = {
+        "model_dir": str(model_dir),
+        "model_type": config.get("model_type"),
+        "architectures": config.get("architectures"),
+        "complete": not errors and len(present_shards) == shard_goal,
+        "present_shards": len(present_shards),
+        "expected_shards": shard_goal,
+        "indexed_tensors": len(weight_map),
+        "inspected_tensors": sum(dtype_counts.values()),
+        "model_file_bytes": file_bytes,
+        "index_total_size": index_total_size,
+        "dtypes": {
+            key: {"tensors": dtype_counts[key], "bytes": dtype_bytes[key]}
+            for key in sorted(dtype_counts)
+        },
+        "categories": {
+            key: {"tensors": category_counts[key], "bytes": category_bytes[key]}
+            for key in sorted(category_counts)
+        },
+        "errors": errors,
+    }
+    return report, errors
+
+
+def gib(value: int | None) -> str:
+    return "n/a" if value is None else f"{value / 2**30:.3f} GiB"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", type=Path, required=True)
+    parser.add_argument("--expected-shards", type=int, default=131)
+    parser.add_argument("--require-complete", action="store_true")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    try:
+        report, errors = inspect(args)
+    except (OSError, InventoryError, json.JSONDecodeError) as exc:
+        print(f"inventory error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"model: {report['model_dir']}")
+        print(
+            f"shards: {report['present_shards']}/{report['expected_shards']}  "
+            f"tensors: {report['inspected_tensors']}/{report['indexed_tensors'] or '?'}"
+        )
+        print(
+            f"model shard bytes: {gib(report['model_file_bytes'])}  "
+            f"index total: {gib(report['index_total_size'])}"
+        )
+        for category, values in report["categories"].items():
+            print(
+                f"  {category:16s} {values['tensors']:7d} tensors  "
+                f"{gib(values['bytes'])}"
+            )
+        if errors:
+            print("errors:", file=sys.stderr)
+            for error in errors:
+                print(f"  - {error}", file=sys.stderr)
+        elif report["complete"]:
+            print("checkpoint inventory: complete and internally consistent")
+        else:
+            print("checkpoint inventory: partial but present shards are consistent")
+
+    return 1 if errors and args.require_complete else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen38-flash-next-qsa-aot.py
+++ b/scripts/qwen38-flash-next-qsa-aot.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Lower the production Qwen3.8-Flash-Next QSA decode kernel for gfx1030.
+
+This is a compiler admission test, not a device-correctness or performance
+claim.  It catches unsupported Triton IR and records the exact resource use
+before the V620 host is powered.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+import triton
+from triton.backends.compiler import GPUTarget
+
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    _sparse_gqa_decode_scores_physical,
+    _sparse_gqa_decode_values_physical,
+)
+
+
+ARCH = "gfx1030"
+HEAD_DIM = 256
+NUM_KV_HEADS = 1
+GROUP_SIZE = 6  # Qwen TP4: 24 query heads / four ranks, replicated KV head.
+TOPK = 2048
+
+
+def parse_resource(assembly: str, field: str) -> int:
+    values = re.findall(rf"\.amdhsa_{re.escape(field)}\s+(\d+)", assembly)
+    if len(values) != 1:
+        raise RuntimeError(f"expected one .amdhsa_{field}, found {values!r}")
+    return int(values[0])
+
+
+def score_signature() -> dict[str, str]:
+    signature = {
+        "q": "*fp16",
+        "k": "*fp16",
+        "scores": "*fp32",
+        "slots": "*i32",
+        "scale": "fp32",
+        "topk": "i32",
+    }
+    signature.update(
+        {
+            name: "constexpr"
+            for name in (
+                "sq_m",
+                "sq_h",
+                "sq_d",
+                "sk_n",
+                "sk_h",
+                "sk_d",
+                "sx_m",
+                "sx_h",
+                "sx_n",
+                "ss_m",
+                "ss_n",
+                "GROUP_SIZE",
+                "BLOCK_M",
+                "BLOCK_N",
+                "HEAD_DIM",
+            )
+        }
+    )
+    if tuple(_sparse_gqa_decode_scores_physical.arg_names) != tuple(signature):
+        raise RuntimeError("QSA score kernel signature differs from AOT contract")
+    return signature
+
+
+def score_constants(block_n: int) -> dict[str, int]:
+    # Contiguous [rows, heads, dim] q/out, [slots, kv_heads, dim] k/v,
+    # and [rows, topk] physical-slot index tensors.
+    return {
+        "sq_m": 6 * HEAD_DIM,
+        "sq_h": HEAD_DIM,
+        "sq_d": 1,
+        "sk_n": HEAD_DIM,
+        "sk_h": HEAD_DIM,
+        "sk_d": 1,
+        "sx_m": GROUP_SIZE * TOPK,
+        "sx_h": TOPK,
+        "sx_n": 1,
+        "ss_m": TOPK,
+        "ss_n": 1,
+        "GROUP_SIZE": GROUP_SIZE,
+        "BLOCK_M": 16,
+        "BLOCK_N": block_n,
+        "HEAD_DIM": HEAD_DIM,
+    }
+
+
+def value_signature() -> dict[str, str]:
+    signature = {
+        "v": "*fp16",
+        "out": "*fp16",
+        "scores": "*fp32",
+        "slots": "*i32",
+        "topk": "i32",
+    }
+    signature.update(
+        {
+            name: "constexpr"
+            for name in (
+                "sv_n",
+                "sv_h",
+                "sv_d",
+                "so_m",
+                "so_h",
+                "so_d",
+                "sx_m",
+                "sx_h",
+                "sx_n",
+                "ss_m",
+                "ss_n",
+                "GROUP_SIZE",
+                "BLOCK_N",
+                "BLOCK_D",
+                "HEAD_DIM",
+            )
+        }
+    )
+    if tuple(_sparse_gqa_decode_values_physical.arg_names) != tuple(signature):
+        raise RuntimeError("QSA value kernel signature differs from AOT contract")
+    return signature
+
+
+def value_constants(block_n: int, block_d: int) -> dict[str, int]:
+    return {
+        "sv_n": HEAD_DIM,
+        "sv_h": HEAD_DIM,
+        "sv_d": 1,
+        "so_m": GROUP_SIZE * HEAD_DIM,
+        "so_h": HEAD_DIM,
+        "so_d": 1,
+        "sx_m": GROUP_SIZE * TOPK,
+        "sx_h": TOPK,
+        "sx_n": 1,
+        "ss_m": TOPK,
+        "ss_n": 1,
+        "GROUP_SIZE": GROUP_SIZE,
+        "BLOCK_N": block_n,
+        "BLOCK_D": block_d,
+        "HEAD_DIM": HEAD_DIM,
+    }
+
+
+def compile_variant(
+    kind: str, block_n: int, num_warps: int, num_stages: int, block_d: int = 0
+) -> dict:
+    if kind == "score":
+        kernel = _sparse_gqa_decode_scores_physical
+        signature = score_signature()
+        constant_values = score_constants(block_n)
+    elif kind == "value":
+        kernel = _sparse_gqa_decode_values_physical
+        signature = value_signature()
+        constant_values = value_constants(block_n, block_d)
+    else:
+        raise ValueError(f"unknown kernel kind: {kind}")
+    source = triton.compiler.ASTSource(
+        fn=kernel,
+        signature=signature,
+        constexprs=constant_values,
+    )
+    compiled = triton.compile(
+        source,
+        target=GPUTarget("hip", ARCH, 32),
+        options={
+            "num_warps": num_warps,
+            "num_stages": num_stages,
+            "waves_per_eu": 1,
+        },
+    )
+    assembly = compiled.asm["amdgcn"]
+    resources = {
+        field: parse_resource(assembly, field)
+        for field in (
+            "next_free_vgpr",
+            "next_free_sgpr",
+            "group_segment_fixed_size",
+            "private_segment_fixed_size",
+        )
+    }
+    if resources["private_segment_fixed_size"] != 0:
+        raise RuntimeError(f"{kind} kernel spills to scratch: {resources}")
+    return {
+        "kind": kind,
+        "block_n": block_n,
+        "block_d": block_d or None,
+        "num_warps": num_warps,
+        "num_stages": num_stages,
+        "kernel_name": compiled.metadata.name,
+        "compiler_hash": compiled.metadata.hash,
+        "resources": resources,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    output = args.output.resolve()
+    if output.exists():
+        raise RuntimeError(f"refusing to overwrite: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    # These are the exact no-spill configurations used by the HIP wrapper.
+    variants = [
+        compile_variant("score", 32, 8, 2),
+        compile_variant("value", 64, 4, 2, 64),
+    ]
+    manifest = {
+        "schema": 1,
+        "kind": "qwen38-flash-next-qsa-gfx1030-aot-admission",
+        "device_execution": False,
+        "correctness_claim": False,
+        "performance_claim": False,
+        "target": {"backend": "hip", "arch": ARCH, "warp_size": 32},
+        "contract": {
+            "head_dim": HEAD_DIM,
+            "num_kv_heads_per_rank": NUM_KV_HEADS,
+            "query_group_size": GROUP_SIZE,
+            "indexer_budget": TOPK,
+            "weight_dtype": "float16",
+            "accumulator_dtype": "float32",
+        },
+        "triton": triton.__version__,
+        "variants": variants,
+    }
+    output.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(manifest, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen38-flash-next-quantize-experts.py
+++ b/scripts/qwen38-flash-next-quantize-experts.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+"""Stream Qwen3.8-Flash-Next routed experts into W4A16.
+
+The output follows compressed-tensors' pack-quantized contract consumed by the
+matching SGLang ROCm Triton MoE implementation.  Only routed expert gate/up/down
+checkpoint weights are changed.  Routers, the shared expert, PLE, GDN, QSA,
+mHC, norms, embeddings, lm_head, MTP, and vision checkpoint weights remain at
+their source precision.  The runtime manifest requests lossy FP8 PLE storage so
+the offloaded tables fit in a 128 GiB Strix Halo host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+from compressed_tensors.compressors.pack_quantized.helpers import (
+    pack_to_int32,
+    unpack_from_int32,
+)
+from compressed_tensors.quantization import QuantizationArgs
+from compressed_tensors.quantization.lifecycle.forward import quantize
+from compressed_tensors.quantization.utils import calculate_qparams
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+FUSED_EXPERT_RE = re.compile(
+    r"^model\.language_model\.layers\.(\d+)\.mlp\.experts\."
+    r"(gate_up_proj|down_proj)$"
+)
+TARGET_RE = r"re:.*\.mlp\.experts\.\d+\.(gate_proj|up_proj|down_proj)$"
+IGNORE_NON_TARGET_RE = (
+    r"re:^(?!.*\.mlp\.experts\.\d+\.(gate_proj|up_proj|down_proj)$).*"
+)
+PLE_RUNTIME_DTYPE = "float8_e4m3fn"
+STATE_NAME = ".quantization-state.json"
+PLAN_VERSION = "qwen38-flash-next-fused-expert-w4a16-rtn-v2"
+SAFETENSORS_DTYPE_BYTES = {
+    "BOOL": 1,
+    "U8": 1,
+    "I8": 1,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I16": 2,
+    "U16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "I32": 4,
+    "U32": 4,
+    "F32": 4,
+    "F64": 8,
+    "I64": 8,
+    "U64": 8,
+}
+
+
+class QuantizationError(RuntimeError):
+    pass
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while block := handle.read(1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def write_json_atomic(path: Path, value: Any) -> None:
+    partial = path.with_name(f".{path.name}.partial")
+    partial.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    partial.chmod(0o644)
+    os.replace(partial, path)
+
+
+def publish_output_modes(output: Path) -> None:
+    """Make a completed checkpoint readable through the read-only model export."""
+    output.chmod(0o755)
+    for item in output.iterdir():
+        if item.is_file():
+            item.chmod(0o644)
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise QuantizationError(f"cannot read JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise QuantizationError(f"expected JSON object in {path}")
+    return value
+
+
+def make_quant_args(group_size: int) -> QuantizationArgs:
+    return QuantizationArgs(
+        num_bits=4,
+        type="int",
+        symmetric=True,
+        strategy="group",
+        group_size=group_size,
+        dynamic=False,
+        scale_dtype="float16",
+    )
+
+
+@torch.no_grad()
+def quantize_weight(
+    weight: torch.Tensor, args: QuantizationArgs
+) -> tuple[dict[str, torch.Tensor], dict[str, float | int]]:
+    if weight.ndim != 2:
+        raise QuantizationError(f"expert weight must be 2-D, got {tuple(weight.shape)}")
+    rows, columns = weight.shape
+    group_size = int(args.group_size)
+    if columns % group_size:
+        raise QuantizationError(
+            f"weight shape {tuple(weight.shape)} is not divisible by group_size={group_size}"
+        )
+    if not weight.is_floating_point():
+        raise QuantizationError(f"expert weight has non-floating dtype {weight.dtype}")
+
+    source = weight.to(torch.float32)
+    grouped = source.reshape(rows, columns // group_size, group_size)
+    minimum = grouped.amin(dim=-1)
+    maximum = grouped.amax(dim=-1)
+    scale, zero_point = calculate_qparams(minimum, maximum, args)
+    stored_scale = scale.to(torch.float16)
+    if not torch.isfinite(stored_scale).all() or torch.count_nonzero(stored_scale) != stored_scale.numel():
+        raise QuantizationError("FP16 group scales overflowed or underflowed")
+
+    qweight = quantize(
+        x=source,
+        scale=stored_scale,
+        zero_point=zero_point,
+        args=args,
+        dtype=torch.int8,
+    )
+    packed = pack_to_int32(qweight, num_bits=4).contiguous()
+    dequantized = qweight.reshape_as(grouped).to(torch.float32) * stored_scale.unsqueeze(-1)
+    error = dequantized - grouped
+    metrics: dict[str, float | int] = {
+        "values": source.numel(),
+        "source_energy": torch.sum(grouped * grouped, dtype=torch.float64).item(),
+        "squared_error": torch.sum(error * error, dtype=torch.float64).item(),
+        "max_abs_error": torch.max(torch.abs(error)).item(),
+        "clipped_low": torch.count_nonzero(qweight == -8).item(),
+        "clipped_high": torch.count_nonzero(qweight == 7).item(),
+    }
+    tensors = {
+        "weight_packed": packed,
+        "weight_scale": stored_scale.contiguous(),
+        "weight_shape": torch.tensor(weight.shape, dtype=torch.int64),
+    }
+    return tensors, metrics
+
+
+def merge_metrics(target: dict[str, float | int], source: dict[str, float | int]) -> None:
+    for key in ("values", "source_energy", "squared_error", "clipped_low", "clipped_high"):
+        target[key] = target.get(key, 0) + source.get(key, 0)
+    target["max_abs_error"] = max(
+        float(target.get("max_abs_error", 0.0)),
+        float(source.get("max_abs_error", 0.0)),
+    )
+
+
+def quantize_shard(
+    source_path: Path,
+    output_path: Path,
+    args: QuantizationArgs,
+) -> tuple[int, int, dict[str, float | int]]:
+    output: dict[str, torch.Tensor] = {}
+    metrics: dict[str, float | int] = {}
+    quantized_count = 0
+    untouched_count = 0
+
+    with safe_open(source_path, framework="pt", device="cpu") as source:
+        metadata = source.metadata()
+        for name in source.keys():
+            tensor = source.get_tensor(name)
+            fused_match = FUSED_EXPERT_RE.fullmatch(name)
+            if fused_match:
+                if tensor.ndim != 3:
+                    raise QuantizationError(
+                        f"fused expert tensor {name} must be 3-D, got {tuple(tensor.shape)}"
+                    )
+                layer = int(fused_match.group(1))
+                projection = fused_match.group(2)
+                expert_count = tensor.shape[0]
+                for expert in range(expert_count):
+                    expert_weight = tensor[expert]
+                    if projection == "gate_up_proj":
+                        if expert_weight.shape[0] % 2:
+                            raise QuantizationError(
+                                f"fused gate/up tensor has odd projection axis: {name}"
+                            )
+                        projections = zip(
+                            ("gate_proj", "up_proj"),
+                            expert_weight.chunk(2, dim=0),
+                            strict=True,
+                        )
+                    else:
+                        projections = (("down_proj", expert_weight),)
+                    for projection_name, projection_weight in projections:
+                        converted, tensor_metrics = quantize_weight(
+                            projection_weight, args
+                        )
+                        prefix = (
+                            f"model.language_model.layers.{layer}.mlp.experts."
+                            f"{expert}.{projection_name}"
+                        )
+                        for suffix, value in converted.items():
+                            output[f"{prefix}.{suffix}"] = value
+                        merge_metrics(metrics, tensor_metrics)
+                        quantized_count += 1
+            else:
+                output[name] = tensor
+                untouched_count += 1
+
+    partial = output_path.with_name(f".{output_path.name}.partial")
+    if partial.exists():
+        partial.unlink()
+    save_file(output, partial, metadata=metadata)
+    partial.chmod(0o644)
+    os.replace(partial, output_path)
+    return quantized_count, untouched_count, metrics
+
+
+def copy_ancillary_files(source: Path, output: Path) -> None:
+    excluded = {
+        "config.json",
+        "model.safetensors.index.json",
+        STATE_NAME,
+    }
+    for item in source.iterdir():
+        if item.name in excluded or item.name.startswith("model-"):
+            continue
+        if item.name == ".cache" or item.is_dir():
+            continue
+        destination = output / item.name
+        shutil.copy2(item, destination)
+        destination.chmod(0o644)
+
+
+def make_output_config(source_config: dict[str, Any], group_size: int) -> dict[str, Any]:
+    config = json.loads(json.dumps(source_config))
+    text_config = config.get("text_config", config)
+    if not isinstance(text_config, dict):
+        raise QuantizationError("config text_config must be a JSON object")
+    # SGLang constructs each TP-sharded, pinned PLE table in this dtype and
+    # downcasts the source BF16 shard while loading.  Keeping BF16 here needs
+    # about 102 GiB of host RAM and OOMs once four workers and ROCm bookkeeping
+    # are included; FP8 needs about 51 GiB and gathers back to BF16 for compute.
+    text_config["ple_embedding_dtype"] = PLE_RUNTIME_DTYPE
+    quantization_config = {
+        "quant_method": "compressed-tensors",
+        "format": "pack-quantized",
+        "quantization_status": "compressed",
+        "config_groups": {
+            "routed_experts": {
+                "targets": [TARGET_RE],
+                "weights": {
+                    "num_bits": 4,
+                    "type": "int",
+                    "symmetric": True,
+                    "strategy": "group",
+                    "group_size": group_size,
+                    "dynamic": False,
+                    "scale_dtype": "float16",
+                },
+                "input_activations": None,
+            }
+        },
+        # compressed-tensors config groups are closed-world: every linear layer
+        # must either match a quantized target or be explicitly ignored.  Keep
+        # the routed expert projections quantized while leaving every other
+        # source-precision layer on SGLang's unquantized path.
+        "ignore": [IGNORE_NON_TARGET_RE],
+    }
+    config["quantization_config"] = quantization_config
+    config["compression_config"] = quantization_config
+    return config
+
+
+def build_index(output: Path) -> tuple[dict[str, Any], int]:
+    weight_map: dict[str, str] = {}
+    total_size = 0
+    for shard in sorted(output.glob("model-*-of-*.safetensors")):
+        with safe_open(shard, framework="pt", device="cpu") as handle:
+            for name in handle.keys():
+                if name in weight_map:
+                    raise QuantizationError(f"duplicate output tensor {name}")
+                tensor = handle.get_slice(name)
+                dtype = tensor.get_dtype()
+                shape = tensor.get_shape()
+                if dtype not in SAFETENSORS_DTYPE_BYTES:
+                    raise QuantizationError(f"unhandled output dtype {dtype} for {name}")
+                total_size += math.prod(shape) * SAFETENSORS_DTYPE_BYTES[dtype]
+                weight_map[name] = shard.name
+    return {"metadata": {"total_size": total_size}, "weight_map": weight_map}, total_size
+
+
+def validate_layout(source: Path, index: dict[str, Any], config: dict[str, Any]) -> int:
+    weight_map = index.get("weight_map") or {}
+    if not isinstance(weight_map, dict):
+        raise QuantizationError("source index has no valid weight_map")
+    fused_names = sorted(name for name in weight_map if FUSED_EXPERT_RE.fullmatch(name))
+    text_config = config.get("text_config") or config
+    layers = int(text_config.get("num_hidden_layers", 0))
+    experts = int(text_config.get("num_experts", 0))
+    expected_projections = layers * experts * 3
+    expected_fused = layers * 2
+    if expected_projections <= 0:
+        raise QuantizationError("config does not declare a positive layer/expert count")
+    expected_names = {
+        f"model.language_model.layers.{layer}.mlp.experts.{projection}"
+        for layer in range(layers)
+        for projection in ("gate_up_proj", "down_proj")
+    }
+    if set(fused_names) != expected_names:
+        missing = sorted(expected_names - set(fused_names))
+        extra = sorted(set(fused_names) - expected_names)
+        raise QuantizationError(
+            f"fused routed-expert layout differs: found {len(fused_names)}, expected "
+            f"{expected_fused}; missing={missing[:3]}, extra={extra[:3]}"
+        )
+    missing_shards = {value for value in weight_map.values() if not (source / value).is_file()}
+    if missing_shards:
+        raise QuantizationError(
+            f"source is incomplete; {len(missing_shards)} indexed shards are absent"
+        )
+    return expected_projections
+
+
+def make_synthetic_source(root: Path) -> tuple[Path, Path]:
+    if root.exists() and any(root.iterdir()):
+        raise QuantizationError(f"self-test directory must be empty: {root}")
+    source = root / "source"
+    output = root / "output"
+    source.mkdir(parents=True, exist_ok=True)
+    generator = torch.Generator(device="cpu").manual_seed(380032)
+    tensors: dict[str, torch.Tensor] = {
+        "model.language_model.embed_tokens.weight": torch.randn(
+            64, 64, generator=generator, dtype=torch.float32
+        ).to(torch.bfloat16)
+    }
+    tensors["model.language_model.layers.0.mlp.experts.gate_up_proj"] = torch.randn(
+        2, 128, 64, generator=generator, dtype=torch.float32
+    ).to(torch.bfloat16)
+    tensors["model.language_model.layers.0.mlp.experts.down_proj"] = torch.randn(
+        2, 64, 64, generator=generator, dtype=torch.float32
+    ).to(torch.bfloat16)
+    # The serving launcher disables MTP initially; its experts must remain exact.
+    tensors["mtp.layers.0.mlp.experts.down_proj"] = torch.randn(
+        2, 64, 64, generator=generator, dtype=torch.float32
+    ).to(torch.bfloat16)
+    shard_names = (
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+    )
+    embedding_name = "model.language_model.embed_tokens.weight"
+    embedding = tensors.pop(embedding_name)
+    save_file(
+        {embedding_name: embedding},
+        source / shard_names[0],
+        metadata={"format": "pt"},
+    )
+    save_file(tensors, source / shard_names[1], metadata={"format": "pt"})
+    config = {
+        "architectures": ["Qwen4ExpForConditionalGeneration"],
+        "model_type": "qwen4_exp",
+        "text_config": {
+            "model_type": "qwen4_exp_text",
+            "num_hidden_layers": 1,
+            "num_experts": 2,
+        },
+    }
+    index = {
+        "metadata": {
+            "total_size": embedding.numel() * embedding.element_size()
+            + sum(
+                tensor.numel() * tensor.element_size()
+                for tensor in tensors.values()
+            )
+        },
+        "weight_map": {
+            embedding_name: shard_names[0],
+            **{name: shard_names[1] for name in tensors},
+        },
+    }
+    write_json_atomic(source / "config.json", config)
+    write_json_atomic(source / "model.safetensors.index.json", index)
+    return source, output
+
+
+def verify_synthetic_output(source: Path, output: Path, group_size: int) -> None:
+    if stat.S_IMODE(output.stat().st_mode) != 0o755:
+        raise QuantizationError("self-test output directory is not mode 0755")
+    bad_modes = {
+        item.name: oct(stat.S_IMODE(item.stat().st_mode))
+        for item in output.iterdir()
+        if item.is_file() and stat.S_IMODE(item.stat().st_mode) != 0o644
+    }
+    if bad_modes:
+        raise QuantizationError(f"self-test output file modes are not 0644: {bad_modes}")
+
+    with safe_open(
+        source / "model-00002-of-00002.safetensors", framework="pt", device="cpu"
+    ) as original, safe_open(
+        output / "model-00002-of-00002.safetensors", framework="pt", device="cpu"
+    ) as converted:
+        converted_names = set(converted.keys())
+        for name in original.keys():
+            fused_match = FUSED_EXPERT_RE.fullmatch(name)
+            if fused_match is None:
+                if not torch.equal(original.get_tensor(name), converted.get_tensor(name)):
+                    raise QuantizationError(f"self-test changed untouched tensor {name}")
+                continue
+            layer = int(fused_match.group(1))
+            source_tensor = original.get_tensor(name)
+            for expert in range(source_tensor.shape[0]):
+                if fused_match.group(2) == "gate_up_proj":
+                    projection_names = ("gate_proj", "up_proj")
+                else:
+                    projection_names = ("down_proj",)
+                for projection_name in projection_names:
+                    prefix = (
+                        f"model.language_model.layers.{layer}.mlp.experts."
+                        f"{expert}.{projection_name}"
+                    )
+                    packed_name = f"{prefix}.weight_packed"
+                    scale_name = f"{prefix}.weight_scale"
+                    shape_name = f"{prefix}.weight_shape"
+                    if not {packed_name, scale_name, shape_name}.issubset(converted_names):
+                        raise QuantizationError(
+                            f"self-test output is incomplete for {prefix}"
+                        )
+                    shape = converted.get_tensor(shape_name).tolist()
+                    packed = converted.get_tensor(packed_name)
+                    scale = converted.get_tensor(scale_name)
+                    unpacked = unpack_from_int32(packed, 4, torch.Size(shape))
+                    reconstructed = (
+                        unpacked.to(torch.float32).reshape(
+                            shape[0], shape[1] // group_size, group_size
+                        )
+                        * scale.to(torch.float32).unsqueeze(-1)
+                    ).reshape(shape)
+                    if not torch.isfinite(reconstructed).all():
+                        raise QuantizationError(
+                            f"self-test produced non-finite values for {prefix}"
+                        )
+    with safe_open(
+        source / "model-00001-of-00002.safetensors", framework="pt", device="cpu"
+    ) as original, safe_open(
+        output / "model-00001-of-00002.safetensors", framework="pt", device="cpu"
+    ) as converted:
+        name = "model.language_model.embed_tokens.weight"
+        if list(converted.keys()) != [name]:
+            raise QuantizationError("self-test changed the untouched-only shard layout")
+        if not torch.equal(original.get_tensor(name), converted.get_tensor(name)):
+            raise QuantizationError("self-test changed the untouched embedding tensor")
+    output_config = load_json(output / "config.json")
+    quant_config = output_config.get("quantization_config") or {}
+    actual_group = (
+        quant_config.get("config_groups", {})
+        .get("routed_experts", {})
+        .get("weights", {})
+        .get("group_size")
+    )
+    if actual_group != group_size:
+        raise QuantizationError(
+            f"self-test config group_size={actual_group}, expected {group_size}"
+        )
+    output_text_config = output_config.get("text_config") or output_config
+    if output_text_config.get("ple_embedding_dtype") != PLE_RUNTIME_DTYPE:
+        raise QuantizationError(
+            "self-test config did not request memory-bounded FP8 PLE storage"
+        )
+    from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+        CompressedTensorsConfig,
+    )
+    from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+        CompressedTensorsWNA16TritonMoE,
+    )
+
+    runtime_config = CompressedTensorsConfig.from_config(quant_config)
+    untouched_scheme = runtime_config.get_scheme_dict(
+        torch.nn.Linear(64, 64),
+        layer_name="model.language_model.layers.0.linear_attn.in_proj_qkvz",
+    )
+    if untouched_scheme is not None:
+        raise QuantizationError(
+            "self-test config did not ignore an untouched linear layer"
+        )
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        expert_scheme = runtime_config.get_scheme_dict(
+            torch.nn.Linear(64, 64),
+            layer_name=(
+                "model.language_model.layers.0.mlp.experts.0."
+                f"{projection}"
+            ),
+        )
+        if expert_scheme is None:
+            raise QuantizationError(
+                f"self-test config incorrectly ignored routed expert {projection}"
+            )
+    runtime_scheme = runtime_config.get_moe_scheme(
+        torch.nn.Module(), layer_name="model.layers.0.mlp.experts"
+    )
+    if not isinstance(runtime_scheme, CompressedTensorsWNA16TritonMoE):
+        raise QuantizationError(
+            "self-test config did not resolve to CompressedTensorsWNA16TritonMoE"
+        )
+    if runtime_scheme.group_size != group_size:
+        raise QuantizationError(
+            f"runtime resolved group_size={runtime_scheme.group_size}, expected {group_size}"
+        )
+
+    import sglang
+
+    mapping_source = (
+        Path(sglang.__file__).parent
+        / "srt/layers/moe/fused_moe_triton/layer.py"
+    ).read_text(encoding="utf-8")
+    for contract in (
+        '"experts.w13_"',
+        'else "experts.w2_"',
+        'f"experts.{expert_id}.{weight_name}."',
+    ):
+        if contract not in mapping_source:
+            raise QuantizationError(
+                f"self-test SGLang expert mapping contract changed: {contract}"
+            )
+    packed_names = sorted(
+        name
+        for name in converted_names
+        if ".mlp.experts." in name
+        and name.endswith(("weight_packed", "weight_scale", "weight_shape"))
+    )
+    for checkpoint_name in packed_names:
+        match = re.fullmatch(
+            r"model\.language_model\.layers\.\d+\.mlp\.experts\.\d+\."
+            r"(gate_proj|up_proj|down_proj)\."
+            r"(weight_packed|weight_scale|weight_shape)",
+            checkpoint_name,
+        )
+        if match is None:
+            raise QuantizationError(
+                f"self-test output cannot map through FusedMoE: {checkpoint_name}"
+            )
+        target = "w2" if match.group(1) == "down_proj" else "w13"
+        mapped_suffix = f"{target}_{match.group(2)}"
+        if mapped_suffix not in {
+            "w13_weight_packed",
+            "w13_weight_scale",
+            "w13_weight_shape",
+            "w2_weight_packed",
+            "w2_weight_scale",
+            "w2_weight_shape",
+        }:
+            raise QuantizationError(
+                f"self-test loader mapping is invalid for {checkpoint_name}"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--group-size", type=int, choices=(32, 64, 128), default=32)
+    parser.add_argument(
+        "--allow-non-spdk",
+        action="store_true",
+        help="permit an output outside /mnt/optane/models (only for synthetic tests)",
+    )
+    parser.add_argument(
+        "--self-test-dir",
+        type=Path,
+        help="create and convert a tiny synthetic checkpoint in this empty directory",
+    )
+    parsed = parser.parse_args()
+
+    try:
+        self_test = parsed.self_test_dir is not None
+        if self_test:
+            source, output = make_synthetic_source(parsed.self_test_dir.resolve())
+            parsed.allow_non_spdk = True
+        else:
+            if parsed.source is None or parsed.output is None:
+                parser.error("--source and --output are required outside --self-test-dir")
+            source = parsed.source.resolve()
+            output = parsed.output.resolve()
+        if source == output:
+            raise QuantizationError("source and output directories must differ")
+        if not source.is_dir():
+            raise QuantizationError(f"source directory does not exist: {source}")
+        if not parsed.allow_non_spdk and not output.is_relative_to("/mnt/optane/models"):
+            raise QuantizationError("output must be under the fast /mnt/optane/models mount")
+
+        config_path = source / "config.json"
+        index_path = source / "model.safetensors.index.json"
+        if not config_path.is_file() or not index_path.is_file():
+            raise QuantizationError("source requires config.json and model.safetensors.index.json")
+        config = load_json(config_path)
+        index = load_json(index_path)
+        expected_expert_tensors = validate_layout(source, index, config)
+
+        plan = {
+            "version": PLAN_VERSION,
+            "source": str(source),
+            "source_index_sha256": sha256(index_path),
+            "group_size": parsed.group_size,
+            "scale_dtype": "float16",
+            "expected_expert_tensors": expected_expert_tensors,
+        }
+        output.mkdir(parents=True, exist_ok=True)
+        state_path = output / STATE_NAME
+        if state_path.exists():
+            state = load_json(state_path)
+            if state.get("plan") != plan:
+                raise QuantizationError(
+                    f"existing output has a different immutable plan: {state_path}"
+                )
+        else:
+            unexpected = [item.name for item in output.iterdir()]
+            if unexpected:
+                raise QuantizationError(
+                    f"output is non-empty but has no resumable {STATE_NAME}: "
+                    + ", ".join(sorted(unexpected)[:5])
+                )
+            state = {"plan": plan, "completed_shards": {}, "metrics": {}}
+            write_json_atomic(state_path, state)
+
+        quant_args = make_quant_args(parsed.group_size)
+        source_shards = sorted({source / value for value in index["weight_map"].values()})
+        for shard_number, source_shard in enumerate(source_shards, start=1):
+            name = source_shard.name
+            source_size = source_shard.stat().st_size
+            recorded = state["completed_shards"].get(name)
+            output_shard = output / name
+            if recorded is not None:
+                if (
+                    recorded.get("source_size") != source_size
+                    or not output_shard.is_file()
+                    or output_shard.stat().st_size != recorded.get("output_size")
+                ):
+                    raise QuantizationError(f"resume record does not match shard {name}")
+                print(f"[{shard_number}/{len(source_shards)}] resume {name}", flush=True)
+                continue
+
+            print(f"[{shard_number}/{len(source_shards)}] quantize {name}", flush=True)
+            quantized, untouched, shard_metrics = quantize_shard(
+                source_shard, output_shard, quant_args
+            )
+            state["completed_shards"][name] = {
+                "source_size": source_size,
+                "output_size": output_shard.stat().st_size,
+                "quantized_tensors": quantized,
+                "untouched_tensors": untouched,
+                "metrics": shard_metrics,
+            }
+            aggregate: dict[str, float | int] = {}
+            for completed in state["completed_shards"].values():
+                merge_metrics(aggregate, completed["metrics"])
+            state["metrics"] = aggregate
+            write_json_atomic(state_path, state)
+
+        actual_quantized = sum(
+            int(value["quantized_tensors"])
+            for value in state["completed_shards"].values()
+        )
+        if actual_quantized != expected_expert_tensors:
+            raise QuantizationError(
+                f"quantized {actual_quantized} expert tensors, expected {expected_expert_tensors}"
+            )
+
+        copy_ancillary_files(source, output)
+        write_json_atomic(
+            output / "config.json", make_output_config(config, parsed.group_size)
+        )
+        output_index, total_size = build_index(output)
+        write_json_atomic(output / "model.safetensors.index.json", output_index)
+
+        metrics = state["metrics"]
+        relative_rmse = math.sqrt(
+            float(metrics["squared_error"]) / float(metrics["source_energy"])
+        )
+        state["complete"] = True
+        state["output_total_size"] = total_size
+        state["relative_rmse"] = relative_rmse
+        write_json_atomic(state_path, state)
+        publish_output_modes(output)
+        print(
+            f"complete: {actual_quantized} routed expert tensors, "
+            f"{total_size / 2**30:.3f} GiB logical, relative_rmse={relative_rmse:.8f}"
+        )
+        if self_test:
+            verify_synthetic_output(source, output, parsed.group_size)
+            print("synthetic pack/config/untouched-tensor self-test: passed")
+        return 0
+    except (OSError, QuantizationError, RuntimeError, ValueError) as exc:
+        print(f"quantization error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qwen38-flash-next-runtime-smoke.py
+++ b/scripts/qwen38-flash-next-runtime-smoke.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Import the actual Qwen4-Exp MoE runtime from the packaged closure."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+
+import torch
+
+
+def main() -> None:
+    os.environ.setdefault("SGLANG_USE_AITER", "0")
+
+    imported = []
+    for module_name in (
+        "sglang.srt.layers.activation",
+        "sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe",
+        "sglang.srt.layers.moe.fused_moe_triton.layer",
+        "sglang.srt.constrained.xgrammar_backend",
+        "sglang.srt.models.qwen4_exp",
+    ):
+        importlib.import_module(module_name)
+        imported.append(module_name)
+
+    if "sgl_kernel" in sys.modules:
+        raise RuntimeError("gfx1030 runtime smoke unexpectedly imported sgl_kernel")
+
+    from sglang.srt.layers.moe.topk import fused_topk_torch_native
+
+    hidden_states = torch.zeros((2, 4), dtype=torch.float16)
+    router_logits = torch.tensor(
+        [[1.0, 3.0, 2.0, -1.0], [4.0, 0.0, 2.0, 1.0]], dtype=torch.float16
+    )
+    topk_weights, topk_ids = fused_topk_torch_native(
+        hidden_states,
+        router_logits,
+        topk=2,
+        renormalize=True,
+        scoring_func="softmax",
+    )
+    if topk_weights.shape != (2, 2) or topk_ids.shape != (2, 2):
+        raise RuntimeError("torch-native MoE top-k returned the wrong shape")
+    if not torch.allclose(topk_weights.sum(dim=-1), torch.ones(2)):
+        raise RuntimeError("torch-native MoE top-k did not renormalize")
+
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "aiter": os.environ["SGLANG_USE_AITER"],
+                "imported": imported,
+                "moe_topk": "torch_native",
+                "sgl_kernel_loaded": False,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/qwen38-flash-next-serve.sh
+++ b/scripts/qwen38-flash-next-serve.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Serve Qwen3.8-Flash-Next on strix-2's four Radeon Pro V620s.
+#
+# Invoke with bash: /mnt/Home is NFS on the diskless Strix nodes and is not
+# mounted executable.  Persistent artifacts and JIT caches never use /tmp.
+set -euo pipefail
+
+MODEL="${MODEL:-/models/Qwen3.8-Flash-Next-W4A16-G32}"
+TP="${TP:-4}"
+PORT="${PORT:-30800}"
+SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-qwen3.8-flash-next}"
+DTYPE="${DTYPE:-float16}"
+SSM_DTYPE="${SSM_DTYPE:-float32}"
+CTX="${CTX:-32768}"
+MEM_FRAC="${MEM_FRAC:-0.78}"
+TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen3_coder}"
+REASONING_PARSER="${REASONING_PARSER:-qwen3}"
+# The unmerged QSA HIP path first needs eager-vs-graph token parity.  Promote
+# CUDA_GRAPH=1 only after that gate passes on the exact production closure.
+CUDA_GRAPH="${CUDA_GRAPH:-0}"
+
+ART="${ART:-/mnt/Home/src/nix-strix-halo-qwen38-flash-next/.bench-artifacts}"
+LOGDIR="$ART/serve"
+RUNDIR="$ART/runtime"
+mkdir -p "$LOGDIR" "$RUNDIR"
+
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/mnt/Home/src/.cache/qwen38-flash-next}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-$XDG_CACHE_HOME/triton}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-$XDG_CACHE_HOME/inductor}"
+export HF_HOME="${HF_HOME:-$XDG_CACHE_HOME/hf}"
+export AITER_JIT_DIR="${AITER_JIT_DIR:-$XDG_CACHE_HOME/aiter/jit}"
+export AITER_ROOT_DIR="${AITER_ROOT_DIR:-$XDG_CACHE_HOME/aiter/root}"
+# Keep the allocator resilient for JIT and inference temporaries.  The larger
+# WNA16 post-load transpose is separately bounded by the gfx1030 host-layout
+# patch; it must not depend on allocator fragmentation for residency.
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+mkdir -p \
+  "$TRITON_CACHE_DIR" \
+  "$TORCHINDUCTOR_CACHE_DIR" \
+  "$HF_HOME" \
+  "$AITER_JIT_DIR" \
+  "$AITER_ROOT_DIR"
+
+# HIP indices 0-3 are the V620s.  The Strix Halo iGPU belongs to the separate
+# DS4 campaign and must never join this TP group.
+export HIP_VISIBLE_DEVICES="${HIP_VISIBLE_DEVICES:-0,1,2,3}"
+export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-lo}"
+export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-0}"
+export SGLANG_USE_AITER=0
+export SGLANG_MAMBA_CONV_DTYPE="${SGLANG_MAMBA_CONV_DTYPE:-$DTYPE}"
+
+if [[ "$TP" != 4 ]]; then
+  echo "error: the qualified V620 topology is TP=4, got TP=$TP" >&2
+  exit 2
+fi
+if [[ "$DTYPE" != float16 ]]; then
+  echo "error: gfx1030 has native FP16, not BF16/FP8 compute; use DTYPE=float16" >&2
+  exit 2
+fi
+if [[ ! -d "$MODEL" ]]; then
+  echo "error: model directory does not exist: $MODEL" >&2
+  exit 2
+fi
+if [[ ! -f "$MODEL/config.json" ]]; then
+  echo "error: missing model config: $MODEL/config.json" >&2
+  exit 2
+fi
+
+# Require the reviewed, source-built Qwen4-Exp closure.  A real store path is
+# deliberate: relinking a result symlink under a running server is unsafe.
+if [[ -z "${SGLANG_QWEN38_FLASH_NEXT_CLOSURE:-}" ]]; then
+  echo "error: set SGLANG_QWEN38_FLASH_NEXT_CLOSURE to the resolved Nix store path" >&2
+  exit 2
+fi
+if [[ -L "$SGLANG_QWEN38_FLASH_NEXT_CLOSURE" ]]; then
+  echo "error: SGLANG_QWEN38_FLASH_NEXT_CLOSURE must not be a symlink" >&2
+  exit 2
+fi
+SGLANG="$SGLANG_QWEN38_FLASH_NEXT_CLOSURE/bin/sglang"
+if [[ ! -x "$SGLANG" ]]; then
+  echo "error: SGLang executable not found: $SGLANG" >&2
+  exit 2
+fi
+
+ARGS=(
+  --model-path "$MODEL"
+  --served-model-name "$SERVED_MODEL_NAME"
+  --tp-size "$TP"
+  --dtype "$DTYPE"
+  --mamba-ssm-dtype "$SSM_DTYPE"
+  --language-model-only
+  --ple-offload-embedding
+  --attention-backend triton
+  --linear-attn-backend triton
+  --bf16-gemm-backend torch
+  --moe-runner-backend triton
+  --disable-custom-all-reduce
+  --weight-loader-drop-cache-after-load
+  --context-length "$CTX"
+  --mem-fraction-static "$MEM_FRAC"
+  --host 0.0.0.0
+  --port "$PORT"
+  --log-level info
+)
+
+if [[ "$CUDA_GRAPH" == 0 ]]; then
+  ARGS+=(--disable-cuda-graph)
+elif [[ "$CUDA_GRAPH" != 1 ]]; then
+  echo "error: CUDA_GRAPH must be 0 or 1" >&2
+  exit 2
+fi
+if [[ -n "$TOOL_CALL_PARSER" ]]; then
+  ARGS+=(--tool-call-parser "$TOOL_CALL_PARSER")
+fi
+if [[ -n "$REASONING_PARSER" ]]; then
+  ARGS+=(--reasoning-parser "$REASONING_PARSER")
+fi
+if [[ $# -gt 0 ]]; then
+  ARGS+=("$@")
+fi
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+LOG="$LOGDIR/serve-$STAMP.log"
+printf 'launching: model=%s tp=%s dtype=%s ctx=%s graph=%s devices=%s\n' \
+  "$MODEL" "$TP" "$DTYPE" "$CTX" "$CUDA_GRAPH" "$HIP_VISIBLE_DEVICES"
+printf 'log: %s\n' "$LOG"
+cd "$RUNDIR"
+exec "$SGLANG" serve "${ARGS[@]}" 2>&1 | tee "$LOG"

--- a/scripts/qwen38-flash-next-serve.sh
+++ b/scripts/qwen38-flash-next-serve.sh
@@ -18,6 +18,11 @@ REASONING_PARSER="${REASONING_PARSER:-qwen3}"
 # The unmerged QSA HIP path first needs eager-vs-graph token parity.  Promote
 # CUDA_GRAPH=1 only after that gate passes on the exact production closure.
 CUDA_GRAPH="${CUDA_GRAPH:-0}"
+# The QSA ring buffers in the pinned experimental SGLang branch are not safe
+# under the overlap scheduler on HIP yet.  In particular, SGLang only enables
+# its default write-after-read barrier when torch.version.cuda is present.
+# Keep the qualified path serial; OVERLAP_SCHEDULE=1 is an explicit experiment.
+OVERLAP_SCHEDULE="${OVERLAP_SCHEDULE:-0}"
 
 ART="${ART:-/mnt/Home/src/nix-strix-halo-qwen38-flash-next/.bench-artifacts}"
 LOGDIR="$ART/serve"
@@ -48,6 +53,10 @@ export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-lo}"
 export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-0}"
 export SGLANG_USE_AITER=0
 export SGLANG_MAMBA_CONV_DTYPE="${SGLANG_MAMBA_CONV_DTYPE:-$DTYPE}"
+# Upstream /health generates from the raw token id [0] by default.  That probe
+# bypasses the chat template and is not a valid Qwen4-Exp readiness request.
+# Keep /health passive; qualification sends a real chat completion separately.
+export SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION="${SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION:-false}"
 
 if [[ "$TP" != 4 ]]; then
   echo "error: the qualified V620 topology is TP=4, got TP=$TP" >&2
@@ -66,11 +75,18 @@ if [[ ! -f "$MODEL/config.json" ]]; then
   exit 2
 fi
 
-# Require the reviewed, source-built Qwen4-Exp closure.  A real store path is
-# deliberate: relinking a result symlink under a running server is unsafe.
+# Prefer an explicit immutable closure for a worktree invocation.  The packaged
+# launcher can discover its own closure, which makes the flake output directly
+# executable without a result symlink or an out-of-band environment variable.
 if [[ -z "${SGLANG_QWEN38_FLASH_NEXT_CLOSURE:-}" ]]; then
-  echo "error: set SGLANG_QWEN38_FLASH_NEXT_CLOSURE to the resolved Nix store path" >&2
-  exit 2
+  launcher_path="$(readlink -f "$0")"
+  launcher_closure="$(dirname "$(dirname "$launcher_path")")"
+  if [[ -x "$launcher_closure/bin/sglang" ]]; then
+    SGLANG_QWEN38_FLASH_NEXT_CLOSURE="$launcher_closure"
+  else
+    echo "error: set SGLANG_QWEN38_FLASH_NEXT_CLOSURE to the resolved Nix store path" >&2
+    exit 2
+  fi
 fi
 if [[ -L "$SGLANG_QWEN38_FLASH_NEXT_CLOSURE" ]]; then
   echo "error: SGLANG_QWEN38_FLASH_NEXT_CLOSURE must not be a symlink" >&2
@@ -109,6 +125,17 @@ elif [[ "$CUDA_GRAPH" != 1 ]]; then
   echo "error: CUDA_GRAPH must be 0 or 1" >&2
   exit 2
 fi
+if [[ "$OVERLAP_SCHEDULE" == 0 ]]; then
+  ARGS+=(--disable-overlap-schedule)
+elif [[ "$OVERLAP_SCHEDULE" == 1 ]]; then
+  # This opt-in is deliberately not part of the qualified production path.
+  # Give HIP the barrier that SGLang otherwise enables only for CUDA.
+  export SGLANG_ENABLE_WAR_BARRIER="${SGLANG_ENABLE_WAR_BARRIER:-true}"
+  export SGLANG_FORCE_COARSE_WAR_BARRIER="${SGLANG_FORCE_COARSE_WAR_BARRIER:-true}"
+else
+  echo "error: OVERLAP_SCHEDULE must be 0 or 1" >&2
+  exit 2
+fi
 if [[ -n "$TOOL_CALL_PARSER" ]]; then
   ARGS+=(--tool-call-parser "$TOOL_CALL_PARSER")
 fi
@@ -121,8 +148,9 @@ fi
 
 STAMP="$(date +%Y%m%d-%H%M%S)"
 LOG="$LOGDIR/serve-$STAMP.log"
-printf 'launching: model=%s tp=%s dtype=%s ctx=%s graph=%s devices=%s\n' \
-  "$MODEL" "$TP" "$DTYPE" "$CTX" "$CUDA_GRAPH" "$HIP_VISIBLE_DEVICES"
+printf 'launching: model=%s tp=%s dtype=%s ctx=%s graph=%s overlap=%s devices=%s\n' \
+  "$MODEL" "$TP" "$DTYPE" "$CTX" "$CUDA_GRAPH" "$OVERLAP_SCHEDULE" \
+  "$HIP_VISIBLE_DEVICES"
 printf 'log: %s\n' "$LOG"
 cd "$RUNDIR"
 exec "$SGLANG" serve "${ARGS[@]}" 2>&1 | tee "$LOG"

--- a/scripts/qwen38-flash-next-stage-bf16.sh
+++ b/scripts/qwen38-flash-next-stage-bf16.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Resume and verify the immutable BF16 oracle on trex's SPDK-backed XFS mount.
+set -euo pipefail
+
+REPO="Qwen/Qwen3.8-Flash-Next"
+REVISION="f5d08274bafd880402bd16f5e3e6c514136ec06c"
+MODEL_DIR="${MODEL_DIR:-/mnt/optane/models/Qwen3.8-Flash-Next-BF16}"
+CACHE_DIR="${CACHE_DIR:-/mnt/optane/models/.cache/huggingface/qwen38-flash-next-bf16}"
+WORKTREE="${WORKTREE:-/mnt/Home/src/nix-strix-halo-qwen38-flash-next}"
+HF_CLI="${HF_CLI:-hf}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+case "$MODEL_DIR" in
+  /mnt/optane/models/*) ;;
+  *)
+    echo "error: MODEL_DIR must be below the fast /mnt/optane/models mount" >&2
+    exit 2
+    ;;
+esac
+if [[ "$(findmnt -n -o TARGET -T "$MODEL_DIR")" != "/mnt/optane/models" ]]; then
+  echo "error: MODEL_DIR is not on the SPDK model filesystem" >&2
+  exit 2
+fi
+if [[ ! -d "$MODEL_DIR" ]]; then
+  echo "error: pre-create $MODEL_DIR with ownership for $(id -un)" >&2
+  exit 2
+fi
+if [[ ! -w "$MODEL_DIR" ]]; then
+  echo "error: $MODEL_DIR is not writable by $(id -un)" >&2
+  exit 2
+fi
+if [[ ! -f "$WORKTREE/scripts/qwen38-flash-next-inventory.py" ]]; then
+  echo "error: campaign inventory script is missing from $WORKTREE" >&2
+  exit 2
+fi
+if ! command -v "$HF_CLI" >/dev/null; then
+  echo "error: Hugging Face CLI not found: $HF_CLI" >&2
+  exit 2
+fi
+if ! command -v "$PYTHON_BIN" >/dev/null; then
+  echo "error: Python interpreter not found: $PYTHON_BIN" >&2
+  exit 2
+fi
+
+mkdir -p "$CACHE_DIR"
+if [[ ! -w "$CACHE_DIR" ]]; then
+  echo "error: $CACHE_DIR is not writable by $(id -un)" >&2
+  exit 2
+fi
+export HF_HOME="${HF_HOME:-/mnt/optane/models/.cache/huggingface}"
+export HF_XET_HIGH_PERFORMANCE=1
+export HF_HUB_DISABLE_XET=0
+
+"$HF_CLI" download "$REPO" \
+  --revision "$REVISION" \
+  --local-dir "$MODEL_DIR" \
+  --cache-dir "$CACHE_DIR"
+
+"$PYTHON_BIN" \
+  "$WORKTREE/scripts/qwen38-flash-next-inventory.py" \
+  --model "$MODEL_DIR" \
+  --require-complete \
+  --expected-shards 131
+
+printf '%s\n' "$REVISION" > "$MODEL_DIR/.campaign-revision"
+printf 'verified BF16 oracle: %s @ %s\n' "$REPO" "$REVISION"

--- a/scripts/qwen38-serve.sh
+++ b/scripts/qwen38-serve.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Serve Qwen3.8-27B on strix-2's four Radeon Pro V620s (gfx1030 / RDNA2).
+#
+# ISOLATION: HIP indices 0-3 are the V620s. Index 4 is the Strix Halo iGPU and
+# belongs to the parallel DS4 campaign -- never expose it here.
+#
+# On the diskless nodes /mnt/Home is NFS and `./script` fails with EACCES, so
+# invoke this as `bash qwen38-serve.sh`. Nothing is written to /tmp: it is
+# tmpfs and these machines reboot.
+set -euo pipefail
+
+# NOT /models: that is an SPDK lvol *snapshot* exported over NVMe-oF, and
+# republishing it to include a new model requires draining and rebooting all
+# four Strix hosts (see machines/x86/trex/spdk-models-snapshot.nix). /mnt/Home
+# is live NFS4 from trex and needs no such ceremony.
+MODEL="${MODEL:-/mnt/Home/models/Qwen3.8-27B}"
+TP="${TP:-4}"
+PORT="${PORT:-30800}"
+# fp16, not bf16: gfx1030 has no bf16 ALU but has native packed fp16 at 2x
+# rate. fp16 carries 10 mantissa bits against bf16's 7, so the conversion is
+# exact for every weight inside fp16's range -- see .bench-artifacts/fidelity/.
+DTYPE="${DTYPE:-float16}"
+# The config pins the DeltaNet recurrent state to fp32 (mamba_ssm_dtype); keep
+# it there regardless of the weight dtype.
+SSM_DTYPE="${SSM_DTYPE:-float32}"
+
+# The GDN *conv* state is a separate dtype from the SSM state and has NO CLI
+# flag: srt/environ.py:678 hardcodes SGLANG_MAMBA_CONV_DTYPE="bfloat16", and
+# srt/configs/mamba_utils.py:68 falls back to torch.bfloat16. With --dtype
+# float16 the activations reaching _causal_conv1d_fwd_kernel are fp16 while the
+# conv_states tensor is bf16, and the Triton frontend rejects the kernel:
+#   AssertionError("Mismatched type for col0 between then block
+#   (<['256'], bf16>) and else block (<['256'], fp16>)")
+# It must therefore track the weight dtype on any bf16-less GPU.
+export SGLANG_MAMBA_CONV_DTYPE="${SGLANG_MAMBA_CONV_DTYPE:-$DTYPE}"
+CTX="${CTX:-32768}"
+MEM_FRAC="${MEM_FRAC:-0.85}"
+# sglang 0.5.14's tool-call parser registry maps "qwen" to Qwen25Detector,
+# which is correct for this model family's <tool_call> JSON format. Set to
+# "" to disable tool-call parsing.
+TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen}"
+# The chat template emits <think> blocks; sglang 0.5.14's reasoning parser
+# registry (srt/parser/reasoning_parser.py, DetectorMap) has a "qwen3" entry
+# for them. Set to "" to disable reasoning parsing.
+REASONING_PARSER="${REASONING_PARSER:-qwen3}"
+
+ART="${ART:-/mnt/Home/src/nix-strix-halo-qwen38/.bench-artifacts}"
+LOGDIR="$ART/serve"
+mkdir -p "$LOGDIR"
+
+# Caches must not land on the node's tmpfs overlay -- it fills and then
+# stale-handles the diskless root.
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-/mnt/Home/src/.cache/qwen38}"
+export TRITON_CACHE_DIR="${TRITON_CACHE_DIR:-$XDG_CACHE_HOME/triton}"
+export TORCHINDUCTOR_CACHE_DIR="${TORCHINDUCTOR_CACHE_DIR:-$XDG_CACHE_HOME/inductor}"
+export HF_HOME="${HF_HOME:-$XDG_CACHE_HOME/hf}"
+mkdir -p "$TRITON_CACHE_DIR" "$TORCHINDUCTOR_CACHE_DIR" "$HF_HOME"
+
+# The four V620s only.
+export HIP_VISIBLE_DEVICES="${HIP_VISIBLE_DEVICES:-0,1,2,3}"
+
+# TP4 here is entirely switch-local P2P/IPC across one PEX880xx, so the socket
+# path is only used for bootstrap. Pin it anyway: unpinned interface selection
+# has previously wedged multi-rank jobs on this fleet.
+export NCCL_SOCKET_IFNAME="${NCCL_SOCKET_IFNAME:-lo}"
+export NCCL_P2P_DISABLE="${NCCL_P2P_DISABLE:-0}"
+
+# SGLANG_GFX1030_CLOSURE must be a real (non-symlink) nix store path for the
+# gfx1030 sglang build. Never point it at a shared result-* symlink: re-linking
+# one out from under a running server has cost this campaign real time before.
+if [[ -z "${SGLANG_GFX1030_CLOSURE:-}" ]]; then
+  echo "error: set SGLANG_GFX1030_CLOSURE to a gfx1030 sglang store path" >&2
+  echo "  e.g. SGLANG_GFX1030_CLOSURE=/nix/store/...-sglang-rocm-gfx1030-0.5.14" >&2
+  exit 2
+fi
+if [[ -L "$SGLANG_GFX1030_CLOSURE" ]]; then
+  echo "error: SGLANG_GFX1030_CLOSURE is a symlink; pass the resolved store path" >&2
+  exit 2
+fi
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+LOG="$LOGDIR/serve-$STAMP.log"
+
+# Backend choice is forced, not preferred: LINEAR_ATTN_KERNEL_BACKEND_CHOICES is
+# ["triton","cutedsl","flashinfer"] and the latter two are CUDA-only, so Triton
+# is the ONLY backend that can drive the 48 Gated-DeltaNet layers on gfx1030.
+# Likewise aiter/wave/flashinfer cannot serve the 16 full-attention layers here.
+ARGS=(
+  --model-path "$MODEL"
+  --tp-size "$TP"
+  --dtype "$DTYPE"
+  --mamba-ssm-dtype "$SSM_DTYPE"
+  --attention-backend triton
+  --linear-attn-backend triton
+  # The mamba radix cache's "extra_buffer" strategy now works on ROCm via the
+  # gfx1030 patch set (it used to assert is_cuda()/is_musa()/is_npu() in
+  # server_args.py:4369). Leaving the radix cache on is the biggest TTFT win
+  # we have -- 74x on warm 30K-token prefixes. --disable-radix-cache remains
+  # available as a manual escape hatch if you need a clean baseline.
+  --context-length "$CTX"
+  --mem-fraction-static "$MEM_FRAC"
+  --host 0.0.0.0
+  --port "$PORT"
+  --log-level info
+)
+
+if [[ -n "$TOOL_CALL_PARSER" ]]; then
+  ARGS+=(--tool-call-parser "$TOOL_CALL_PARSER")
+fi
+if [[ -n "$REASONING_PARSER" ]]; then
+  ARGS+=(--reasoning-parser "$REASONING_PARSER")
+fi
+
+# Extra args passed through, e.g. --disable-cuda-graph while bisecting a hang.
+if [[ $# -gt 0 ]]; then
+  ARGS+=("$@")
+fi
+
+echo "launching: tp=$TP dtype=$DTYPE ctx=$CTX devices=$HIP_VISIBLE_DEVICES"
+echo "log: $LOG"
+# NOTE: sglang 0.5.14's CLI subcommands are {serve,generate,version}. The old
+# `launch_server` entry point is gone; `sglang serve` is the replacement.
+exec "$SGLANG_GFX1030_CLOSURE/bin/sglang" serve "${ARGS[@]}" 2>&1 | tee "$LOG"

--- a/scripts/qwen38-serve.sh
+++ b/scripts/qwen38-serve.sh
@@ -38,7 +38,11 @@ MEM_FRAC="${MEM_FRAC:-0.85}"
 # sglang 0.5.14's tool-call parser registry maps "qwen" to Qwen25Detector,
 # which is correct for this model family's <tool_call> JSON format. Set to
 # "" to disable tool-call parsing.
-TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen}"
+# qwen3_coder, not qwen: the chat template emits the XML-ish
+# <function=name><parameter=k>v</parameter></function> form, which the qwen25
+# JSON parser detects (finish_reason=tool_calls) but cannot extract -- it
+# returns an empty tool_calls array. Verified against the live model 2026-08-26.
+TOOL_CALL_PARSER="${TOOL_CALL_PARSER:-qwen3_coder}"
 # The chat template emits <think> blocks; sglang 0.5.14's reasoning parser
 # registry (srt/parser/reasoning_parser.py, DetectorMap) has a "qwen3" entry
 # for them. Set to "" to disable reasoning parsing.


### PR DESCRIPTION
## Summary

- package pinned SGLang Qwen4-Exp support beside the released SGLang service
- add a four-V620 TP4 launcher and expert-only W4A16-G32 checkpoint tooling
- make QSA, MoE, HyperConnection, GDN, grammar, and WNA16 post-processing work on gfx1030 without NVIDIA-only extensions
- package the production launcher with conservative HIP defaults: serial scheduling and passive health
- archive exact four-V620 live-serving evidence, including the rejected failure runs and final qualification

This is stacked on #165 so the ROCm 10 HIP compiler and TorchAO downstream fixes stay in the provider PR rather than being duplicated here.

## Live qualification

On `strix-2`, unit `codex-qwen38-flash-next-tp4-v29.service` is serving the exact packaged closure:

```
/nix/store/816iqv6ikd913gzbkqz1gy605rszfz7m-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552
```

Four V620s run TP4; the Strix Halo iGPU is excluded. The 131-shard 173.558 GiB expert-only W4A16-G32 checkpoint is mounted read-only.

- exact completion: `V620 FLASH WORKS`, HTTP 200, 5.272 s
- 59-token prompt: 140 coherent completion tokens, HTTP 200, 11.075 s
- warm server counter: up to 13.93 generation tok/s
- arithmetic control: exact `14`, HTTP 200, 0.379 s
- passive health: HTTP 200 in roughly 1.4–1.6 ms between requests
- post-idle control: exact `STILL PACKAGED`; unit remained active

The first v26 responses were rejected after all four ranks later reported an asynchronous PyTorch gather hardware exception under SGLang's overlap event loop. A v27 control then showed that upstream `/health` generates from raw token ID zero by default. The qualified launcher disables scheduler overlap and model-generating health checks. v28 passed seven requests in total under those settings; v29 repeated the acceptance set from the packaged closure.

The longer prompt also exercises the QSA prefill tile that previously failed at 67,584 bytes of LDS against gfx1030's 65,536-byte limit. The final ROCm-only one-stage configuration passes. Tracked evidence: `docs/evidence/qwen38-flash-next-v620-20260828.md`.

## Verification

- Qwen gfx1030: `/nix/store/816iqv6ikd913gzbkqz1gy605rszfz7m-sglang-rocm-gfx1030-0.5.17.dev0+qwen4exp.73a2552`
- Qwen gfx1151: `/nix/store/n67vv71dw7axn9vvlypnncn1843w2c28-sglang-rocm-gfx1151-0.5.17.dev0+qwen4exp.73a2552`
- packaged runtime smoke: AITER off, Torch-native MoE top-k, no `sgl_kernel`
- gfx1030 vLLM: `/nix/store/lshnzk3143w5fdlggwm1gkbjhafrkgb2-python3.13-vllm-0.25.1`
- default/source vLLM: `/nix/store/1mmff759x0yixyqjc9i84zikqk4b9nii-python3.13-vllm-0.25.1`
- released SGLang gfx1030: `/nix/store/27rlb1yj4c0f58ir4rjm7d7fx1f640q2-sglang-rocm-gfx1030-0.5.14`
- released SGLang gfx1151: `/nix/store/pwyajk7ikpjw86zsz4lwah8akrvxb4dl-sglang-rocm-gfx1151-0.5.14`
- source-provider aggregate: `/nix/store/w5vp68qz5rvdqpmwjdzpyv0v5x3gl6mi-nix-strix-halo-ci-source`
- check aggregate: `/nix/store/mlqrvn96dsj5x81zh0df85aih5dkw4bv-nix-strix-halo-ci-checks`
- `nix flake check --accept-flake-config --no-build`
- ShellCheck and `bash -n` for the packaged launcher

The source-provider aggregate covers vLLM, SGLang, MLX, DS4, and both llama.cpp tracks.